### PR TITLE
docs: add llms-full.txt for AI coding assistant integration

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -63,11 +63,13 @@ Standard OpenAI-compatible chat completions with Venice extensions.
     }
   },
   "venice_parameters": {
-    "enable_web_search": "on|off|auto (default: off) — enables real-time web search",
-    "enable_web_scraping": "boolean — auto-detect and scrape URLs in messages",
-    "include_venice_system_prompt": "boolean — include Venice's default system prompt",
-    "character_slug": "string — use a Venice character persona",
-    "thinking_mode": "off|medium|extended — for reasoning models"
+    "enable_web_search": "on|off|auto (default: off) — enable web search for this request. 'on' forces search, 'auto' lets model decide. Citations returned in first streaming chunk or response.",
+    "enable_web_scraping": "boolean (default: false) — auto-detect and scrape URLs in the latest user message via Firecrawl",
+    "enable_web_citations": "boolean (default: false) — when web search is enabled, request the LLM cite sources using ^index^ superscript format",
+    "include_venice_system_prompt": "boolean (default: true) — whether to include Venice's default system prompts alongside your system prompts",
+    "character_slug": "string — the public ID of a Venice character persona (discoverable on published character pages)",
+    "strip_thinking_response": "boolean (default: false) — strip <think></think> blocks from reasoning model responses. Also available as a model feature suffix.",
+    "disable_thinking": "boolean (default: false) — on supported reasoning models, disables thinking entirely and strips <think></think> blocks from the response"
   }
 }
 ```
@@ -268,7 +270,25 @@ Returns estimated price before generation.
 
 Returns all available models with capabilities, pricing, and constraints.
 
-### GET /models/{model_id}/traits — Get Model Traits
+### GET /models/traits — Get Model Traits
+
+Returns trait information for all models (capabilities, features, constraints).
+
+### GET /models/compatibility_mapping — Get Model Compatibility Mapping
+
+Returns OpenAI-to-Venice model compatibility mapping for migration.
+
+### GET /billing/usage — Get Billing Usage (Beta)
+
+Returns usage data including timestamps, SKUs, pricing, and inference details (request ID, execution time, token counts).
+
+### POST /images/generations — OpenAI-Compatible Image Generation
+
+OpenAI-compatible image generation endpoint. Use this if migrating from OpenAI's DALL-E API.
+
+### POST /video/complete — Complete Video
+
+Marks a video generation job as complete/cleaned up.
 
 ### POST /api_keys — Create API Key
 ### GET /api_keys — List API Keys
@@ -328,6 +348,7 @@ Returns all available models with capabilities, pricing, and constraints.
 | Flux 2 Pro | flux-2-pro | $0.04 | Anonymized |
 | SeedreamV4.5 | seedream-v4 | $0.05 | Anonymized |
 | Flux 2 Max | flux-2-max | $0.09 | Anonymized |
+| Nano Banana Pro | nano-banana-pro | $0.18-$0.35 (resolution-based: 1K=$0.18, 2K=$0.24, 4K=$0.35) | Anonymized |
 | GPT Image 1.5 | gpt-image-1-5 | $0.23 | Anonymized |
 
 ## Audio Models
@@ -362,6 +383,8 @@ Returns all available models with capabilities, pricing, and constraints.
 
 ## Rate Limits (API Keys)
 
+### Text Models
+
 | Tier | RPM | TPM |
 |------|-----|-----|
 | XS (qwen3-4b, llama-3.2-3b, embeddings) | 500 | 1M |
@@ -369,17 +392,31 @@ Returns all available models with capabilities, pricing, and constraints.
 | M (llama-3.3-70b, qwen3-next-80b, gemma-3) | 50 | 750K |
 | L (all flagship/large models) | 20 | 500K |
 
+### Non-Text Models
+
+| Type | RPM |
+|------|-----|
+| Image | 20 |
+| Audio | 60 |
+| Embedding | 500 |
+| Video (queue) | 40 |
+| Video (retrieve) | 120 |
+
+Abuse protection: 20+ failed requests in 30s triggers a 30s block. Use exponential backoff for 429 errors. Check `x-ratelimit-reset-requests` header for retry timing.
+
 ---
 
 ## Venice Parameters (venice_parameters)
 
 These are Venice-specific extensions passed alongside standard OpenAI parameters:
 
-- `enable_web_search`: `"on"|"off"|"auto"` — Real-time web search integration
-- `enable_web_scraping`: `boolean` — Auto-detect URLs and scrape content into context
-- `include_venice_system_prompt`: `boolean` — Include Venice's default helpful system prompt
-- `character_slug`: `string` — Use a pre-defined Venice character personality
-- `thinking_mode`: `"off"|"medium"|"extended"` — Control reasoning depth (for reasoning models)
+- `enable_web_search`: `"on"|"off"|"auto"` (default: `"off"`) — Enable real-time web search. `"on"` forces search, `"auto"` lets the model decide. Citations returned in first streaming chunk or non-streaming response.
+- `enable_web_scraping`: `boolean` (default: `false`) — Auto-detect and scrape URLs in the latest user message via Firecrawl.
+- `enable_web_citations`: `boolean` (default: `false`) — When web search is enabled, request the LLM cite sources using `^index^` superscript format.
+- `include_venice_system_prompt`: `boolean` (default: `true`) — Whether to include Venice's default system prompts alongside your specified system prompts.
+- `character_slug`: `string` — The public ID of a Venice character persona (discoverable on published character pages).
+- `strip_thinking_response`: `boolean` (default: `false`) — Strip `<think></think>` blocks from reasoning model responses. Also available as a model feature suffix.
+- `disable_thinking`: `boolean` (default: `false`) — On supported reasoning models, disables thinking entirely and strips `<think></think>` blocks from the response.
 
 **Python extra_body syntax:**
 ```python


