### PR TITLE
docs: add text-parser API endpoint documentation

### DIFF
--- a/api-reference/endpoint/augment/text-parser.mdx
+++ b/api-reference/endpoint/augment/text-parser.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Text Parser'
-openapi: 'POST /text-parser'
+openapi: 'POST /augment/text-parser'
 "og:title": "Text Parser | Venice API Docs"
 "og:description": "Documentation covering Venice's text parser API for extracting text from PDF, DOCX, XLSX, and plain text files."
 ---
@@ -14,7 +14,7 @@ Set `response_format` to `json` (default) for structured output with extracted t
 ### Example (cURL)
 
 ```bash
-curl -X POST https://api.venice.ai/api/v1/text-parser \
+curl -X POST https://api.venice.ai/api/v1/augment/text-parser \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -F "file=@document.pdf" \
   -F "response_format=json"

--- a/api-reference/endpoint/text-parser/parse.mdx
+++ b/api-reference/endpoint/text-parser/parse.mdx
@@ -1,0 +1,24 @@
+---
+title: 'Text Parser'
+openapi: 'POST /text-parser'
+"og:title": "Text Parser | Venice API Docs"
+"og:description": "Documentation covering Venice's text parser API for extracting text from PDF, DOCX, XLSX, and plain text files."
+---
+
+Upload a document file via multipart/form-data using the `file` field. Supported formats include **PDF**, **DOCX**, **XLSX**, and **plain text** files (up to 25MB).
+
+Set `response_format` to `json` (default) for structured output with extracted text and token count, or `text` for the raw extracted text.
+
+**Pricing:** $0.01 per request.
+
+### Example (cURL)
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/text-parser \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -F "file=@document.pdf" \
+  -F "response_format=json"
+```
+
+-------
+

--- a/docs.json
+++ b/docs.json
@@ -150,9 +150,9 @@
                 ]
               },
               {
-                "group": "Text Parser",
+                "group": "Augment",
                 "pages": [
-                  "api-reference/endpoint/text-parser/parse"
+                  "api-reference/endpoint/augment/text-parser"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -150,6 +150,12 @@
                 ]
               },
               {
+                "group": "Text Parser",
+                "pages": [
+                  "api-reference/endpoint/text-parser/parse"
+                ]
+              },
+              {
                 "group": "Embeddings",
                 "pages": [
                   "api-reference/endpoint/embeddings/generate"

--- a/llms.txt
+++ b/llms.txt
@@ -43,8 +43,8 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Video Generation (Complete)](https://docs.venice.ai/api-reference/endpoint/video/complete): Queue and wait for video generation in one call
 - [Video Transcription](https://docs.venice.ai/api-reference/endpoint/video/transcriptions): Extract text/speech from videos
 
-### Text Parser
-- [Text Parser](https://docs.venice.ai/api-reference/endpoint/text-parser/parse): Extract text from PDF, DOCX, XLSX, and plain text files ($0.01/request)
+### Augment
+- [Text Parser](https://docs.venice.ai/api-reference/endpoint/augment/text-parser): Extract text from PDF, DOCX, XLSX, and plain text files ($0.01/request)
 
 ### Embeddings
 - [Embeddings](https://docs.venice.ai/api-reference/endpoint/embeddings/generate): Generate vector embeddings for semantic search

--- a/llms.txt
+++ b/llms.txt
@@ -43,6 +43,9 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Video Generation (Complete)](https://docs.venice.ai/api-reference/endpoint/video/complete): Queue and wait for video generation in one call
 - [Video Transcription](https://docs.venice.ai/api-reference/endpoint/video/transcriptions): Extract text/speech from videos
 
+### Text Parser
+- [Text Parser](https://docs.venice.ai/api-reference/endpoint/text-parser/parse): Extract text from PDF, DOCX, XLSX, and plain text files ($0.01/request)
+
 ### Embeddings
 - [Embeddings](https://docs.venice.ai/api-reference/endpoint/embeddings/generate): Generate vector embeddings for semantic search
 


### PR DESCRIPTION
## Summary

Adds documentation for the new `POST /text-parser` API endpoint.

- New endpoint page at `api-reference/endpoint/text-parser/parse.mdx` with usage examples and pricing info
- Navigation entry added to `docs.json` under a "Text Parser" group between Video and Embeddings

**Companion PR:** veniceai/outerface#5265 (adds the endpoint + OpenAPI swagger spec)

## Test plan

- [ ] Verify the page renders correctly on Mintlify preview
- [ ] Verify navigation shows "Text Parser" group in API Reference tab
- [ ] Verify the OpenAPI playground works once the outerface swagger.yaml is updated

Made with [Cursor](https://cursor.com)