### PR TITLE
Docs usage analytics missing

### DIFF
--- a/.github/workflows/purge-cloudflare-cache.yml
+++ b/.github/workflows/purge-cloudflare-cache.yml
@@ -1,0 +1,38 @@
+name: Purge Cloudflare Cache
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  purge-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Purge Cloudflare cache
+        run: |
+          # Wait for Mintlify deployment to propagate before purging
+          sleep 45
+
+          response=$(curl -s -w "\n%{http_code}" -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything": true}')
+
+          http_code=$(echo "$response" | tail -1)
+          body=$(echo "$response" | head -n -1)
+
+          echo "$body" | jq . 2>/dev/null || echo "$body"
+
+          if [ "$http_code" -ne 200 ]; then
+            echo "::error::Cloudflare cache purge failed with HTTP $http_code"
+            exit 1
+          fi
+
+          success=$(echo "$body" | jq -r '.success')
+          if [ "$success" != "true" ]; then
+            echo "::error::Cloudflare cache purge returned success=false"
+            exit 1
+          fi
+
+          echo "Cache purged successfully"


### PR DESCRIPTION
Add GitHub Actions workflow to purge Cloudflare cache on `main` branch pushes.

This workflow ensures that `docs.venice.ai` displays the latest content immediately after Mintlify deployments by clearing Cloudflare's cache. Previously, Cloudflare would serve stale pages until its TTL expired. Requires `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_API_TOKEN` repository secrets.

---
<p><a href="https://cursor.com/agents/bc-e45c6317-fcb3-48d2-927c-fc9c35eadc46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e45c6317-fcb3-48d2-927c-fc9c35eadc46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

