### PR TITLE
docs: add web search API endpoint

### DIFF
--- a/api-reference/endpoint/augment/search.mdx
+++ b/api-reference/endpoint/augment/search.mdx
@@ -1,0 +1,25 @@
+---
+title: 'Web Search'
+openapi: 'POST /augment/search'
+"og:title": "Web Search | Venice API Docs"
+"og:description": "Documentation covering Venice's web search API for retrieving structured search results with privacy-preserving providers."
+---
+
+Send a search query in the `query` field. The API returns structured results including titles, URLs, content snippets, and dates.
+
+**Search providers:**
+- `brave` (default) — Brave Search with Zero Data Retention (ZDR). Search queries are never stored or logged by the search provider.
+- `google` — Google Search with anonymized queries. Searches are proxied and stripped of identifying information before being sent to Google.
+
+**Pricing:** $0.01 per request.
+
+### Example (cURL)
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/augment/search \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "latest news about AI"}'
+```
+
+-------

--- a/docs.json
+++ b/docs.json
@@ -153,7 +153,8 @@
                 "group": "Augment",
                 "pages": [
                   "api-reference/endpoint/augment/text-parser",
-                  "api-reference/endpoint/augment/scrape"
+                  "api-reference/endpoint/augment/scrape",
+                  "api-reference/endpoint/augment/search"
                 ]
               },
               {

--- a/llms.txt
+++ b/llms.txt
@@ -46,6 +46,7 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 ### Augment
 - [Text Parser](https://docs.venice.ai/api-reference/endpoint/augment/text-parser): Extract text from PDF, DOCX, XLSX, and plain text files ($0.01/request)
 - [Web Scrape](https://docs.venice.ai/api-reference/endpoint/augment/scrape): Scrape a web page and return its content as markdown ($0.01/request)
+- [Web Search](https://docs.venice.ai/api-reference/endpoint/augment/search): Search the web with privacy-preserving providers (Brave ZDR or anonymized Google) and return structured results ($0.01/request)
 
 ### Embeddings
 - [Embeddings](https://docs.venice.ai/api-reference/endpoint/embeddings/generate): Generate vector embeddings for semantic search

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5,7 +5,7 @@ info:
   description: The Venice.ai API.
   termsOfService: https://venice.ai/legal/tos
   title: Venice.ai API
-  version: "20260413.052051"
+  version: "20260413.053421"
   x-guidance: >-
     Venice.ai is an OpenAI-compatible inference API supporting text, image,
     audio, and video generation.
@@ -3916,6 +3916,35 @@ components:
           example: https://example.com
       required:
         - url
+    WebSearchRequest:
+      type: object
+      properties:
+        query:
+          type: string
+          minLength: 1
+          maxLength: 400
+          description: The search query
+          example: latest news about AI
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 20
+          default: 10
+          description: "Maximum number of results to return (default: 10, max: 20)"
+          example: 10
+        search_provider:
+          type: string
+          enum:
+            - google
+            - brave
+          description: Search provider to use. "brave" uses Brave Search with Zero Data
+            Retention (ZDR) for maximum privacy — search queries are never
+            stored or logged. "google" uses Google Search with anonymized
+            queries — searches are proxied and stripped of identifying
+            information before being sent to Google. Defaults to "brave".
+          example: brave
+      required:
+        - query
     ModelResponse:
       type: object
       properties:
@@ -4898,6 +4927,38 @@ components:
         - url
         - content
         - format
+    WebSearchResponse:
+      type: object
+      properties:
+        query:
+          type: string
+          description: The search query that was executed
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+                description: The title of the search result
+              url:
+                type: string
+                description: The URL of the search result
+              content:
+                type: string
+                description: A snippet or description of the search result
+              date:
+                type: string
+                description: The date of the search result, if available
+            required:
+              - title
+              - url
+              - content
+              - date
+          description: The search results
+      required:
+        - query
+        - results
   parameters: {}
 paths:
   /chat/completions:
@@ -11933,6 +11994,132 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebScrapeResponse"
+        "400":
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DetailedError"
+        "401":
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardError"
+        "402":
+          description: >-
+            Insufficient balance. Response varies by authentication method:
+
+
+            **API Key users:** Standard error response with
+            `INSUFFICIENT_BALANCE` code. Top up your Venice balance at
+            venice.ai.
+
+
+            **x402 wallet users:** Structured response with `PAYMENT_REQUIRED`
+            code containing:
+
+            - `topUpInstructions`: Step-by-step guide to top up via x402
+            protocol
+
+            - `siwxChallenge`: Sign-In-With-X challenge template for
+            authentication
+
+            - `supportedTokens` / `supportedChains`: Accepted payment methods
+
+
+            The `PAYMENT-REQUIRED` header also contains a base64-encoded JSON
+            object with the same payment requirements for protocol-level
+            discovery (x402 v2 spec).
+          headers:
+            PAYMENT-REQUIRED:
+              description: Base64-encoded JSON with x402 payment requirements and SIWX
+                challenge. Present only for x402 wallet authentication. Decode
+                to get payment instructions programmatically.
+              required: false
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/StandardError"
+                  - $ref: "#/components/schemas/X402InferencePaymentRequired"
+                discriminator:
+                  propertyName: code
+        "403":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardError"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardError"
+        "500":
+          description: An unknown error occurred
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardError"
+  /augment/search:
+    post:
+      description: >-
+        Search the web and return results directly. Returns structured search
+        results including titles, URLs, content snippets, and dates.
+
+
+        **Search providers:**
+
+        - `brave` (default) — Brave Search with Zero Data Retention (ZDR).
+        Search queries are never stored or logged by the search provider.
+
+        - `google` — Google Search with anonymized queries. Searches are proxied
+        and stripped of identifying information before being sent to Google.
+
+
+        **Authentication:** This endpoint accepts either a Bearer API key or an
+        `X-Sign-In-With-X` header for x402 wallet-based authentication. When
+        using x402, a `402 Payment Required` response indicates insufficient
+        balance and includes top-up instructions.
+      operationId: webSearch
+      security:
+        - BearerAuth: []
+        - siwx: []
+      x-payment-info:
+        price:
+          mode: dynamic
+          currency: USD
+          min: "0.001"
+          max: "10.00"
+        protocols:
+          - x402: {}
+      summary: /api/v1/augment/search
+      tags:
+        - Augment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebSearchRequest"
+      responses:
+        "200":
+          description: Successfully executed search
+          headers:
+            X-Balance-Remaining:
+              description: Remaining x402 credit balance in USD after this request (only
+                present for x402 auth).
+              required: false
+              schema:
+                type: string
+                example: "4.230000"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebSearchResponse"
         "400":
           description: Invalid request parameters
           content:


### PR DESCRIPTION
## Summary
- Add documentation page for the new `POST /augment/search` endpoint (`search.mdx`)
- Add nav entry in `docs.json` under the Augment group
- Add `llms.txt` entry for LLM discoverability
- Sync `swagger.yaml` from outerface to include both `/augment/scrape` and `/augment/search` schemas

Companion to veniceai/outerface PR for the web search API endpoint.

## Test plan
- [ ] Verify the search page renders correctly on docs.venice.ai preview
- [ ] Confirm the OpenAPI auto-generated request/response sections appear from the synced swagger
- [ ] Check nav shows Web Search under the Augment group

Made with [Cursor](https://cursor.com)