### PR TITLE
docs: add Claude Opus 4.6 Fast and fix model IDs

### DIFF
--- a/api-reference/endpoint/augment/scrape.mdx
+++ b/api-reference/endpoint/augment/scrape.mdx
@@ -5,6 +5,8 @@ openapi: 'POST /augment/scrape'
 "og:description": "Documentation covering Venice's web scraping API for extracting markdown content from web pages."
 ---
 
+<Warning>This is an experimental API. The request and response format may change without notice.</Warning>
+
 Send a publicly accessible URL in the `url` field. The API returns the page content as **markdown**.
 
 The scraper first tries the target site's native markdown support (via [Cloudflare Markdown for Agents](https://blog.cloudflare.com/markdown-for-agents/)), then falls back to a headless browser extraction. Some sites that block automated access (e.g. X/Twitter, Reddit) are rejected immediately with a `400` error.

--- a/api-reference/endpoint/augment/search.mdx
+++ b/api-reference/endpoint/augment/search.mdx
@@ -5,6 +5,8 @@ openapi: 'POST /augment/search'
 "og:description": "Documentation covering Venice's web search API for retrieving structured search results with privacy-preserving providers."
 ---
 
+<Warning>This is an experimental API. The request and response format may change without notice.</Warning>
+
 Send a search query in the `query` field. The API returns structured results including titles, URLs, content snippets, and dates.
 
 **Search providers:**

--- a/api-reference/endpoint/augment/text-parser.mdx
+++ b/api-reference/endpoint/augment/text-parser.mdx
@@ -5,6 +5,8 @@ openapi: 'POST /augment/text-parser'
 "og:description": "Documentation covering Venice's text parser API for extracting text from PDF, DOCX, XLSX, and plain text files."
 ---
 
+<Warning>This is an experimental API. The request and response format may change without notice.</Warning>
+
 Upload a document file via multipart/form-data using the `file` field. Supported formats include **PDF**, **DOCX**, **XLSX**, and **plain text** files (up to 25MB).
 
 Set `response_format` to `json` (default) for structured output with extracted text and token count, or `text` for the raw extracted text.

--- a/overview/guides/claude-code.mdx
+++ b/overview/guides/claude-code.mdx
@@ -28,7 +28,7 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
     Catches Claude Code's outgoing requests before they reach Anthropic
   </Step>
   <Step title="Transforms" icon="arrows-rotate">
-    Converts request format and maps model IDs (e.g., `claude-opus-45`)
+    Converts request format and maps model IDs (e.g., `claude-opus-4-5`)
   </Step>
   <Step title="Redirects" icon="route">
     Forwards requests to Venice at `api.venice.ai/api/v1/chat/completions`
@@ -106,9 +106,10 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
           "api_base_url": "https://api.venice.ai/api/v1/chat/completions",
           "api_key": "your-venice-api-key-here",
           "models": [
-            "claude-opus-45",
-            "claude-sonnet-45",
+            "claude-opus-4-5",
+            "claude-sonnet-4-5",
             "claude-opus-4-6",
+            "claude-opus-4-6-fast",
             "claude-sonnet-4-6"
           ],
           "transformer": {
@@ -117,10 +118,10 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
         }
       ],
       "Router": {
-        "default": "venice,claude-opus-45",
-        "think": "venice,claude-opus-45",
-        "background": "venice,claude-opus-45",
-        "longContext": "venice,claude-opus-45",
+        "default": "venice,claude-opus-4-5",
+        "think": "venice,claude-opus-4-5",
+        "background": "venice,claude-opus-4-5",
+        "longContext": "venice,claude-opus-4-5",
         "longContextThreshold": 100000
       }
     }
@@ -153,9 +154,10 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
 
 | Model | Venice ID | Best For |
 |-------|-----------|----------|
-| Claude Opus 4.5 | `claude-opus-45` | Complex reasoning, large refactors |
-| Claude Sonnet 4.5 | `claude-sonnet-45` | Fast iteration, everyday coding |
+| Claude Opus 4.5 | `claude-opus-4-5` | Complex reasoning, large refactors |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5` | Fast iteration, everyday coding |
 | Claude Opus 4.6 | `claude-opus-4-6` | Complex reasoning, large refactors |
+| Claude Opus 4.6 Fast | `claude-opus-4-6-fast` | Complex reasoning with lower latency |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | Fast iteration, everyday coding |
 
 <Info>
@@ -173,7 +175,7 @@ The router provides several useful features beyond basic routing:
     Use the `/model` command inside Claude Code to switch models without restarting:
     
     ```
