### PR TITLE
Default model configuration

### DIFF
--- a/overview/deprecations.mdx
+++ b/overview/deprecations.mdx
@@ -57,13 +57,9 @@ All Venice models are identified by a unique, permanent ID. For example:
 
 Model IDs are stable. If there's a breaking change, we will release a new model ID (for example, add a version like v2). If there are no breaking changes, we may update the existing model and will communicate significant changes.
 
-To provide flexibility, Venice also maintains symbolic aliases — implemented through traits — that point to the recommended default model for a given task. Examples include:
+To provide flexibility, Venice also maintains symbolic aliases — implemented through traits — that point to the recommended default model for a given task:
 
-- `default` → currently routes to `llama-3.3-70b`
-- `function_calling_default` → currently routes to `llama-3.3-70b`
-- `default_vision` → currently routes to `mistral-31-24b`
-- `most_uncensored` → currently routes to `venice-uncensored`
-- `fastest` → currently routes to `llama-3.2-3b`
+<div id="traits-list-placeholder"></div>
 
 Traits offer a stable abstraction for selecting models while giving Venice the flexibility to improve the underlying implementation. Developers who prefer automatic access to the latest recommended models can rely on trait-based aliases.
 


### PR DESCRIPTION
Dynamically fetch and display model traits in `deprecations.mdx` to prevent documentation from becoming outdated.

The previous hardcoded trait list in `deprecations.mdx` was out of sync with the actual backend definitions, leading to incorrect information about which models were assigned to traits like `default` and `function_calling_default`. This PR replaces the static list with a dynamic one that pulls data from the `/models/traits` API endpoint, ensuring the documentation always reflects the current state.

---
[Slack Thread](https://veniceai.slack.com/archives/C08KMNC77N1/p1769991832289429?thread_ts=1769991832.289429&cid=C08KMNC77N1)

<a href="https://cursor.com/background-agent?bcId=bc-2ed00534-de7e-5547-bc75-cdf406222c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ed00534-de7e-5547-bc75-cdf406222c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

