### PR TITLE
Add X Search to dynamic pricing tables

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -777,7 +777,18 @@
           </div>
         </div>
         <div class="vpt-row-bottom">
-          <span class="vpt-price-item"><span class="vpt-price-label">Per 1K Calls</span><span class="vpt-price-value">$10.00</span></span>
+          <span class="vpt-price-item"><span class="vpt-price-label">Per 1K URLs</span><span class="vpt-price-value">$10.00</span></span>
+        </div>
+      </div>
+      <div class="vpt-row">
+        <div class="vpt-row-top">
+          <div class="vpt-row-left">
+            <span class="vpt-model-name">X Search (xAI)</span>
+            <code class="vpt-model-id">enable_x_search: true</code>${pricingCopyBtn('enable_x_search: true')}
+          </div>
+        </div>
+        <div class="vpt-row-bottom">
+          <span class="vpt-price-item"><span class="vpt-price-label">Per 1K Results</span><span class="vpt-price-value">$10.00</span></span>
         </div>
       </div>
     </div>`;

--- a/scripts/generate-pricing-static.js
+++ b/scripts/generate-pricing-static.js
@@ -320,8 +320,8 @@ function renderPricingVideoTable(models) {
 
 // Render Web Search Table
 function renderPricingWebSearchTable() {
-  const header = `| Feature | Config | Per 1K Calls |\n|---|---|---|`;
-  const rows = `| Web Search | \`enable_web_search: true\` | $10.00 |\n| Web Scraping | \`enable_web_scraping: true\` | $10.00 |`;
+  const header = `| Feature | Config | Pricing |\n|---|---|---|`;
+  const rows = `| Web Search | \`enable_web_search: true\` | $10.00 per 1K requests |\n| Web Scraping | \`enable_web_scraping: true\` | $10.00 per 1K URLs |\n| X Search (xAI) | \`enable_x_search: true\` | $10.00 per 1K results |`;
   return header + '\n' + rows + '\n';
 }
 
@@ -445,7 +445,11 @@ function generatePricingMdx() {
   sections.push('</div>');
   sections.push('');
   sections.push('<Info>');
-  sections.push('Web Scraping automatically detects up to 5 URLs per request, scrapes and converts content into structured markdown, and adds the extracted text into model context. Only successfully scraped URLs are billed. These charges apply in addition to standard model token pricing.');
+  sections.push('**Web Scraping** automatically detects up to 5 URLs per request, scrapes and converts content into structured markdown, and adds the extracted text into model context. Only successfully scraped URLs are billed.');
+  sections.push('');
+  sections.push("**X Search** enables xAI's native search for supported Grok models (e.g., `grok-4-20-beta`). This searches both the web and X/Twitter for real-time information. Billed per search result returned by the model (e.g., if the model returns 10 search results, you are charged for 10 results at $0.01 each = $0.10).");
+  sections.push('');
+  sections.push('These charges apply in addition to standard model token pricing.');
   sections.push('</Info>');
   sections.push('');
   sections.push('## Payment Options');


### PR DESCRIPTION
## Summary

The `pricing.mdx` file had the X Search row in the static markdown table, but the JavaScript that dynamically renders pricing on the docs site (`model-search.js`) was missing it. This caused the X Search row to not appear on the live docs even though the source MDX had it.

**Changes:**
- Added X Search (xAI) entry to `renderPricingWebSearchTable()` in `model-search.js`
- Added X Search to `renderPricingWebSearchTable()` in `scripts/generate-pricing-static.js`
- Updated Info block in static generator to include X Search explanation

## Test plan

- [ ] Verify X Search row appears in the rendered pricing table at docs.venice.ai/overview/pricing

Made with [Cursor](https://cursor.com)