### PR TITLE
Audio models page filtering

### DIFF
--- a/models/audio.mdx
+++ b/models/audio.mdx
@@ -4,7 +4,7 @@ description: "Text-to-speech models with multilingual voice support"
 "og:title": "Audio Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="tts">Loading models...</div>
+<div id="model-search-placeholder" data-filter="audio">Loading models...</div>
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Revert `data-filter` in `models/audio.mdx` to `audio` to correctly filter for TTS and ASR models.

A previous change set `data-filter="tts"` on the Audio Models page. However, the `matchesCategory()` function in `model-search.js` only has a handler for `activeFilter === 'audio'` to display both TTS and ASR models. Without a specific `tts` handler, the filter defaulted to showing all models.

---
[Slack Thread](https://veniceai.slack.com/archives/C0A9S3GQ2KV/p1772861240532069?thread_ts=1772861240.532069&cid=C0A9S3GQ2KV)

<p><a href="https://cursor.com/agents/bc-319840fc-0869-5128-935a-dbee37ca738f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-319840fc-0869-5128-935a-dbee37ca738f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->