### PR TITLE
docs: add video transcriptions API reference page

### DIFF
--- a/api-reference/endpoint/video/transcriptions.mdx
+++ b/api-reference/endpoint/video/transcriptions.mdx
@@ -1,0 +1,11 @@
+---
+title: 'Video Transcriptions API (Beta)'
+openapi: 'POST /video/transcriptions'
+"og:title": "Video Transcriptions | Venice API Docs"
+"og:description": "Documentation covering Venice's video transcription API for extracting text from video audio."
+---
+
+Send a publicly accessible video URL in `url`. Optionally set `response_format` to `json` (default) or `text` depending on whether you want structured output or plain transcript text.
+
+-------
+

--- a/docs.json
+++ b/docs.json
@@ -110,6 +110,7 @@
                 "group": "Video",
                 "pages": [
                   "api-reference/endpoint/video/queue",
+                  "api-reference/endpoint/video/transcriptions",
                   "api-reference/endpoint/video/retrieve",
                   "api-reference/endpoint/video/quote",
                   "api-reference/endpoint/video/complete"


### PR DESCRIPTION
Document the POST /video/transcriptions endpoint and add it to API navigation so users can discover request fields and response formats.

Made-with: Cursor