### PR TITLE
Update default vision model to Qwen3 VL 235B and rename Venice Medium

### DIFF
--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -264,7 +264,7 @@ Copy a Model ID and use it as `model` in your requests.
     ```
   </Card>
   
-  <Card title="Venice Medium 3.1" icon="eye">
+  <Card title="Mistral 3.1 24B" icon="eye">
     **Vision + tools**
     
     Model ID: `mistral-31-24b`
@@ -693,7 +693,7 @@ curl https://api.venice.ai/api/v1/chat/completions \
 </Accordion>
 
 <Accordion title="Vision Processing Code Samples">
-Image understanding and multimodal analysis. Available on **vision models**: `mistral-31-24b`. Upload images via base64 data URIs or URLs for analysis, description, and reasoning.
+Image understanding and multimodal analysis. Available on **vision models**: `qwen3-vl-235b-a22b`. Upload images via base64 data URIs or URLs for analysis, description, and reasoning.
 
 <CodeGroup>
 ```bash Curl
@@ -701,7 +701,7 @@ curl https://api.venice.ai/api/v1/chat/completions \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "mistral-31-24b",
+    "model": "qwen3-vl-235b-a22b",
     "messages": [
       {
         "role": "user",
@@ -723,7 +723,7 @@ const openai = new OpenAI({
 });
 
 const completion = await openai.chat.completions.create({
-  model: "mistral-31-24b",
+  model: "qwen3-vl-235b-a22b",
   messages: [
     {
       role: "user",
@@ -747,7 +747,7 @@ client = openai.OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="mistral-31-24b",
+    model="qwen3-vl-235b-a22b",
     messages=[
         {
             "role": "user",
@@ -784,7 +784,7 @@ func main() {
     resp, err := client.CreateChatCompletion(
         context.Background(),
         openai.ChatCompletionRequest{
-            Model: "mistral-31-24b",
+            Model: "qwen3-vl-235b-a22b",
             Messages: []openai.ChatCompletionMessage{
                 {
                     Role: openai.ChatMessageRoleUser,
@@ -817,7 +817,7 @@ $client = OpenAI::client('your-api-key');
 $client->setBaseUrl('https://api.venice.ai/api/v1');
 
 $response = $client->chat()->create([
-    'model' => 'mistral-31-24b',
+    'model' => 'qwen3-vl-235b-a22b',
     'messages' => [
         [
             'role' => 'user',
@@ -840,7 +840,7 @@ client.BaseUrl = "https://api.venice.ai/api/v1";
 
 var chatCompletion = await client.GetChatCompletionsAsync(new ChatCompletionOptions
 {
-    Model = "mistral-31-24b",
+    Model = "qwen3-vl-235b-a22b",
     Messages = { 
         new ChatMessage(ChatRole.User, [
             ChatMessageContentPart.CreateTextPart("What do you see in this image?"),
@@ -868,7 +868,7 @@ public class Main {
         try {
             ChatCompletionResponse response = client.chatCompletions().create(
                 ChatCompletionRequest.builder()
-                    .model("mistral-31-24b")
+                    .model("qwen3-vl-235b-a22b")
                     .messages(ChatMessage.builder()
                         .role(ChatMessage.Role.USER)
                         .content(ChatMessage.Content.ofMultiple(

--- a/overview/getting-started.mdx
+++ b/overview/getting-started.mdx
@@ -108,7 +108,7 @@ Get up and running with the Venice API in minutes. Generate an API key, make you
     Venice has multiple models for different use cases. Popular choices:
     - `llama-3.3-70b` - Balanced performance, great for most use cases
     - `zai-org-glm-4.7` - Flagship model for complex tasks and deep reasoning
-    - `mistral-31-24b` - Vision + function calling support
+    - `qwen3-vl-235b-a22b` - Vision support
     - `venice-uncensored` - No content filtering
 
     <Card title="View All Models" icon="database" href="/overview/models">
@@ -755,7 +755,7 @@ See the [Embeddings API](/api-reference/endpoint/embeddings/generate) for batch 
 
 ### Vision (Multimodal)
 
-Analyze images alongside text using vision-capable models like `mistral-31-24b`:
+Analyze images alongside text using vision-capable models like `qwen3-vl-235b-a22b`:
 
 <CodeGroup>
   ```python Python
@@ -768,7 +768,7 @@ Analyze images alongside text using vision-capable models like `mistral-31-24b`:
   )
 
   response = client.chat.completions.create(
-      model="mistral-31-24b",
+      model="qwen3-vl-235b-a22b",
       messages=[
           {
               "role": "user",
@@ -795,7 +795,7 @@ Analyze images alongside text using vision-capable models like `mistral-31-24b`:
   });
 
   const response = await client.chat.completions.create({
-      model: 'mistral-31-24b',
+      model: 'qwen3-vl-235b-a22b',
       messages: [
           {
               role: 'user',
@@ -818,7 +818,7 @@ Analyze images alongside text using vision-capable models like `mistral-31-24b`:
     -H "Authorization: Bearer $VENICE_API_KEY" \
     -H "Content-Type: application/json" \
     -d '{
-      "model": "mistral-31-24b",
+      "model": "qwen3-vl-235b-a22b",
       "messages": [
         {
           "role": "user",

--- a/overview/pricing.mdx
+++ b/overview/pricing.mdx
@@ -592,7 +592,7 @@ All prices are in USD. Diem users pay the same rates (1 Diem = $1 of compute per
 <div className="vpt-row">
 <div className="vpt-row-top">
 <div className="vpt-row-left">
-<span className="vpt-model-name">Venice Medium</span>
+<span className="vpt-model-name">Mistral 3.1 24B</span>
 <code className="vpt-model-id">mistral-31-24b</code>
 </div>
 <div className="vpt-row-right">


### PR DESCRIPTION
… to Mistral 3.1 24B

- Changed 'Venice Medium' branding to 'Mistral 3.1 24B' in pricing and about pages

- Updated vision model examples from mistral-31-24b to qwen3-vl-235b-a22b