### PR TITLE
Music sound effect page filtering

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -1315,6 +1315,7 @@
       if (activeFilter === 'video') return model.type === 'video';
       if (activeFilter === 'audio') return model.type === 'tts' || model.type === 'asr';
       if (activeFilter === 'embedding') return model.type === 'embedding';
+      if (activeFilter === 'music') return model.type === 'music';
       return true;
     }
 

--- a/models/music.mdx
+++ b/models/music.mdx
@@ -9,13 +9,17 @@ description: "AI-powered music generation, song creation, and sound effects synt
 ## Model Categories
 
 **Song Generation:** Create full songs with optional lyrics and vocal support
-- ACE-Step 1.5, MiniMax Music 2.0
+- ACE-Step 1.5, ElevenLabs Music, MiniMax Music 2.0
 
-**Instrumental Music:** Generate production-ready instrumental tracks
-- ElevenLabs Music
+**Music & Sound Effects:** Generate instrumental music or sound effects from text prompts
+- Stable Audio 2.5
 
 **Sound Effects:** Synthesize audio effects and ambient sounds from text prompts
-- ElevenLabs Sound Effects, MMAudio V2, Stable Audio 2.5
+- ElevenLabs Sound Effects, MMAudio V2
+
+<Tip>
+ElevenLabs Music is the only model that supports `force_instrumental` to generate music without vocals.
+</Tip>
 
 <Note>
 Audio generation uses an async queue system. See the [Audio Queue API](/api-reference/endpoint/audio/queue) to start generation and [Audio Retrieve API](/api-reference/endpoint/audio/retrieve) to fetch results.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix music model filtering and correct model categories on the music & sound effect page.

The `model-search.js` file was missing a case for the 'music' filter, leading to all models being displayed instead of just music models. Additionally, the categories for ElevenLabs Music and Stable Audio 2.5 were updated in `music.mdx` to reflect their capabilities accurately.

---
[Slack Thread](https://veniceai.slack.com/archives/C0A9S3GQ2KV/p1772861240532069?thread_ts=1772861240.532069&cid=C0A9S3GQ2KV)

<p><a href="https://cursor.com/agents/bc-fec37934-4595-55ea-af0a-45fef52043d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fec37934-4595-55ea-af0a-45fef52043d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->