### PR TITLE
Add Moderated badge for xAI media models and normalize tooltip styles

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -157,8 +157,21 @@
     beta: 'Experimental model that may change or be removed without notice. Not recommended for production.',
     deprecated: 'This model is scheduled for removal. See the deprecations page for timeline and migration guide.',
     uncensored: 'Responds to all prompts without content-based refusals or filtering.',
-    upgraded: 'A newer version of this model is available with improved performance.'
+    upgraded: 'A newer version of this model is available with improved performance.',
+    content_moderation: 'This model applies upstream content moderation. Requests blocked by the provider\u2019s filters are still billed at the full rate.'
   };
+
+  // Models subject to upstream provider content moderation that still bills on blocked requests
+  const CONTENT_MODERATED_MODELS = new Set([
+    'grok-imagine',
+    'grok-imagine-edit',
+    'grok-imagine-text-to-video',
+    'grok-imagine-image-to-video'
+  ]);
+
+  function hasContentModeration(modelId) {
+    return CONTENT_MODERATED_MODELS.has(modelId);
+  }
 
   let isInitializing = false;
 
@@ -387,6 +400,7 @@
       const capTags = getCapabilityTags(spec.capabilities, isUncensoredModel(model));
       const betaTag = isBetaModel(model) ? '<span class="vpt-badge vpt-beta vpt-tooltip" data-tooltip="Experimental model that may change or be removed without notice.">Beta</span>' : '';
       const upgradedTag = isUpgradedModel(model) ? '<span class="vpt-badge vpt-upgraded vpt-tooltip" data-tooltip="A newer version of this model is available with improved performance.">Upgraded</span>' : '';
+      const moderationTag = hasContentModeration(model.id) ? `<span class="vpt-badge vpt-moderation vpt-tooltip" data-tooltip="${TOOLTIPS.content_moderation}">Moderated</span>` : '';
       const privacyTag = isAnonymizedModel(model) 
         ? `<span class="vpt-cap-tag vpt-cap-anonymized vpt-tooltip" data-tooltip="${TOOLTIPS.anonymized}">Anonymized</span>` 
         : `<span class="vpt-cap-tag vpt-cap-private vpt-tooltip" data-tooltip="${TOOLTIPS.private}">Private</span>`;
@@ -421,7 +435,7 @@
             <span class="vpt-model-name">${name}</span>${betaTag}${upgradedTag}
             <code class="vpt-model-id">${modelId}</code>${pricingCopyBtn(modelId)}
           </div>
-          <div class="vpt-row-right">${privacyTag}${capTags}</div>
+          <div class="vpt-row-right">${moderationTag}${privacyTag}${capTags}</div>
         </div>
         <div class="vpt-row-bottom">
           ${priceItems}
@@ -493,6 +507,7 @@
       const modelId = escapeHtml(model.id);
       const name = escapeHtml(spec.name || model.id);
       const betaTag = isBetaModel(model) ? '<span class="vpt-badge vpt-beta vpt-tooltip" data-tooltip="Experimental model that may change or be removed without notice.">Beta</span>' : '';
+      const moderationTag = hasContentModeration(model.id) ? `<span class="vpt-badge vpt-moderation vpt-tooltip" data-tooltip="${TOOLTIPS.content_moderation}">Moderated</span>` : '';
       const privacyTag = isAnonymizedModel(model) 
         ? `<span class="vpt-cap-tag vpt-tooltip" data-tooltip="${TOOLTIPS.anonymized}">Anonymized</span>` 
         : `<span class="vpt-cap-tag vpt-tooltip" data-tooltip="${TOOLTIPS.private}">Private</span>`;
@@ -516,7 +531,7 @@
             <span class="vpt-model-name">${name}</span>${betaTag}
             <code class="vpt-model-id">${modelId}</code>${pricingCopyBtn(modelId)}
           </div>
-          <div class="vpt-row-right">${privacyTag}</div>
+          <div class="vpt-row-right">${moderationTag}${privacyTag}</div>
         </div>
         <div class="vpt-row-bottom">
           ${priceItems}
