### PR TITLE
docs: clarify Google search proxy behavior and add text parser privacy info

### DIFF
--- a/api-reference/endpoint/augment/search.mdx
+++ b/api-reference/endpoint/augment/search.mdx
@@ -11,7 +11,7 @@ Send a search query in the `query` field. The API returns structured results inc
 
 **Search providers:**
 - `brave` (default) — Brave Search with Zero Data Retention (ZDR). Search queries are never stored or logged by the search provider.
-- `google` — Google Search with anonymized queries. Searches are proxied and stripped of identifying information before being sent to Google.
+- `google` — Google Search with anonymized queries. Searches are proxied through Venice's infrastructure so that your identity is not associated with the search request sent to Google. Venice does not store or log search queries.
 
 **Pricing:** $0.01 per request.
 

--- a/api-reference/endpoint/augment/text-parser.mdx
+++ b/api-reference/endpoint/augment/text-parser.mdx
@@ -11,6 +11,8 @@ Upload a document file via multipart/form-data using the `file` field. Supported
 
 Set `response_format` to `json` (default) for structured output with extracted text and token count, or `text` for the raw extracted text.
 
+**Privacy:** Text parsing runs entirely in-memory on Venice's infrastructure with zero data retention. Your documents are processed and immediately discarded — no content is stored or logged.
+
 **Pricing:** $0.01 per request.
 
 ### Example (cURL)

--- a/llms.txt
+++ b/llms.txt
@@ -44,9 +44,9 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Video Transcription](https://docs.venice.ai/api-reference/endpoint/video/transcriptions): Extract text/speech from videos
 
 ### Augment
-- [Text Parser](https://docs.venice.ai/api-reference/endpoint/augment/text-parser): Extract text from PDF, DOCX, XLSX, and plain text files ($0.01/request)
+- [Text Parser](https://docs.venice.ai/api-reference/endpoint/augment/text-parser): Extract text from PDF, DOCX, XLSX, and plain text files. Runs in-memory on Venice infrastructure with zero data retention ($0.01/request)
 - [Web Scrape](https://docs.venice.ai/api-reference/endpoint/augment/scrape): Scrape a web page and return its content as markdown ($0.01/request)
-- [Web Search](https://docs.venice.ai/api-reference/endpoint/augment/search): Search the web with privacy-preserving providers (Brave ZDR or anonymized Google) and return structured results ($0.01/request)
+- [Web Search](https://docs.venice.ai/api-reference/endpoint/augment/search): Search the web with privacy-preserving providers — Brave (ZDR, zero data retention) or Google (proxied through Venice so your identity is not associated with the search) ($0.01/request)
 
 ### Embeddings
 - [Embeddings](https://docs.venice.ai/api-reference/endpoint/embeddings/generate): Generate vector embeddings for semantic search

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3940,8 +3940,9 @@ components:
           description: Search provider to use. "brave" uses Brave Search with Zero Data
             Retention (ZDR) for maximum privacy — search queries are never
             stored or logged. "google" uses Google Search with anonymized
-            queries — searches are proxied and stripped of identifying
-            information before being sent to Google. Defaults to "brave".
+            queries — searches are proxied through Venice's infrastructure so
+            that your identity is not associated with the search request sent
+            to Google. Venice does not store or log search queries. Defaults to "brave".
           example: brave
       required:
         - query
@@ -10256,6 +10257,11 @@ paths:
         text formats. Upload a file via multipart/form-data.
 
 
+        **Privacy:** Text parsing runs entirely in-memory on Venice's
+        infrastructure with zero data retention. Documents are processed and
+        immediately discarded — no content is stored or logged.
+
+
         **Authentication:** This endpoint accepts either a Bearer API key or an
         `X-Sign-In-With-X` header for x402 wallet-based authentication. When
         using x402, a `402 Payment Required` response indicates insufficient
@@ -12078,7 +12084,9 @@ paths:
         Search queries are never stored or logged by the search provider.
 
         - `google` — Google Search with anonymized queries. Searches are proxied
-        and stripped of identifying information before being sent to Google.
+        through Venice's infrastructure so that your identity is not associated
+        with the search request sent to Google. Venice does not store or log
+        search queries.
 
 
         **Authentication:** This endpoint accepts either a Bearer API key or an


### PR DESCRIPTION
## Summary
- Clarifies the Google search provider description across all docs surfaces (endpoint page, swagger, llms.txt) — the previous wording "stripped of identifying information" was ambiguous and could imply Venice scans/modifies the prompt for PII. The actual behavior is that Venice proxies the search request so the user's identity is disassociated from it.
- Adds privacy documentation to the Text Parser endpoint noting that parsing runs in-memory on Venice infrastructure with zero data retention (no documents are stored or logged).

## Context
Community feedback flagged the Google search description as unclear and asked about Text Parser privacy guarantees.

## Test plan
- [ ] Verify docs render correctly on Mintlify preview
- [ ] Confirm swagger.yaml changes don't break OpenAPI validation

Made with [Cursor](https://cursor.com)