### PR TITLE
Add Claude Opus 4.6 in Claude Code documentation

### DIFF
--- a/overview/guides/claude-code.mdx
+++ b/overview/guides/claude-code.mdx
@@ -108,6 +108,7 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
           "models": [
             "claude-opus-45",
             "claude-sonnet-45"
+            "claude-opus-4-6",
           ],
           "transformer": {
             "use": ["anthropic"]
@@ -153,6 +154,7 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
 |-------|-----------|----------|
 | Claude Opus 4.5 | `claude-opus-45` | Complex reasoning, large refactors |
 | Claude Sonnet 4.5 | `claude-sonnet-45` | Fast iteration, everyday coding |
+| Claude Opus 4.6 | `claude-opus-4-6` | Complex reasoning, large refactors |
 
 <Info>
 Claude Code is optimized for Claude models. While other models available through Venice (GPT, DeepSeek, Grok, etc.) may work, we cannot guarantee an equivalent experience since Claude Code relies on Claude-specific features like extended thinking. For other models, consider using Venice's [standard API](/api-reference/endpoint/chat/completions).


### PR DESCRIPTION
Add Claude Opus 4.6 model in Claude Code documentation.
At it is new and still in beta in Venice.ai, keep Opus 4.5 as the
default model.
