### PR TITLE
Fix: Use scoped npm package name for @musistudio/claude-code-router

### DIFF
--- a/overview/guides/claude-code.mdx
+++ b/overview/guides/claude-code.mdx
@@ -66,7 +66,7 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
 
   <Step title="Install the Router">
     ```bash
-    npm install -g claude-code-router
+    npm install -g @musistudio/claude-code-router
     ```
   </Step>
 


### PR DESCRIPTION
This PR updates the installation command to use the correct scoped package @musistudio/claude-code-router as specified in the official documentation. Previously, installing claude-code-router inadvertently pulled in the package fanzhang16/claude-code-router, which is a distinct package with incompatible configuration requirements. This change ensures the correct dependency is installed.

fixes #102