### PR TITLE
docs(video): document Grok Imagine Private models and download_url

### DIFF
--- a/overview/guides/video-generation.mdx
+++ b/overview/guides/video-generation.mdx
@@ -58,7 +58,7 @@ For Grok Imagine Private models, the queue response includes an extra `download_
 - `grok-imagine-reference-to-video-private`
 - `grok-imagine-video-to-video-private`
 
-Grok Imagine Private models route directly to xAI. Unlike the public `grok-imagine-*-video` variants, they are not billed for content-moderation rejections, so you only pay for successful generations.
+Unlike the public `grok-imagine-*-video` variants, Grok Imagine Private models are not billed for content-moderation rejections, so you only pay for successful generations.
 
 Save `model`, `queue_id`, and `download_url` (if present) for all subsequent calls.
 

--- a/overview/guides/video-generation.mdx
+++ b/overview/guides/video-generation.mdx
@@ -41,17 +41,24 @@ Content-Type: application/json
 }
 ```
 
-For some models, the response includes an extra `download_url` field:
+For Grok Imagine Private models, the queue response includes an extra `download_url` field:
 
 ```json
 {
-  "model": "grok-imagine-text-to-video",
+  "model": "grok-imagine-text-to-video-private",
   "queue_id": "123e4567-e89b-12d3-a456-426614174000",
   "download_url": "https://private-share.venice.ai/v1/share/read/..."
 }
 ```
 
-When present, `download_url` is a pre-signed URL you will use to download the finished video instead of reading it from the retrieve response. It is only returned once, so persist it alongside `queue_id`. This applies to models that upload videos directly to Venice's private storage (currently Grok Imagine variants).
+`download_url` is a pre-signed URL you use to download the finished video instead of reading it from the retrieve response. It is only returned once, so persist it alongside `queue_id`. This applies to all four Grok Imagine Private variants:
+
+- `grok-imagine-text-to-video-private`
+- `grok-imagine-image-to-video-private`
+- `grok-imagine-reference-to-video-private`
+- `grok-imagine-video-to-video-private`
+
+Grok Imagine Private models route directly to xAI. Unlike the public `grok-imagine-*-video` variants, they are not billed for content-moderation rejections, so you only pay for successful generations.
 
 Save `model`, `queue_id`, and `download_url` (if present) for all subsequent calls.
 


### PR DESCRIPTION
﻿## Summary

Updates `overview/guides/video-generation.mdx` to accurately describe the `download_url` queue-response pattern and the Grok Imagine Private models that use it.

## What changes

- **Example uses the correct ID.** The `download_url` queue-response example now shows `grok-imagine-text-to-video-private` instead of `grok-imagine-text-to-video`.
- **All four private variants listed.** The guide now names every Grok Imagine Private model that returns `download_url`:
  - `grok-imagine-text-to-video-private`
  - `grok-imagine-image-to-video-private`
  - `grok-imagine-reference-to-video-private`
  - `grok-imagine-video-to-video-private`
- **Content-moderation billing is now documented.** Grok Imagine Private routes directly to xAI and carries `chargesForContentModeration: false` on the model spec. Callers are only billed for successful generations, unlike the public `grok-imagine-*-video` variants which are billed for every generation xAI moderates. This is a real cost difference API users need to know about when choosing between variants.

## Verification

- Private IDs are API-available to all users: confirmed against `main` of outerface (commit `7c4cd0f6` removed `alphaAccess: true` from all four private variants; `apiModel: true` and `apiModelId` are set).
- `chargesForContentModeration: false`: confirmed on all four `GrokImagine*Private` definitions in `src/lib/venice-models/model-definitions/video-models/xai/grok-imagine-private.ts`.

## Out of scope (explicitly)

- No deprecation date for the public `grok-imagine-*-video` variants. There is no `model_spec.deprecation.date` set on outerface, and `apiShowDeprecation: false` is active on those models, so the API does not currently emit a `Deprecation` header. Publishing a date in docs without matching outerface signals would be misleading; that's a separate PR once the API-side schedule is set.
- No changes to `overview/pricing.mdx`.
- No changes to `STATIC_MODELS` in `model-search.js`; the live API is the source of truth.

## Test plan

- [ ] Render check on Mintlify preview: `download_url` section reads cleanly, bulleted list renders, moderation paragraph has no line-break issues.
- [ ] Copy-paste sanity: a user with any API key can queue `grok-imagine-text-to-video-private` and receive a `download_url` in the response.
