### PR TITLE
Simplify web search/scrape pricing to flat /1K, increase video queue RPM

### DIFF
--- a/api-reference/rate-limiting.mdx
+++ b/api-reference/rate-limiting.mdx
@@ -52,7 +52,7 @@ Text models are grouped into tiers based on size. Each model card on the [Models
 | Image | 20 |
 | Audio | 60 |
 | Embedding | 500 |
-| Video (queue) | 20 |
+| Video (queue) | 40 |
 | Video (retrieve) | 120 |
 
 ## Handling Errors

--- a/overview/pricing.mdx
+++ b/overview/pricing.mdx
@@ -30,12 +30,10 @@ All prices are in USD. Diem users pay the same rates (1 Diem = $1 of compute per
 
 Web Search and Web Scraping features run on dedicated compute infrastructure designed for large-scale crawling and real-time content extraction. These features are usage-based and charged per API call when enabled:
 
-| Feature | Venice Models | Other Models | Parameters |
-|---------|:-------------:|:------------:|------------|
-| Web Search | $10 / 1K calls | $25 / 1K calls | `enable_web_search: true` |
-| Web Scraping | $10 / 1K calls | $25 / 1K calls | `enable_web_scraping: true` |
-
-**Venice Models**: `venice-uncensored`, `qwen3-4b`, `mistral-31-24b`
+| Feature | Price | Parameters |
+|---------|:-----:|------------|
+| Web Search | $10 / 1K calls | `enable_web_search: true` |
+| Web Scraping | $10 / 1K calls | `enable_web_scraping: true` |
 
 <Info>
 Web Scraping automatically detects up to 3 URLs per message, scrapes and converts content into structured markdown, and adds the extracted text into model context. These charges apply in addition to standard model token pricing.


### PR DESCRIPTION
Simplify web search/scrape pricing to flat /1K, increase video queue to 40 rpm