-    /model venice,claude-sonnet-45
+    /model venice,claude-sonnet-4-5
     ```
     
     Useful when you want Opus for complex tasks and Sonnet for quick iterations.

--- a/overview/guides/cursor.mdx
+++ b/overview/guides/cursor.mdx
@@ -63,9 +63,10 @@ Cursor rewrites requests for `claude-*` models into Anthropic's native format, w
 | Model | Standard ID | Cursor ID |
 |-------|------------|-----------|
 | Claude Opus 4.6 | `claude-opus-4-6` | `venice-claude-opus-4-6` |
+| Claude Opus 4.6 Fast | `claude-opus-4-6-fast` | `venice-claude-opus-4-6-fast` |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | `venice-claude-sonnet-4-6` |
-| Claude Opus 4.5 | `claude-opus-45` | `venice-claude-opus-45` |
-| Claude Sonnet 4.5 | `claude-sonnet-45` | `venice-claude-sonnet-45` |
+| Claude Opus 4.5 | `claude-opus-4-5` | `venice-claude-opus-4-5` |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5` | `venice-claude-sonnet-4-5` |
 
 <Info>
 Non-Claude models (e.g. `minimax-m25`, `kimi-k2-5`, `zai-org-glm-5`) are **not affected** and work without the prefix. The `venice-` prefix is safe to use on any model since Venice always strips it, but it is only required for Claude models in Cursor.

--- a/overview/guides/prompt-caching.mdx
+++ b/overview/guides/prompt-caching.mdx
@@ -137,7 +137,7 @@ For conversations or agentic workflows, use a consistent `prompt_cache_key` to i
 
 ```json
 {
-  "model": "claude-opus-45",
+  "model": "claude-opus-4-5",
   "prompt_cache_key": "session-abc-123",
   "messages": [...]
 }
@@ -271,7 +271,7 @@ Function definitions can be cached along with system prompts:
 
 ```json
 {
-  "model": "claude-opus-45",
+  "model": "claude-opus-4-5",
   "tools": [
     {
       "type": "function",
@@ -306,7 +306,7 @@ For vision models, images can be included in cached content:
 
 ```json
 {
-  "model": "claude-opus-45",
+  "model": "claude-opus-4-5",
   "messages": [
     {
       "role": "user",

--- a/overview/guides/reasoning-models.mdx
+++ b/overview/guides/reasoning-models.mdx
@@ -135,7 +135,7 @@ When in doubt, use `low`, `medium`, or `high`. These are the most widely support
 
 | Model | Supported values |
 |-------|-----------------|
-| Claude Opus 4.6 | `low`, `medium`, `high`, `max` |
+| Claude Opus 4.6, Opus 4.6 Fast | `low`, `medium`, `high`, `max` |
 | Claude Opus 4.5, Sonnet 4.5, Sonnet 4.6 | `low`, `medium`, `high` |
 
 #### Google
@@ -212,7 +212,7 @@ For models that support it, `reasoning.enabled: false` is the more reliable opti
 | GPT-5.2 Codex, GPT-5.3 Codex | Yes (but `none` effort not supported) |
 | Qwen 3 235B A22B Thinking, Qwen 3.5 35B A3B | Yes |
 | GLM 4.7 series | Yes |
-| Claude Opus 4.5/4.6, Sonnet 4.5/4.6 | No (always reasons) |
+| Claude Opus 4.5/4.6/4.6 Fast, Sonnet 4.5/4.6 | No (always reasons) |
 | Gemini 3 Pro, 3.1 Pro, 3 Flash | No (always reasons) |
 | DeepSeek R1 | No (always reasons) |
 

--- a/overview/pricing.mdx
+++ b/overview/pricing.mdx
@@ -16,6 +16,7 @@ Prices per 1M tokens unless noted. All prices in USD. 1 Diem = $1/day of compute
 |---|---|---|---|---|---|---|---|
 | Claude Opus 4.5 | `claude-opus-4-5` | $6.00 | $30.00 | $0.60 | $7.50 | 198K | Anonymized |
 | Claude Opus 4.6 (Beta) | `claude-opus-4-6` | $6.00 | $30.00 | $0.60 | $7.50 | 1000K | Anonymized |
+| Claude Opus 4.6 Fast (Beta) | `claude-opus-4-6-fast` | $36.00 | $180.00 | $3.60 | $45.00 | 1000K | Anonymized |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5` | $3.75 | $18.75 | $0.38 | $4.69 | 198K | Anonymized |
 | Claude Sonnet 4.6 (Beta) | `claude-sonnet-4-6` | $3.60 | $18.00 | $0.36 | $4.50 | 1000K | Anonymized |
 | DeepSeek V3.2 | `deepseek-v3.2` | $0.33 | $0.48 | $0.16 | - | 160K | Private |


### PR DESCRIPTION
## Summary
- Add Claude Opus 4.6 Fast (Beta) to pricing table, Claude Code guide, Cursor guide, and reasoning models guide
- Fix Claude 4.5 model IDs from internal format (`claude-opus-45` / `claude-sonnet-45`) to canonical API format (`claude-opus-4-5` / `claude-sonnet-4-5`) across all guides (Claude Code, Cursor, prompt caching)

## Test plan
- [ ] Verify pricing page renders correctly with the new row
- [ ] Verify Claude Code guide config JSON is valid
- [ ] Verify all model IDs in guides match `apiModelId` from outerface model definitions

Made with [Cursor](https://cursor.com)