### PR TITLE
Audio API swagger definition

### DIFF
--- a/api-reference/endpoint/audio/complete.mdx
+++ b/api-reference/endpoint/audio/complete.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Complete Audio'
+openapi: 'POST /audio/complete'
+"og:title": "Audio Complete | Venice API Docs"
+"og:description": "Documentation covering Venice's audio completion and cleanup API."
+---
+
+Call this endpoint after you have successfully downloaded generated audio when you want Venice to clean up stored media associated with the request.
+
+-------

--- a/api-reference/endpoint/audio/queue.mdx
+++ b/api-reference/endpoint/audio/queue.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Queue Audio Generation'
+openapi: 'POST /audio/queue'
+"og:title": "Audio Queue | Venice API Docs"
+"og:description": "Documentation covering Venice's queued audio generation API."
+---
+
+Call `/audio/quote` to estimate cost, then poll `/audio/retrieve` with the returned `queue_id` until the generation finishes. If you keep generated media after retrieval, call `/audio/complete` once you have downloaded it.
+
+-------

--- a/api-reference/endpoint/audio/quote.mdx
+++ b/api-reference/endpoint/audio/quote.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Quote Audio Generation'
+openapi: 'POST /audio/quote'
+"og:title": "Audio Quote | Venice API Docs"
+"og:description": "Documentation covering Venice's audio generation quote API."
+---
+
+Use this endpoint before `/audio/queue` to estimate the USD cost of an audio generation request for the selected model and parameters.
+
+-------

--- a/api-reference/endpoint/audio/retrieve.mdx
+++ b/api-reference/endpoint/audio/retrieve.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Retrieve Audio'
+openapi: 'POST /audio/retrieve'
+"og:title": "Audio Retrieve | Venice API Docs"
+"og:description": "Documentation covering Venice's audio generation retrieval API."
+---
+
+Use the `queue_id` returned by `/audio/queue` to check generation status. When the request completes, this endpoint returns the generated audio data.
+
+-------

--- a/docs.json
+++ b/docs.json
@@ -98,7 +98,11 @@
                 "group": "Audio",
                 "pages": [
                   "api-reference/endpoint/audio/speech",
-                  "api-reference/endpoint/audio/transcriptions"
+                  "api-reference/endpoint/audio/transcriptions",
+                  "api-reference/endpoint/audio/queue",
+                  "api-reference/endpoint/audio/retrieve",
+                  "api-reference/endpoint/audio/quote",
+                  "api-reference/endpoint/audio/complete"
                 ]
               },
               {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add API reference pages for the new `/audio/queue`, `/audio/retrieve`, `/audio/quote`, and `/audio/complete` endpoints.

---
[Slack Thread](https://veniceai.slack.com/archives/C0A9S3GQ2KV/p1772861240532069?thread_ts=1772861240.532069&cid=C0A9S3GQ2KV)

<p><a href="https://cursor.com/agents/bc-f4976e81-2c81-55cb-af88-b75d4908e8f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4976e81-2c81-55cb-af88-b75d4908e8f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->