@@ -560,6 +575,7 @@
       const modelId = escapeHtml(model.id);
       const name = escapeHtml(spec.name || model.id);
       const editPrice = spec.pricing?.inpaint?.usd ?? spec.pricing?.generation?.usd ?? 0.04;
+      const moderationTag = hasContentModeration(model.id) ? `<span class="vpt-badge vpt-moderation vpt-tooltip" data-tooltip="${TOOLTIPS.content_moderation}">Moderated</span>` : '';
 
       return `<div class="vpt-row">
         <div class="vpt-row-top">
@@ -567,6 +583,7 @@
             <span class="vpt-model-name">${name}</span>
             <code class="vpt-model-id">${modelId}</code>${pricingCopyBtn(modelId)}
           </div>
+          <div class="vpt-row-right">${moderationTag}</div>
         </div>
         <div class="vpt-row-bottom">
           <span class="vpt-price-item"><span class="vpt-price-label">Per Edit</span><span class="vpt-price-value">${formatPrice(editPrice)}</span></span>
@@ -679,6 +696,7 @@
       const modelId = escapeHtml(model.id);
       const name = escapeHtml(spec.name || model.id);
       const betaTag = isBetaModel(model) ? '<span class="vpt-badge vpt-beta vpt-tooltip" data-tooltip="Experimental model that may change or be removed without notice.">Beta</span>' : '';
+      const moderationTag = hasContentModeration(model.id) ? `<span class="vpt-badge vpt-moderation vpt-tooltip" data-tooltip="${TOOLTIPS.content_moderation}">Moderated</span>` : '';
       const privacyTag = isAnonymizedModel(model) 
         ? `<span class="vpt-cap-tag vpt-tooltip" data-tooltip="${TOOLTIPS.anonymized}">Anonymized</span>` 
         : `<span class="vpt-cap-tag vpt-tooltip" data-tooltip="${TOOLTIPS.private}">Private</span>`;
@@ -693,7 +711,7 @@
             <span class="vpt-model-name">${name}</span>${betaTag}
             <code class="vpt-model-id">${modelId}</code>${pricingCopyBtn(modelId)}
           </div>
-          <div class="vpt-row-right">${privacyTag}${videoTypeBadge}</div>
+          <div class="vpt-row-right">${moderationTag}${privacyTag}${videoTypeBadge}</div>
         </div>
         <div class="vpt-row-bottom">
           ${durations.length > 0 ? `<span class="vpt-price-item"><span class="vpt-price-label">Durations</span><span class="vpt-price-value vpt-context-value">${durations.join(', ')}</span></span>` : ''}
@@ -1519,6 +1537,10 @@
         ? `<span class="vmb-upgraded-badge vmb-tooltip" data-tooltip="${TOOLTIPS.upgraded}">Upgraded</span>` 
         : '';
       
+      const moderationBadge = hasContentModeration(model.id)
+        ? `<span class="vmb-moderation-badge vmb-tooltip" data-tooltip="${TOOLTIPS.content_moderation}">Moderated</span>`
+        : '';
+      
       const newBadge = dateInfo?.isNew
         ? '<span class="vmb-new-badge">NEW</span>'
         : '';
@@ -1584,7 +1606,7 @@
               </div>
               <div class="vmb-model-right">
                 ${contextStr ? `<span class="vmb-context vmb-context-desktop">${contextStr}</span>` : ''}
-                ${typeBadge}${videoTypeBadge}${privacyBadge}${betaBadge}${deprecatedBadge}${upgradedBadge}${uncensoredBadge}${rateLimitBadge}
+                ${typeBadge}${videoTypeBadge}${privacyBadge}${betaBadge}${deprecatedBadge}${upgradedBadge}${uncensoredBadge}${moderationBadge}${rateLimitBadge}
               </div>
             </div>
             <div class="vmb-model-info">

--- a/style.css
+++ b/style.css
@@ -539,10 +539,11 @@
   width: auto;
   max-width: none;
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: 13px;
   background: #fafafa;
   border: 1px solid #e4e4e7;
   color: #18181b;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
   opacity: 0; /* Start hidden */
 }
 
@@ -551,10 +552,10 @@
 }
 
 .dark .vmb-cap.vmb-tooltip::after {
-  background: #000000;
-  border-color: #404040;
-  color: #ffffff;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.8);
+  background: #18181b;
+  border-color: #3f3f46;
+  color: #fafafa;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
 }
 
 .vmb-cap-icon {
@@ -649,8 +650,11 @@
   letter-spacing: 0.3px;
   background: transparent;
   border: 1px solid rgba(128, 128, 128, 0.3);
-  color: inherit;
-  opacity: 0.7;
+  color: #71717a;
+}
+
+.dark .vmb-privacy-badge {
+  color: #a1a1aa;
 }
 
 .vmb-beta-badge {
@@ -680,8 +684,11 @@
   letter-spacing: 0.3px;
   background: transparent;
   border: 1px solid rgba(128, 128, 128, 0.3);
-  color: inherit;
-  opacity: 0.7;
+  color: #71717a;
+}
+
+.dark .vmb-uncensored-badge {
+  color: #a1a1aa;
 }
 
 .vmb-deprecated-badge {
@@ -704,6 +711,23 @@
   color: #10b981;
 }
 
+.vmb-moderation-badge {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+  text-transform: uppercase;
+  background: rgba(130, 115, 150, 0.12);
+  border: 1px solid rgba(130, 115, 150, 0.25);
+  color: #8a7ea0;
+}
+
+.dark .vmb-moderation-badge {
+  background: rgba(150, 135, 170, 0.1);
+  border-color: rgba(150, 135, 170, 0.25);
+  color: #a098b8;
+}
+
 .vmb-ratelimit-badge {
   font-size: 10px;
   padding: 2px 6px;
@@ -712,8 +736,11 @@
   font-family: monospace;
   background: transparent;
   border: 1px solid rgba(128, 128, 128, 0.3);
-  color: inherit;
-  opacity: 0.7;
+  color: #71717a;
+}
+
+.dark .vmb-ratelimit-badge {
+  color: #a1a1aa;
 }
 
 .vmb-tooltip {
@@ -734,6 +761,7 @@
   font-size: 13px;
   font-weight: 400;
   text-transform: none;
+  letter-spacing: normal;
   line-height: 1.5;
   color: #18181b;
   white-space: normal;
@@ -915,6 +943,7 @@
   font-size: 13px;
   font-weight: 400;
   text-transform: none;
+  letter-spacing: normal;
   line-height: 1.5;
   color: #18181b;
   white-space: normal;
@@ -1099,6 +1128,17 @@
   opacity: 0.7;
 }
 
+.vpt-moderation {
+  margin-left: 6px;
+  background: rgba(130, 115, 150, 0.12);
+  color: #8a7ea0;
+}
+
+.dark .vpt-moderation {
+  background: rgba(150, 135, 170, 0.1);
+  color: #a098b8;
+}
+
 .vpt-badge {
   font-size: 10px;
   font-weight: 600;
@@ -1203,8 +1243,11 @@
   padding: 2px 6px;
   border-radius: 3px;
   background: rgba(128, 128, 128, 0.12);
-  color: inherit;
-  opacity: 0.7;
+  color: #71717a;
+}
+
+.dark .vpt-cap-tag {
+  color: #a1a1aa;
 }
 
 /* Capability icons for pricing page */
@@ -1230,10 +1273,11 @@
   width: auto;
   max-width: none;
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: 13px;
   background: #fafafa;
   border: 1px solid #e4e4e7;
   color: #18181b;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
 }
 
 .vpt-cap.vpt-tooltip:hover::after {
@@ -1241,10 +1285,10 @@
 }
 
 .dark .vpt-cap.vpt-tooltip::after {
-  background: #000000;
-  border-color: #404040;
-  color: #ffffff;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.8);
+  background: #18181b;
+  border-color: #3f3f46;
+  color: #fafafa;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
 }
 
 /* ========== MOBILE RESPONSIVE ========== */


### PR DESCRIPTION
- Add Moderated badge on grok-imagine, grok-imagine-edit, grok-imagine-text-to-video, grok-imagine-image-to-video to warn that blocked requests are still billed. - Fix tooltip opacity bug: replace opacity:0.7 on badge parents with explicit muted colors to prevent tooltip fading via CSS compositing. - Normalize tooltip font-size, background, shadow, and text color across all tooltip variants.