### PR TITLE
docs: add experimental API notice to augment endpoints

### DIFF
--- a/api-reference/endpoint/augment/scrape.mdx
+++ b/api-reference/endpoint/augment/scrape.mdx
@@ -5,6 +5,8 @@ openapi: 'POST /augment/scrape'
 "og:description": "Documentation covering Venice's web scraping API for extracting markdown content from web pages."
 ---
 
+<Warning>This is an experimental API. The request and response format may change without notice.</Warning>
+
 Send a publicly accessible URL in the `url` field. The API returns the page content as **markdown**.
 
 The scraper first tries the target site's native markdown support (via [Cloudflare Markdown for Agents](https://blog.cloudflare.com/markdown-for-agents/)), then falls back to a headless browser extraction. Some sites that block automated access (e.g. X/Twitter, Reddit) are rejected immediately with a `400` error.

--- a/api-reference/endpoint/augment/search.mdx
+++ b/api-reference/endpoint/augment/search.mdx
@@ -5,6 +5,8 @@ openapi: 'POST /augment/search'
 "og:description": "Documentation covering Venice's web search API for retrieving structured search results with privacy-preserving providers."
 ---
 
+<Warning>This is an experimental API. The request and response format may change without notice.</Warning>
+
 Send a search query in the `query` field. The API returns structured results including titles, URLs, content snippets, and dates.
 
 **Search providers:**

--- a/api-reference/endpoint/augment/text-parser.mdx
+++ b/api-reference/endpoint/augment/text-parser.mdx
@@ -5,6 +5,8 @@ openapi: 'POST /augment/text-parser'
 "og:description": "Documentation covering Venice's text parser API for extracting text from PDF, DOCX, XLSX, and plain text files."
 ---
 
+<Warning>This is an experimental API. The request and response format may change without notice.</Warning>
+
 Upload a document file via multipart/form-data using the `file` field. Supported formats include **PDF**, **DOCX**, **XLSX**, and **plain text** files (up to 25MB).
 
 Set `response_format` to `json` (default) for structured output with extracted text and token count, or `text` for the raw extracted text.


### PR DESCRIPTION
## Summary
- Add `<Warning>` callout to all three augment endpoint pages (search, scrape, text-parser) noting these are experimental APIs whose request/response format may change without notice

## Test plan
- [ ] Verify the warning renders as a yellow callout on each page

Made with [Cursor](https://cursor.com)