### PR TITLE
feat(models): split Audio page into Text-to-Speech and Speech-to-Text

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -92,7 +92,8 @@
               "models/overview",
               "models/text",
               "models/image",
-              "models/audio",
+              "models/text-to-speech",
+              "models/speech-to-text",
               "models/music",
               "models/video",
               "models/embeddings"
@@ -310,6 +311,10 @@
     {
       "source": "/overview/guides/molt-bot",
       "destination": "/overview/guides/openclaw-bot"
+    },
+    {
+      "source": "/models/audio",
+      "destination": "/models/text-to-speech"
     }
   ]
 }

--- a/llms.txt
+++ b/llms.txt
@@ -90,7 +90,8 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Model Overview](https://docs.venice.ai/models/overview): Browse all available models
 - [Text Models](https://docs.venice.ai/models/text): LLMs including venice-uncensored, GLM-4.7, Qwen3, Mistral, Llama, Grok, DeepSeek, Kimi
 - [Image Models](https://docs.venice.ai/models/image): Diffusion models for image generation (Flux, Stable Diffusion)
-- [Audio Models](https://docs.venice.ai/models/audio): Text-to-speech models
+- [Text-to-Speech Models](https://docs.venice.ai/models/text-to-speech): TTS models with multilingual voice support (Kokoro, Qwen 3 TTS)
+- [Speech-to-Text Models](https://docs.venice.ai/models/speech-to-text): Audio transcription models (Whisper, Parakeet)
 - [Music Models](https://docs.venice.ai/models/music): Music and sound effects generation with lyrics support
 - [Video Models](https://docs.venice.ai/models/video): Text-to-video and image-to-video models
 - [Embedding Models](https://docs.venice.ai/models/embeddings): Vector embedding models

--- a/model-search.js
+++ b/model-search.js
@@ -1529,6 +1529,8 @@
       if (activeFilter === 'image') return model.type === 'image' || model.type === 'upscale' || model.type === 'inpaint';
       if (activeFilter === 'video') return model.type === 'video';
       if (activeFilter === 'audio') return model.type === 'tts' || model.type === 'asr';
+      if (activeFilter === 'tts') return model.type === 'tts';
+      if (activeFilter === 'asr') return model.type === 'asr';
       if (activeFilter === 'embedding') return model.type === 'embedding';
       if (activeFilter === 'music') return model.type === 'music';
       return true;

--- a/models/speech-to-text.mdx
+++ b/models/speech-to-text.mdx
@@ -1,0 +1,31 @@
+---
+title: "Speech-to-Text Models"
+description: "Speech recognition models for transcribing audio to text"
+"og:title": "Speech-to-Text Models | Venice API Docs"
+---
+
+<div id="model-search-placeholder" data-filter="asr">Loading models...</div>
+
+---
+
+## Usage
+
+Speech-to-text models transcribe spoken audio into written text. They are accessed via the [Audio Transcriptions API](/api-reference/endpoint/audio/transcriptions).
+
+### Supported audio formats
+
+`mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `wav`, `webm`, `flac`, `ogg`
+
+### Response formats
+
+| Format | Description |
+|--------|-------------|
+| `json` | Default. Returns `{ "text": "..." }`. |
+| `text` | Plain transcribed text. |
+| `srt` | SubRip subtitle format with timestamps. |
+| `vtt` | WebVTT subtitle format with timestamps. |
+| `verbose_json` | Full response with segment-level timestamps and metadata. |
+
+<Note>
+Pricing is billed per second of input audio. See the [Audio Transcriptions API](/api-reference/endpoint/audio/transcriptions) for request examples and parameter details.
+</Note>

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Audio Models"
+title: "Text-to-Speech Models"
 description: "Text-to-speech models with multilingual voice support"
-"og:title": "Audio Models | Venice API Docs"
+"og:title": "Text-to-Speech Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="audio">Loading models...</div>
+<div id="model-search-placeholder" data-filter="tts">Loading models...</div>
 
 ---
 


### PR DESCRIPTION
The Audio models page previously combined TTS (Kokoro, Qwen 3 TTS, ElevenLabs) with Speech-to-Text (Whisper, Parakeet), which made the voice tables and the transcription API feel unrelated.

- Add models/text-to-speech.mdx (data-filter="tts") with the Kokoro voice tables
- Add models/speech-to-text.mdx (data-filter="asr") with supported audio formats and response formats for the transcriptions API
- Remove models/audio.mdx
- docs.json: replace the "Audio" sidebar entry with Text-to-Speech and Speech-to-Text; add a redirect from /models/audio to /models/text-to-speech so existing inbound links keep working
- llms.txt: list both pages separately
- model-search.js: accept "tts" and "asr" as preset filters so the new pages only render models of the correct type

The combined "Audio" filter on the overview page still works (matches tts + asr), so the filter bar is unchanged.