### PR TITLE
Add TEE/E2EE models guide to docs navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -37,6 +37,7 @@
               "overview/guides/integrations",
               "overview/guides/structured-responses",
               "overview/guides/reasoning-models",
+              "overview/guides/tee-e2ee-models",
               "overview/guides/prompt-caching",
               "overview/guides/claude-code",
               "overview/guides/cursor",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `overview/guides/tee-e2ee-models` to the docs.json navigation under the Guides section.

## Context

The E2EE documentation was previously merged in PR #176, but the guide was not added to `docs.json`, which meant it wasn't appearing in the docs navigation or search. This PR fixes that by adding the entry to the Guides group in the Overview tab.

## Changes

- Added `overview/guides/tee-e2ee-models` to the navigation in `docs.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://veniceai.slack.com/archives/C08KMNC77N1/p1773851806388559?thread_ts=1773851806.388559&cid=C08KMNC77N1)

<div><a href="https://cursor.com/agents/bc-5246cc18-183a-5231-95f2-526a6de82281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5246cc18-183a-5231-95f2-526a6de82281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

