### PR TITLE
Document reasoning_effort values and per-model support matrix

### DIFF
--- a/overview/guides/reasoning-models.mdx
+++ b/overview/guides/reasoning-models.mdx
@@ -34,7 +34,7 @@ Some models think out loud before answering. They work through problems step by 
 | Venice Small | `qwen3-4b` |
 {/* END_SUPPORTED_MODELS */}
 
-See the full list of models, pricing and context limits on the [Models page](/overview/models). Not all reasoning models support the [`reasoning_effort`](#reasoning-effort) parameter — see [model support](#model-support) for details.
+See the full list of models, pricing and context limits on the [Models page](/overview/models). Not all reasoning models support the [`reasoning_effort`](#reasoning-effort) parameter. See [model support](#model-support) for details.
 
 ## Reading the output
 
@@ -142,9 +142,9 @@ The `reasoning_effort` parameter controls how much thinking a model does before 
 | `max` | Maximum reasoning capability |
 
 <Warning>
-Not all models support all values. Venice does **not** auto-map to the nearest supported level — unsupported values return a 400 error from the upstream provider. For example, sending `xhigh` to Claude or `max` to GPT-5.2 will fail.
+Not all models support all values. Venice does **not** auto-map to the nearest supported level. Unsupported values return a 400 error from the upstream provider. For example, sending `xhigh` to Claude or `max` to GPT-5.2 will fail.
 
-When in doubt, use `low`, `medium`, or `high` — these are the most widely supported values.
+When in doubt, use `low`, `medium`, or `high`. These are the most widely supported values.
 </Warning>
 
 ### Model support
@@ -225,7 +225,7 @@ There are two ways to disable reasoning:
 
 | Method | Syntax | How it works |
 |--------|--------|-------------|
-| `reasoning.enabled: false` | `"reasoning": {"enabled": false}` | Venice-level toggle — prevents reasoning parameters from being sent to the provider. **Recommended.** |
+| `reasoning.enabled: false` | `"reasoning": {"enabled": false}` | Venice-level toggle that prevents reasoning parameters from being sent to the provider. **Recommended.** |
 | `reasoning.effort: "none"` | `"reasoning": {"effort": "none"}` | Passed to the provider, which decides how to handle it. Only supported by some models (e.g. GPT-5.x). |
 
 For models that support it, `reasoning.enabled: false` is the more reliable option:
@@ -283,4 +283,4 @@ Check what a model supports via the [`/v1/models`](/api-reference/endpoint/model
 - Use `high` or `xhigh` for complex tasks (math, code, analysis)
 - Use `low` for latency-sensitive applications
 - Use `reasoning.enabled: false` or set effort to `none` to disable reasoning
-- When in doubt, use `low`, `medium`, or `high` — these are the most widely supported values
+- When in doubt, use `low`, `medium`, or `high`. These are the most widely supported values


### PR DESCRIPTION
- Add full accepted values table (none, minimal, low, medium, high, xhigh, max)

- Add per-provider model support matrix with supported values

- Add disabling reasoning section with reasoning.enabled: false

- Add encrypted reasoning callout and capability discovery section

- Clean up reading output section and add best practices