### PR TITLE
Add agent-specific guidance for binary audio data handling

### DIFF
--- a/api-reference/endpoint/audio/queue.mdx
+++ b/api-reference/endpoint/audio/queue.mdx
@@ -7,4 +7,41 @@ openapi: 'POST /audio/queue'
 
 Call `/audio/quote` to estimate cost, then poll `/audio/retrieve` with the returned `queue_id` until the generation finishes. If you keep generated media after retrieval, call `/audio/complete` once you have downloaded it.
 
+## For AI Agents
+
+<Tip title="Working with Audio APIs">
+When generating audio via API, the final response will be **binary data**, not JSON. AI agents often make the mistake of capturing this in shell variables, which corrupts the audio.
+
+Key principles:
+1. **Queue requests** → Returns JSON with `queue_id`
+2. **Poll for status** → Returns JSON while processing, **binary audio when complete**
+3. **Save binary directly** → Use `curl -o filename` or `response.content` in Python, never shell variables
+4. **Cleanup** → Call `/audio/complete` after downloading
+
+See [Retrieve Audio](/api-reference/endpoint/audio/retrieve) for detailed binary handling instructions.
+</Tip>
+
+## Music Models Quick Reference
+
+| Model | Best For | Lyrics | Duration |
+|-------|----------|--------|----------|
+| `elevenlabs-music` | High-quality instrumentals | In prompt (as description) | 60, 120, 180, 240s |
+| `minimax-music-v2` | Songs with sung lyrics | `lyrics_prompt` parameter | Auto-determined |
+| `ace-step-15` | Controlled song generation | `lyrics_prompt` parameter | 60-210s in 30s steps |
+
+## Example Request
+
+```bash
+# Queue a music generation
+curl -s -X POST "https://api.venice.ai/api/v1/audio/queue" \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "elevenlabs-music",
+    "prompt": "90s hip hop boom bap instrumental with heavy drums",
+    "duration_seconds": 120
+  }'
+# Returns: {"model":"elevenlabs-music","queue_id":"xxx","status":"QUEUED"}
+```
+
 -------

--- a/api-reference/endpoint/audio/retrieve.mdx
+++ b/api-reference/endpoint/audio/retrieve.mdx
@@ -7,4 +7,89 @@ openapi: 'POST /audio/retrieve'
 
 Use the `queue_id` returned by `/audio/queue` to check generation status. When the request completes, this endpoint returns the generated audio data.
 
+<Tip>
+When the audio is ready, the response will be **binary audio data** (MP3, FLAC, or WAV depending on the model), not JSON. The `Content-Type` header will indicate the audio format.
+</Tip>
+
+## For AI Agents
+
+<Warning title="Critical: Binary Data Handling">
+**Do NOT capture audio responses in shell variables or pipe through text processing tools.** This corrupts binary data and results in truncated audio files (e.g., 30KB instead of 2MB, 2 seconds instead of 120 seconds).
+
+### ❌ Wrong - Corrupts Binary Data
+
+```bash
+# Capturing in shell variable corrupts binary
+result=$(curl -s -X POST "$URL" -d "$DATA")
+echo "$result" > audio.mp3  # File will be corrupted!
+
+# Piping through jq also corrupts
+queue_id=$(curl ... | jq -r '.queue_id')  # OK for JSON
+# But later: curl ... | jq '.' > audio.mp3  # CORRUPTED!
+```
+
+### ✅ Correct - Save Binary Directly
+
+```bash
+# Use curl -o to save binary directly
+curl -s -o audio.mp3 -X POST "https://api.venice.ai/api/v1/audio/retrieve" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "elevenlabs-music", "queue_id": "..."}'
+
+# Or use Python's requests with binary write
+import requests
+resp = requests.post(url, headers=headers, json=data)
+if resp.headers.get("content-type", "").startswith("audio/"):
+    with open("audio.mp3", "wb") as f:
+        f.write(resp.content)  # Binary write!
+```
+
+**Symptom of corruption:** File size is tiny (30-50KB instead of 1-2MB), duration shows 2-10 seconds instead of requested 60-120 seconds.
+</Warning>
+
+## Polling Pattern
+
+```bash
+# Poll until binary data is returned
+for i in {1..30}; do
+  # Check response before saving
+  http_code=$(curl -s -w "%{http_code}" -o /tmp/check.json \
+    -X POST "https://api.venice.ai/api/v1/audio/retrieve" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"model": "elevenlabs-music", "queue_id": "XXX"}')
+  
+  # If starts with {, still processing (JSON response)
+  if head -c 1 /tmp/check.json | grep -q "{"; then
+    status=$(jq -r '.status' /tmp/check.json 2>/dev/null)
+    echo "Still processing... ($status)"
+    sleep 5
+    continue
+  fi
+  
+  # Binary data! Save properly now
+  curl -s -o audio.mp3 -X POST "https://api.venice.ai/api/v1/audio/retrieve" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"model": "elevenlabs-music", "queue_id": "XXX"}'
+  
+  echo "Audio saved to audio.mp3"
+  break
+done
+```
+
+## Response Format
+
+When still processing, returns JSON:
+```json
+{
+  "status": "PROCESSING",
+  "average_execution_time": 25000,
+  "execution_duration": 15000
+}
+```
+
+When complete, returns binary audio data with `Content-Type: audio/mpeg` (or `audio/flac`, `audio/wav` depending on model).
+
 -------


### PR DESCRIPTION
## Summary

AI agents frequently make the mistake of capturing binary audio responses in shell variables, which corrupts the data and results in truncated files (30KB instead of 2MB, 2 seconds instead of 120 seconds).

## Changes

- **retrieve.mdx**: Added critical warning about binary data handling with correct patterns using `curl -o` and Python binary write
- **queue.mdx**: Added agent tip linking to retrieve docs and music models quick reference table

## The Problem

When AI agents use this pattern:
```bash
result=$(curl -s -X POST "$URL" -d "$DATA")
echo "$result" > audio.mp3
```

The binary audio data gets corrupted by shell variable handling, resulting in truncated files.

## The Solution

Use `curl -o` to save binary directly:
```bash
curl -s -o audio.mp3 -X POST "https://api.venice.ai/api/v1/audio/retrieve" \
  -H "Authorization: Bearer $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model": "elevenlabs-music", "queue_id": "..."}'
```

## Testing

This guidance was developed through actual debugging of audio generation workflows where files were consistently truncated to 2-10 seconds instead of 60-120 seconds due to binary corruption.

---

This documentation improvement will help other AI agents and developers using the Venice audio API.