### PR DESCRIPTION
## What This PR Adds

Adds `llms-full.txt` — a comprehensive, single-file API reference designed for AI coding assistants (Cursor, Claude Code, Copilot, etc.) to consume when developers ask about Venice's API.

This follows the `llms.txt` convention (see [llmstxt.org](https://llmstxt.org/)) where `llms.txt` is a concise index and `llms-full.txt` is the complete reference.

## Key Fixes in This Update

- **Removed hallucinated `thinking_mode` parameter** — this never existed in the API
- **Added real venice_parameters** from swagger.yaml: `strip_thinking_response`, `disable_thinking`, `enable_web_citations` with accurate descriptions and defaults
- **Fixed `/models/traits` endpoint** — removed incorrect `{model_id}` path parameter
- **Added 4 missing endpoints**: `POST /images/generations` (OpenAI-compatible), `GET /models/compatibility_mapping`, `GET /billing/usage`, `POST /video/complete`
- **Added `nano-banana-pro`** to image models table with resolution-based pricing ($0.18-$0.35)
- **Added non-text rate limits** (image: 20 RPM, audio: 60 RPM, embedding: 500 RPM, video queue/retrieve: 40/120 RPM)
- **Added abuse protection notes**

## Why This Matters for Venice

- **Developer adoption**: AI coding assistants are now the primary way developers discover and integrate APIs. Having accurate `llms-full.txt` means Venice gets recommended correctly when developers ask "how do I use Venice?"
- **Revenue impact**: Every correct API integration suggestion from an AI assistant is a potential new paying user
- **Reduces support burden**: Accurate docs in AI assistants means fewer incorrect implementations and support tickets

## Verification

All changes cross-referenced against:
- `swagger.yaml` (OpenAPI spec) for parameter names, types, defaults, and descriptions
- `api-reference/rate-limiting.mdx` for rate limit tiers
- `overview/pricing.mdx` for nano-banana-pro pricing
- `api-reference/endpoint/` files for endpoint paths and descriptions