### PR TITLE
Music model pricing display

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -1638,6 +1638,17 @@
           if (upscalePricing['2x']?.usd) prices.push(`${formatPrice(upscalePricing['2x'].usd)} 2x`);
           if (upscalePricing['4x']?.usd) prices.push(`${formatPrice(upscalePricing['4x'].usd)} 4x`);
           priceStr = prices.join(' · ');
+        } else if (model.type === 'music' && pricing.durations) {
+          const durationKeys = Object.keys(pricing.durations).sort((a, b) => Number(a) - Number(b));
+          if (durationKeys.length > 0) {
+            const minDur = durationKeys[0];
+            const minPrice = pricing.durations[minDur]?.usd;
+            priceStr = `from ${formatPrice(minPrice)}/${minDur}s`;
+          }
+        } else if (model.type === 'music' && pricing.per_second) {
+          priceStr = `${formatPrice(pricing.per_second.usd)}/sec`;
+        } else if (model.type === 'music' && pricing.generation) {
+          priceStr = `${formatPrice(pricing.generation.usd)}/audio`;
         } else if (pricing.generation) {
           priceStr = `${formatPrice(pricing.generation.usd)}/image`;
         } else if (pricing.perCharacter) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes incorrect and missing pricing units for music and sound effect models in the API docs.

Previously, music models either displayed no price (for duration-based or per-second pricing) or showed an incorrect unit like "$/image" (for per-generation pricing). This PR adds specific handlers to correctly display pricing as "$/60s", "$/sec", or "$/audio" as appropriate for each music model type.

---
[Slack Thread](https://veniceai.slack.com/archives/C0A9S3GQ2KV/p1773019412079409?thread_ts=1773019412.079409&cid=C0A9S3GQ2KV)

<p><a href="https://cursor.com/agents/bc-6a6584d0-6301-5851-8917-852b98aa9e75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a6584d0-6301-5851-8917-852b98aa9e75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->