### PR TITLE
Remove redundant "with Venice" from guide page titles

### DIFF
--- a/overview/guides/claude-code.mdx
+++ b/overview/guides/claude-code.mdx
@@ -1,5 +1,5 @@
 ---
-title: Claude Code with Venice
+title: Claude Code
 description: Use Claude Code CLI with Venice AI's Claude models
 "og:title": "Claude Code with Venice | Venice API Docs"
 "og:description": "Set up Claude Code to use Claude Opus 4.5/4.6 and Sonnet 4.5/4.6 through Venice AI"

--- a/overview/guides/codex-cli.mdx
+++ b/overview/guides/codex-cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: Codex CLI with Venice
+title: Codex CLI
 description: Use OpenAI Codex CLI with Venice AI models through a local config.toml file
 "og:title": "Codex CLI with Venice | Venice API Docs"
 "og:description": "Configure Codex CLI to send requests to Venice AI using a simple model provider config"

--- a/overview/guides/cursor.mdx
+++ b/overview/guides/cursor.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cursor IDE with Venice
+title: Cursor IDE
 description: Use Venice AI models in Cursor IDE with the venice- model prefix
 "og:title": "Cursor IDE with Venice | Venice API Docs"
 "og:description": "Set up Cursor IDE to use Venice AI models including Claude, GPT, DeepSeek, and more"

--- a/overview/guides/nanoclaw-venice.mdx
+++ b/overview/guides/nanoclaw-venice.mdx
@@ -1,5 +1,5 @@
 ---
-title: NanoClaw with Venice
+title: NanoClaw
 description: Run a personal AI assistant on WhatsApp and Telegram powered by Venice AI
 "og:title": "NanoClaw with Venice | Venice API Docs"
 "og:description": "Set up NanoClaw, a lightweight AI assistant for WhatsApp and Telegram, using Venice AI for private, uncensored inference."

--- a/overview/guides/openclaw-bot.mdx
+++ b/overview/guides/openclaw-bot.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenClaw with Venice
+title: OpenClaw
 description: Use Venice AI as your model provider in OpenClaw
 "og:title": "OpenClaw with Venice | Venice API Docs"
 "og:description": "Set up Venice AI as a provider in OpenClaw for privacy-focused, uncensored AI across WhatsApp, Telegram, Discord, and more."

--- a/overview/guides/x402-venice-api.mdx
+++ b/overview/guides/x402-venice-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: X402 with Venice
+title: X402
 description: A guide on how to use the X402 protocol with Venice, covering both human and agent use cases.
 "og:title": "X402 with Venice for Agents | Venice API Docs"
 "og:description": "Learn what you and your agents can do with X402 on Venice."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the "with Venice" suffix from six guide page titles. Since these pages already live inside Venice's docs site, the suffix is redundant and adds clutter to the left nav.

## Changes

| Before | After |
|---|---|
| Claude Code with Venice | Claude Code |
| Cursor IDE with Venice | Cursor IDE |
| Codex CLI with Venice | Codex CLI |
| OpenClaw with Venice | OpenClaw |
| NanoClaw with Venice | NanoClaw |
| X402 with Venice | X402 |

Only the `title` frontmatter field is changed in each file — no other content is modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cb43d33-e32a-460e-8fe8-100f813effc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cb43d33-e32a-460e-8fe8-100f813effc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

