### PR TITLE
docs: clarify E2EE tool call handling

### DIFF
--- a/overview/guides/tee-e2ee-models.mdx
+++ b/overview/guides/tee-e2ee-models.mdx
@@ -805,6 +805,67 @@ def process_e2ee_stream(response, client_private_key: bytes) -> str:
 ```
 </CodeGroup>
 
+### Tool Calls with E2EE
+
+When E2EE is active, tool calls are returned as decrypted message content instead of a structured `tool_calls` field. After decryption, you will receive a raw JSON string that your client must parse and convert into the tool-call type expected by your application or framework.
+
+At minimum, extract:
+
+- the tool name
+- the tool parameters / arguments object
+
+For example, after decrypting a chunk you might receive message content like:
+
+```json
+{"name":"get_weather","parameters":{"location":"San Francisco, CA"}}
+```
+
+If your SDK or agent framework expects typed tool-call objects, deserialize that JSON string and map it into the required shape before invoking the tool.
+
+<CodeGroup>
+```javascript JavaScript
+function parseE2EEToolCall(decryptedContent) {
+  const raw = JSON.parse(decryptedContent)
+
+  return {
+    toolName: raw.name,
+    parameters: raw.parameters ?? {},
+  }
+}
+
+// Example:
+const toolCall = parseE2EEToolCall(
+  '{"name":"get_weather","parameters":{"location":"San Francisco, CA"}}'
+)
+
+console.log(toolCall.toolName) // "get_weather"
+console.log(toolCall.parameters.location) // "San Francisco, CA"
+```
+
+```python Python
+import json
+
+def parse_e2ee_tool_call(decrypted_content: str) -> dict:
+    raw = json.loads(decrypted_content)
+    return {
+        'tool_name': raw['name'],
+        'parameters': raw.get('parameters', {})
+    }
+
+# Example:
+tool_call = parse_e2ee_tool_call(
+    '{"name":"get_weather","parameters":{"location":"San Francisco, CA"}}'
+)
+
+print(tool_call['tool_name'])  # get_weather
+print(tool_call['parameters']['location'])  # San Francisco, CA
+```
+</CodeGroup>
+
+<Note>
+If your framework expects OpenAI-compatible tool call objects, add a small adapter layer that transforms the decrypted JSON string into that framework's required tool name + arguments type.
+</Note>
+
 ### Complete Working Example
 
 <Tabs>
@@ -1089,7 +1150,7 @@ E2EE has some constraints due to the encryption requirements:
 | Streaming | **Required** (non-streaming not supported) |
 | Web search | **Disabled** (would leak content) |
 | File uploads | **Not supported** |
-| Function calling | **Not supported** |
+| Tool / function calling | **Returned as message content** (client must parse decrypted JSON into tool name + parameters) |
 | Venice system prompt | **Disabled** (must be encrypted client-side) |
 
 ### Security Best Practices


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new TEE/E2EE guide section explaining how tool calls are returned when E2EE is active
- document that decrypted tool invocations arrive as raw JSON in message content rather than structured `tool_calls`
- show users how to parse that JSON into a tool name + parameters shape and update the limitations table accordingly

## Testing
- not run (documentation-only change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a31a11fe-d288-40b8-a406-60b86d389247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a31a11fe-d288-40b8-a406-60b86d389247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

