### PR TITLE
Regroup and reorganize the Guides section

### DIFF
--- a/api-reference/api-spec.mdx
+++ b/api-reference/api-spec.mdx
@@ -274,9 +274,12 @@ While Venice maintains high compatibility with the OpenAI API specification, the
 
 Venice maintains backward compatibility for v1 endpoints and parameters. For model lifecycle policy, deprecation notices, and migration guidance, see [Deprecations](/overview/deprecations).
 
-## OpenAPI specification
+## OpenAPI Specification & Raw Data
 
-For programmatically viewing our API reference, check out our [OpenAPI specification.](https://api.venice.ai/doc/api/swagger.yaml)
+For programmatic access to Venice API docs and data — including use with RAG (Retrieval-Augmented Generation) — the following resources are available:
+
+* [OpenAPI Spec (YAML)](https://api.venice.ai/doc/api/swagger.yaml) — the full API specification in YAML format
+* [API Docs Source](https://github.com/veniceai/api-docs/archive/refs/heads/main.zip) — all documentation pages (`.mdx` format) as a downloadable archive
 
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -28,32 +28,57 @@
             ]
           },
           {
-            "group": "Guides",
+            "group": "Getting Started",
             "pages": [
               "overview/guides/generating-api-key",
               "overview/guides/generating-api-key-agent",
-              "overview/guides/ai-agents",
-              "overview/guides/postman",
-              "overview/guides/integrations",
+              "overview/guides/openai-migration",
+              "overview/guides/postman"
+            ]
+          },
+          {
+            "group": "Text & Chat",
+            "pages": [
               "overview/guides/structured-responses",
               "overview/guides/reasoning-models",
+              "overview/guides/prompt-caching",
+              "overview/guides/tee-e2ee-models"
+            ]
+          },
+          {
+            "group": "Image & Video",
+            "pages": [
               "overview/guides/image-generation",
               "overview/guides/image-editing",
               "overview/guides/video-generation",
-              "overview/guides/tee-e2ee-models",
-              "overview/guides/prompt-caching",
+              "overview/guides/reference-to-video",
+              "overview/guides/video-upscaling"
+            ]
+          },
+          {
+            "group": "Coding Tools",
+            "pages": [
               "overview/guides/claude-code",
               "overview/guides/cursor",
-              "overview/guides/codex-cli",
+              "overview/guides/codex-cli"
+            ]
+          },
+          {
+            "group": "SDKs & Frameworks",
+            "pages": [
+              "overview/guides/langchain",
+              "overview/guides/vercel-ai-sdk",
+              "overview/guides/crewai"
+            ]
+          },
+          {
+            "group": "Agents & Integrations",
+            "pages": [
+              "overview/guides/ai-agents",
               "overview/guides/openclaw-bot",
               "overview/guides/nanoclaw-venice",
               "overview/guides/x402-venice-api",
-              "overview/guides/openai-migration",
-              "overview/guides/langchain",
-              "overview/guides/vercel-ai-sdk",
-              "overview/guides/crewai",
-              "overview/guides/reference-to-video",
-              "overview/guides/video-upscaling"
+              "overview/guides/integrations"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -28,6 +28,16 @@
             ]
           },
           {
+            "group": "Agents & Integrations",
+            "pages": [
+              "overview/guides/ai-agents",
+              "overview/guides/openclaw-bot",
+              "overview/guides/nanoclaw-venice",
+              "overview/guides/x402-venice-api",
+              "overview/guides/integrations"
+            ]
+          },
+          {
             "group": "Getting Started",
             "pages": [
               "overview/guides/generating-api-key",
@@ -69,16 +79,6 @@
               "overview/guides/langchain",
               "overview/guides/vercel-ai-sdk",
               "overview/guides/crewai"
-            ]
-          },
-          {
-            "group": "Agents & Integrations",
-            "pages": [
-              "overview/guides/ai-agents",
-              "overview/guides/openclaw-bot",
-              "overview/guides/nanoclaw-venice",
-              "overview/guides/x402-venice-api",
-              "overview/guides/integrations"
             ]
           }
         ]

--- a/overview/guides/integrations.mdx
+++ b/overview/guides/integrations.mdx
@@ -1,45 +1,35 @@
 ---
 title: "Integrations"
-description: "Here is a list of third party tools with Venice.ai integrations."
+description: "Third-party tools and community projects with Venice AI integrations."
 "og:title": "Integrations | Venice API Docs"
