### PR TITLE
Add context paragraph to API Pricing

### DIFF
--- a/overview/pricing.mdx
+++ b/overview/pricing.mdx
@@ -4,6 +4,10 @@ title: API Pricing
 "og:description": "Learn about pricing for Venice's API."
 ---
 
+## API-Pricing
+
+Venice provides a unified API that exposes multiple AI models with different pricing tiers and privacy constraints. Some models are hosted directly on Venice’s infrastructure (typically open-source, lower cost, more privacy-focused), while others—such as Grok or Claude—are accessed via anonymized proxying to external providers.
+
 All prices are in USD. Diem users pay the same rates (1 Diem = $1 of compute per day).
 
 ## Text Models


### PR DESCRIPTION
The API pricing page was missing context. Particularly for outside new users / devs that are just parusing Venices various pricing mechanisms. I was confused as to what I was even looking at, so I asked your included ai and then summarized that answer. Gives a nice upfront ‘about’ context.