### PR TITLE
Sort models by newest first on overview page only

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -1254,9 +1254,16 @@
     let activeCapability = null;
     let activeVideoType = null;
     let activeImageType = null;
-    let activeSort = 'default';
+    // On overview page (no preset filter), default to newest first
+    let activeSort = presetFilter ? 'default' : 'newest';
     
     const sortToggle = container.querySelector('.vmb-sort-toggle');
+    
+    // Set initial sort toggle UI state for overview page
+    if (!presetFilter) {
+      sortToggle.classList.add('active');
+      sortToggle.title = 'Newest first (click for oldest)';
+    }
 
     // Always render static data immediately for instant display
     allModels = STATIC_MODELS;


### PR DESCRIPTION
- On /models/overview page (no data-filter attribute), default sort to 'newest' so newest models appear first
- On filtered pages like /models/text, keep the default API order
- Initialize sort toggle UI state appropriately for overview page