### PR TITLE
Remove duplicate 'TEE & E2EE Models' entry from sidebar navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -48,8 +48,7 @@
               "overview/guides/langchain",
               "overview/guides/vercel-ai-sdk",
               "overview/guides/crewai",
-              "overview/guides/reference-to-video",
-              "overview/guides/tee-e2ee-models"
+              "overview/guides/reference-to-video"
             ]
           }
         ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The "TEE & E2EE Models" page (`overview/guides/tee-e2ee-models`) appeared twice in the Overview sidebar navigation — once in its correct position (after "Reasoning Models", before "Prompt Caching") and again at the very end of the Guides list (after "Reference to Video").

## Fix

Removed the duplicate entry at the end of the Guides `pages` array in `docs.json`, keeping the correctly positioned one.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f60aaaa-9f1c-425e-968c-8e8f2e4a9c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f60aaaa-9f1c-425e-968c-8e8f2e4a9c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

