### PR TITLE
Missing Kokoro voices

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ Venice provides permissionless access to AI models with no content filtering, ma
 - [Image Generation](https://docs.venice.ai/api-reference/endpoint/image/generate): Create images from text prompts
 - [Image Upscaling](https://docs.venice.ai/api-reference/endpoint/image/upscale): Enhance and upscale images
 - [Image Editing](https://docs.venice.ai/api-reference/endpoint/image/edit): AI-powered image inpainting
-- [Text-to-Speech](https://docs.venice.ai/api-reference/endpoint/audio/speech): Convert text to audio with 60+ voices
+- [Text-to-Speech](https://docs.venice.ai/api-reference/endpoint/audio/speech): Convert text to audio with 50+ voices
 - [Video Generation](https://docs.venice.ai/api-reference/endpoint/video/queue): Generate videos from text or images
 - [Embeddings](https://docs.venice.ai/api-reference/endpoint/embeddings/generate): Generate vector embeddings for semantic search
 - [Rate Limiting](https://docs.venice.ai/api-reference/rate-limiting): Rate limits and best practices

--- a/models/audio.mdx
+++ b/models/audio.mdx
@@ -10,15 +10,106 @@ description: "Text-to-speech models with multilingual voice support"
 
 ## Available Voices
 
-Kokoro TTS supports 60+ multilingual and stylistic voices:
+Kokoro TTS supports 54 multilingual and stylistic voices across 10 languages:
+
+### American English
 
 | Voice ID | Description |
 |----------|-------------|
+| `af_alloy` | Female, American English |
+| `af_aoede` | Female, American English |
+| `af_bella` | Female, American English |
+| `af_heart` | Female, American English |
+| `af_jadzia` | Female, American English |
+| `af_jessica` | Female, American English |
+| `af_kore` | Female, American English |
+| `af_nicole` | Female, American English |
 | `af_nova` | Female, American English |
+| `af_river` | Female, American English |
+| `af_sarah` | Female, American English |
+| `af_sky` | Female, American English (default) |
+| `am_adam` | Male, American English |
+| `am_echo` | Male, American English |
+| `am_eric` | Male, American English |
+| `am_fenrir` | Male, American English |
 | `am_liam` | Male, American English |
+| `am_michael` | Male, American English |
+| `am_onyx` | Male, American English |
+| `am_puck` | Male, American English |
+| `am_santa` | Male, American English |
+
+### British English
+
+| Voice ID | Description |
+|----------|-------------|
+| `bf_alice` | Female, British English |
 | `bf_emma` | Female, British English |
+| `bf_lily` | Female, British English |
+| `bm_daniel` | Male, British English |
+| `bm_fable` | Male, British English |
+| `bm_george` | Male, British English |
+| `bm_lewis` | Male, British English |
+
+### Chinese (Mandarin)
+
+| Voice ID | Description |
+|----------|-------------|
 | `zf_xiaobei` | Female, Chinese |
+| `zf_xiaoni` | Female, Chinese |
+| `zf_xiaoxiao` | Female, Chinese |
+| `zf_xiaoyi` | Female, Chinese |
+| `zm_yunjian` | Male, Chinese |
+| `zm_yunxi` | Male, Chinese |
+| `zm_yunxia` | Male, Chinese |
+| `zm_yunyang` | Male, Chinese |
+
+### Japanese
+
+| Voice ID | Description |
+|----------|-------------|
+| `jf_alpha` | Female, Japanese |
+| `jf_gongitsune` | Female, Japanese |
+| `jf_nezumi` | Female, Japanese |
+| `jf_tebukuro` | Female, Japanese |
 | `jm_kumo` | Male, Japanese |
+
+### French
+
+| Voice ID | Description |
+|----------|-------------|
+| `ff_siwis` | Female, French |
+
+### Hindi
+
+| Voice ID | Description |
+|----------|-------------|
+| `hf_alpha` | Female, Hindi |
+| `hf_beta` | Female, Hindi |
+| `hm_omega` | Male, Hindi |
+| `hm_psi` | Male, Hindi |
+
+### Italian
+
+| Voice ID | Description |
+|----------|-------------|
+| `if_sara` | Female, Italian |
+| `im_nicola` | Male, Italian |
+
+### Portuguese (Brazilian)
+
+| Voice ID | Description |
+|----------|-------------|
+| `pf_dora` | Female, Portuguese |
+| `pm_alex` | Male, Portuguese |
+| `pm_santa` | Male, Portuguese |
+
+### Spanish
+
+| Voice ID | Description |
+|----------|-------------|
+| `ef_dora` | Female, Spanish |
+| `em_alex` | Male, Spanish |
+| `em_santa` | Male, Spanish |
 
 <Note>
 Voice is selected using the `voice` parameter in the request payload. See the [Audio Speech API](/api-reference/endpoint/audio/speech) for usage examples.

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -216,7 +216,7 @@ Access chat, image generation (generate/upscale/edit), audio (TTS), and characte
   <Card title="Audio Synthesis" href="/api-reference/endpoint/audio/speech" icon="headphones">
     **Text → speech**
     
-    60+ multilingual voices
+    50+ multilingual voices
   </Card>
   
   <Card title="AI Characters" href="/api-reference/endpoint/characters/list" icon="user">

--- a/overview/getting-started.mdx
+++ b/overview/getting-started.mdx
@@ -563,7 +563,7 @@ See the [Image Upscale API](/api-reference/endpoint/image/upscale) for all param
 
 ### Text-to-Speech
 
-Convert text to audio with 60+ multilingual voices:
+Convert text to audio with 50+ multilingual voices:
 
 <CodeGroup>
   ```python Python
@@ -621,7 +621,7 @@ Convert text to audio with 60+ multilingual voices:
   ```
 </CodeGroup>
 
-The `tts-kokoro` model supports 60+ multilingual voices including `af_sky`, `af_nova`, `am_liam`, `bf_emma`, `zf_xiaobei`, and `jm_kumo`.
+The `tts-kokoro` model supports 50+ multilingual voices including `af_sky`, `af_nova`, `am_liam`, `bf_emma`, `zf_xiaobei`, and `jm_kumo`.
 
 See the [TTS API](/api-reference/endpoint/audio/speech) for all voice options.
 


### PR DESCRIPTION
Update Kokoro TTS voice list and count in documentation.

The documentation in `models/audio.mdx` incorrectly listed only 5 voices and claimed "60+" voices, while the `swagger.yaml` showed 54 available voices. This PR updates `models/audio.mdx` with the complete list of 54 voices and corrects all "60+" references to "50+" across the documentation for accuracy.

---
[Slack Thread](https://veniceai.slack.com/archives/C08KMNC77N1/p1769663945089859?thread_ts=1769663945.089859&cid=C08KMNC77N1)

<a href="https://cursor.com/background-agent?bcId=bc-eb95d319-3407-4c11-9445-f7c84e465e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb95d319-3407-4c11-9445-f7c84e465e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

