### PR TITLE
Audio API Postman tests

### DIFF
--- a/venice-audio-music-and-sfx.postman_collection.json
+++ b/venice-audio-music-and-sfx.postman_collection.json
@@ -1,0 +1,554 @@
+{
+  "info": {
+    "_postman_id": "8d52c3d0-9178-4ba0-9ad7-18d4b0c6144e",
+    "name": "Venice API - Audio Music and SFX Tests",
+    "description": "Importable Postman collection containing a folder named `api/v1/audio - Music and SFX`. The requests and tests are based on `swagger.yaml` audio generation endpoints for the async music and sound-effects flow: `/audio/quote`, `/audio/queue`, `/audio/retrieve`, and `/audio/complete`.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{veniceApiKey}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://api.venice.ai/api/v1",
+      "type": "string"
+    },
+    {
+      "key": "veniceApiKey",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "audioModel",
+      "value": "elevenlabs-music",
+      "type": "string"
+    },
+    {
+      "key": "audioQueuedModel",
+      "value": "elevenlabs-music",
+      "type": "string"
+    },
+    {
+      "key": "audioPrompt",
+      "value": "A cinematic electronic pulse with punchy drums, rising synth tension, and a dramatic finish.",
+      "type": "string"
+    },
+    {
+      "key": "audioDurationSeconds",
+      "value": "30",
+      "type": "string"
+    },
+    {
+      "key": "audioQueueId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "missingAudioQueueId",
+      "value": "00000000-0000-0000-0000-000000000000",
+      "type": "string"
+    },
+    {
+      "key": "lastAudioQuoteUsd",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "audioQueueStatus",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "audioRetrieveStatus",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "audioRetrievedMediaType",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "audioCleanupSuccess",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "api/v1/audio - Music and SFX",
+      "description": "Async music and sound-effects workflow based on the OpenAPI spec. Run `Quote` first, then `Queue`, then `Retrieve` until the response switches from JSON `PROCESSING` to binary audio, and finally `Complete` if you did not delete media automatically during retrieval.",
+      "item": [
+        {
+          "name": "Quote Audio Generation - Success",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{audioModel}}\",\n  \"duration_seconds\": {{audioDurationSeconds}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/audio/quote",
+            "description": "OpenAPI contract: POST /audio/quote returns HTTP 200 JSON with a numeric `quote` field."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Content-Type is application/json', function () {",
+                  "  pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "",
+                  "pm.test('Response has non-negative numeric quote', function () {",
+                  "  pm.expect(json).to.have.property('quote');",
+                  "  pm.expect(json.quote).to.be.a('number');",
+                  "  pm.expect(json.quote).to.be.at.least(0);",
+                  "});",
+                  "",
+                  "pm.collectionVariables.set('lastAudioQuoteUsd', String(json.quote));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Quote Audio Generation - Missing Model",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/audio/quote",
+            "description": "Negative contract test from the schema: `model` is required, so the spec documents a 400 validation response."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 400', function () {",
+                  "  pm.response.to.have.status(400);",
+                  "});",
+                  "",
+                  "pm.test('Content-Type is application/json', function () {",
+                  "  pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "",
+                  "pm.test('Validation error has error message', function () {",
+                  "  pm.expect(json).to.have.property('error');",
+                  "  pm.expect(json.error).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Queue Audio Generation - Success",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{audioModel}}\",\n  \"prompt\": \"{{audioPrompt}}\",\n  \"duration_seconds\": {{audioDurationSeconds}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/audio/queue",
+            "description": "OpenAPI contract: POST /audio/queue returns HTTP 200 JSON with `model`, `queue_id`, and `status: QUEUED`."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Content-Type is application/json', function () {",
+                  "  pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;",
+                  "",
+                  "pm.test('Response includes required queue fields', function () {",
+                  "  pm.expect(json).to.have.property('model');",
+                  "  pm.expect(json).to.have.property('queue_id');",
+                  "  pm.expect(json).to.have.property('status');",
+                  "});",
+                  "",
+                  "pm.test('Status is QUEUED', function () {",
+                  "  pm.expect(json.status).to.eql('QUEUED');",
+                  "});",
+                  "",
+                  "pm.test('queue_id is UUID-like', function () {",
+                  "  pm.expect(json.queue_id).to.match(uuidPattern);",
+                  "});",
+                  "",
+                  "pm.collectionVariables.set('audioQueueId', json.queue_id);",
+                  "pm.collectionVariables.set('audioQueuedModel', json.model);",
+                  "pm.collectionVariables.set('audioQueueStatus', json.status);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Queue Audio Generation - Missing Prompt",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{audioModel}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/audio/queue",
+            "description": "Negative contract test from the schema: `prompt` is required, so the spec documents a 400 validation response."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 400', function () {",
+                  "  pm.response.to.have.status(400);",
+                  "});",
+                  "",
+                  "pm.test('Content-Type is application/json', function () {",
+                  "  pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "",
+                  "pm.test('Validation error has error message', function () {",
+                  "  pm.expect(json).to.have.property('error');",
+                  "  pm.expect(json.error).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Retrieve Audio Generation - Success",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json, audio/mpeg, audio/wav, audio/flac",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{audioQueuedModel}}\",\n  \"queue_id\": \"{{audioQueueId}}\",\n  \"delete_media_on_completion\": false\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/audio/retrieve",
+            "description": "OpenAPI contract: POST /audio/retrieve returns either JSON `PROCESSING` metadata or binary audio (`audio/mpeg`, `audio/wav`, or `audio/flac`) once the job is complete."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const contentType = (pm.response.headers.get('Content-Type') || '').toLowerCase();",
+                  "const supportedAudioTypes = ['audio/mpeg', 'audio/wav', 'audio/flac'];",
+                  "",
+                  "if (contentType.includes('application/json')) {",
+                  "  const json = pm.response.json();",
+                  "",
+                  "  pm.test('Processing payload matches schema', function () {",
+                  "    pm.expect(json).to.have.property('status', 'PROCESSING');",
+                  "    pm.expect(json).to.have.property('average_execution_time');",
+                  "    pm.expect(json).to.have.property('execution_duration');",
+                  "    pm.expect(json.average_execution_time).to.be.a('number');",
+                  "    pm.expect(json.execution_duration).to.be.a('number');",
+                  "  });",
+                  "",
+                  "  pm.collectionVariables.set('audioRetrieveStatus', json.status);",
+                  "  pm.collectionVariables.set('audioRetrievedMediaType', '');",
+                  "} else {",
+                  "  pm.test('Binary response uses a supported audio content type', function () {",
+                  "    pm.expect(supportedAudioTypes.some(function (type) { return contentType.includes(type); })).to.eql(true);",
+                  "  });",
+                  "",
+                  "  pm.test('Binary audio response is not empty', function () {",
+                  "    pm.expect(pm.response.text().length).to.be.greaterThan(0);",
+                  "  });",
+                  "",
+                  "  pm.collectionVariables.set('audioRetrieveStatus', 'COMPLETED');",
+                  "  pm.collectionVariables.set('audioRetrievedMediaType', contentType);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Retrieve Audio Generation - Not Found",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{audioModel}}\",\n  \"queue_id\": \"{{missingAudioQueueId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/audio/retrieve",
+            "description": "Negative contract test from the schema: a missing or expired `queue_id` should return HTTP 404 with a standard error payload."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 404', function () {",
+                  "  pm.response.to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('Content-Type is application/json', function () {",
+                  "  pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "",
+                  "pm.test('Not-found payload has error message', function () {",
+                  "  pm.expect(json).to.have.property('error');",
+                  "  pm.expect(json.error).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Complete Audio Generation - Success",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{audioQueuedModel}}\",\n  \"queue_id\": \"{{audioQueueId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/audio/complete",
+            "description": "OpenAPI contract: POST /audio/complete returns HTTP 200 JSON with a boolean `success`. The spec explicitly allows `success: false` so cleanup can be retried later."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Content-Type is application/json', function () {",
+                  "  pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "",
+                  "pm.test('Cleanup response has boolean success field', function () {",
+                  "  pm.expect(json).to.have.property('success');",
+                  "  pm.expect(json.success).to.be.a('boolean');",
+                  "});",
+                  "",
+                  "pm.collectionVariables.set('audioCleanupSuccess', String(json.success));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Complete Audio Generation - Missing Queue ID",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{audioModel}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/audio/complete",
+            "description": "Negative contract test from the schema: `queue_id` is required, so the spec documents a 400 validation response."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 400', function () {",
+                  "  pm.response.to.have.status(400);",
+                  "});",
+                  "",
+                  "pm.test('Content-Type is application/json', function () {",
+                  "  pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "",
+                  "pm.test('Validation error has error message', function () {",
+                  "  pm.expect(json).to.have.property('error');",
+                  "  pm.expect(json.error).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add Postman tests for the `api/v1/audio - Music and SFX` endpoints to cover async music/SFX workflows with happy-path and negative scenarios.

---
<p><a href="https://cursor.com/agents/bc-bab1276b-69ce-4d69-8ee6-7fb807023de1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bab1276b-69ce-4d69-8ee6-7fb807023de1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->