-"og:description": "Here is a list of third party tools with Venice.ai integrations."
+"og:description": "Third-party tools and community projects with Venice AI integrations."
 ---
 
 [How to use Venice API](https://venice.ai/blog/how-to-use-venice-api) reference guide.
 
+<Note>
+Several integrations have their own dedicated guides — see [AI Agents](/overview/guides/ai-agents), [OpenClaw](/overview/guides/openclaw-bot), [NanoClaw](/overview/guides/nanoclaw-venice), [Cursor](/overview/guides/cursor), [Claude Code](/overview/guides/claude-code), and [Codex CLI](/overview/guides/codex-cli).
+</Note>
+
 ## Venice Confirmed Integrations
-
-* Agents
-
-  * [ElizaOS](https://venice.ai/blog/how-to-build-a-social-media-ai-agent-with-elizaos-venice-api) (local build)
-
-  * [ElizaOS](https://venice.ai/blog/how-to-launch-an-elizaos-agent-on-akash-using-venice-api-in-less-than-10-minutes) (via [Akash Template](https://console.akash.network/templates/akash-network-awesome-akash-Venice-ElizaOS))
-
-  * [Molt Bot](https://docs.molt.bot/providers/venice) Discord bot with Venice API integration.
 
 * Coding
 
-  * [Cursor IDE](https://venice.ai/blog/how-to-code-with-the-venice-api-in-cursor-a-quick-guide)
-
   * [Cline](https://venice.ai/blog/how-to-use-the-venice-api-with-cline-in-vscode-a-developers-guide) (VSC Extension)
 
-  * [ROO Code ](https://venice.ai/blog/how-to-use-the-roo-ai-coding-assistant-in-private-with-venice-api-a-quick-guide)(VSC Extension)
+  * [ROO Code](https://venice.ai/blog/how-to-use-the-roo-ai-coding-assistant-in-private-with-venice-api-a-quick-guide) (VSC Extension)
 
-  * [VOID IDE](https://venice.ai/blog/how-to-use-open-source-ai-code-editor-void-in-private-with-venice-api)&#x20;
+  * [VOID IDE](https://venice.ai/blog/how-to-use-open-source-ai-code-editor-void-in-private-with-venice-api)
 
 * Assistants
 
-  * [Brave Leo Browser ](https://venice.ai/blog/how-to-use-brave-leo-ai-with-venice-api-a-privacy-first-browser-ai-assistant)
+  * [Brave Leo Browser](https://venice.ai/blog/how-to-use-brave-leo-ai-with-venice-api-a-privacy-first-browser-ai-assistant)
 
-## Community Confirmed&#x20;
+## Community Confirmed
 
 These integrations have been confirmed by the community. Venice is in the process of confirming these integrations and creating how-to guides for each of the following:
 
 * Agents/Bots
-
-  * [Coinbase Agentkit](https://www.coinbase.com/developer-platform/discover/launches/introducing-agentkit)
-
-  * [Eliza\_Starter](https://github.com/Baidis/eliza-Venice) Simplified Eliza setup.
 
   * [Venice AI Discord Bot](https://bobbiebeach.space/blog/venice-ai-discord-bot-full-setup-guide-features/)
 
@@ -66,11 +56,3 @@ These integrations have been confirmed by the community. Venice is in the proces
   * [Librechat](https://www.librechat.ai/)
 
   * [ScreenSnapAI](https://screensnap.ai/)
-
-## Venice API Raw Data
-
-Many users have requested access to Venice API docs and data in a format acceptable for use with RAG (Retrieval-Augmented Generation) for various purposes. The full API specification is available within the "API Swagger" document below, in yaml format. The Venice API documents included throughout this API Reference webpage are available from the link below, with most documents in .mdx format.
-
-[API Swagger](https://api.venice.ai/doc/api/swagger.yaml)
-
-[API Docs](https://github.com/veniceai/api-docs/archive/refs/heads/main.zip)

--- a/overview/guides/integrations.mdx
+++ b/overview/guides/integrations.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Integrations"
+title: "Additional Integrations"
 description: "Third-party tools and community projects with Venice AI integrations."
-"og:title": "Integrations | Venice API Docs"
+"og:title": "Additional Integrations | Venice API Docs"
 "og:description": "Third-party tools and community projects with Venice AI integrations."
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorganizes the Guides section in the docs sidebar from a flat list of 24 items into six logical sub-groups, de-duplicates the Integrations page, and moves the raw API data links to a more appropriate location.

## Navigation reorganization

The single flat "Guides" group is replaced with six focused groups under the Overview tab:

| Group | Pages | What it covers |
|---|---|---|
| **Agents & Integrations** | 5 | AI agents overview, OpenClaw, NanoClaw, X402 protocol, integrations list |
| **Getting Started** | 4 | API key generation (manual + agent), OpenAI migration, Postman testing |
| **Text & Chat** | 4 | Structured responses, reasoning models, prompt caching, TEE & E2EE privacy |
| **Image & Video** | 5 | Image generation/editing, video generation, reference-to-video, video upscaling |
| **Coding Tools** | 3 | Claude Code, Cursor IDE, Codex CLI |
| **SDKs & Frameworks** | 3 | LangChain, Vercel AI SDK, CrewAI |

## Integrations page de-duplication

Removed entries from `integrations.mdx` that already have their own dedicated guide pages:
- ElizaOS (local build + Akash) — covered by `ai-agents.mdx`
- Molt Bot/OpenClaw — has `openclaw-bot.mdx`
- Cursor IDE — has `cursor.mdx`
- Coinbase Agentkit — referenced in `ai-agents.mdx`
- Eliza_Starter — variant of Eliza, covered by `ai-agents.mdx`

Added a cross-reference `<Note>` at the top linking readers to the dedicated guides.

## Raw API data relocation

Moved the "Venice API Raw Data" section (Swagger YAML + docs archive download links) from the bottom of `integrations.mdx` to `api-reference/api-spec.mdx`, where the OpenAPI specification section already lives. This is a much more natural home for programmatic API access resources.

## Details

- No guide pages were added, removed, or renamed — all 24 original pages remain
- Existing redirects remain valid since no file paths changed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cb43d33-e32a-460e-8fe8-100f813effc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cb43d33-e32a-460e-8fe8-100f813effc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

