### PR TITLE
Add insufficient balance error code to API reference

### DIFF
--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -12,6 +12,7 @@ When an error occurs in the API, we return a consistent error response format th
 | `AUTHENTICATION_FAILED` | 401         | Authentication failed                     | -         |
 | `AUTHENTICATION_FAILED_INACTIVE_KEY` | 401         | Authentication failed - Pro subscription is inactive. Please upgrade your subscription to continue using the API.                     | -         |
 | `INVALID_API_KEY`       | 401         | Invalid API key provided                  | -         |
+| `INSUFFICIENT_BALANCE`  | 402         | Insufficient USD or Diem balance to complete request. Visit https://venice.ai/settings/api to add credits. | -         |
 | `UNAUTHORIZED`          | 403         | Unauthorized access                       | -         |
 | `INVALID_REQUEST`       | 400         | Invalid request parameters                | -         |
 | `INVALID_MODEL`         | 400         | Invalid model specified                   | -         |


### PR DESCRIPTION
- Introduced `INSUFFICIENT_BALANCE` error code with a description for cases where the user lacks sufficient USD or Diem balance to complete a request. This update enhances the clarity of error responses in the API documentation.