### PR TITLE
docs(tts): organize voice catalog by model

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -1286,6 +1286,205 @@
     }).catch(() => {});
   }
 
+  // ===== TTS Voice Picker =====
+
+  const KOKORO_LANG_MAP = {
+    a: 'American English',
+    b: 'British English',
+    z: 'Chinese',
+    j: 'Japanese',
+    e: 'Spanish',
+    f: 'French',
+    h: 'Hindi',
+    i: 'Italian',
+    p: 'Portuguese (BR)'
+  };
+
+  const TTS_MODEL_BLURBS = {
+    'tts-kokoro': 'Open-weights Kokoro 82M — multilingual coverage across 10 languages.',
+    'tts-elevenlabs-turbo-v2-5': 'Curated voices from the ElevenLabs Turbo v2.5 library.',
+    'tts-minimax-speech-02-hd': 'MiniMax Speech-02 HD — voice names describe persona and style directly.',
+    'tts-inworld-1-5-max': 'Expressive English voices from Inworld AI.',
+    'tts-chatterbox-hd': 'High-fidelity English voices from Resemble AI Chatterbox HD.',
+    'tts-orpheus': 'Conversational English voices from open-source Orpheus 3B.',
+    'tts-qwen3-0-6b': 'Qwen 3 TTS, 0.6B parameter variant. Shares its catalog with the 1.7B variant.',
+    'tts-qwen3-1-7b': 'Qwen 3 TTS, 1.7B parameter variant. Higher quality than the 0.6B variant.',
+    'tts-xai-v1': "xAI TTS v1."
+  };
+
+  function kokoroVoiceMeta(voiceId) {
+    if (typeof voiceId !== 'string' || voiceId.length < 3 || voiceId[2] !== '_') return '';
+    const langKey = voiceId[0];
+    const genderKey = voiceId[1];
+    const lang = KOKORO_LANG_MAP[langKey];
+    if (!lang) return '';
+    const gender = genderKey === 'f' ? 'Female' : genderKey === 'm' ? 'Male' : '';
+    let meta = gender ? `${lang} · ${gender}` : lang;
+    if (voiceId === 'af_sky') meta += ' · default';
+    return meta;
+  }
+
+  function getTTSModels(models) {
+    return (models || [])
+      .filter(m => m.type === 'tts' && !isDeprecatedModel(m))
+      .sort((a, b) => {
+        const an = (a.model_spec?.name || a.id).toLowerCase();
+        const bn = (b.model_spec?.name || b.id).toLowerCase();
+        return an.localeCompare(bn);
+      });
+  }
+
+  function renderVoicePickerShell(ttsModels, selectedId) {
+    const options = ttsModels.map(m => {
+      const id = escapeHtml(m.id);
+      const name = escapeHtml(m.model_spec?.name || m.id);
+      const count = m.model_spec?.voices?.length || 0;
+      const sel = m.id === selectedId ? ' selected' : '';
+      return `<option value="${id}"${sel}>${name} — ${count} voice${count === 1 ? '' : 's'}</option>`;
+    }).join('');
+
+    return `
+      <div class="vtp-picker">
+        <div class="vtp-row vtp-row-controls">
+          <label class="vtp-field vtp-field-model">
+            <span class="vtp-label">Model</span>
+            <select class="vtp-model-select" aria-label="Choose a TTS model">${options}</select>
+          </label>
+          <label class="vtp-field vtp-field-search">
+            <span class="vtp-label">Search voices</span>
+            <input type="search" class="vtp-search" placeholder="e.g. af_sky" aria-label="Search voices" />
+          </label>
+        </div>
+        <div class="vtp-meta" data-target="meta"></div>
+        <div class="vtp-list-header">
+          <span class="vtp-list-title">Voices</span>
+          <span class="vtp-count" data-target="count"></span>
+        </div>
+        <div class="vtp-voice-list" data-target="list"></div>
+        <p class="vtp-hint">Click any voice to copy its ID. Use it as the <code>voice</code> field together with the matching <code>model</code> above.</p>
+      </div>
+    `;
+  }
+
+  function renderVoiceMeta(model) {
+    const id = escapeHtml(model.id);
+    const count = model.model_spec?.voices?.length || 0;
+    const price = model.model_spec?.pricing?.input?.usd;
+    const blurb = TTS_MODEL_BLURBS[model.id] || '';
+    const pills = [
+      `<span class="vtp-pill vtp-pill-id"><code>${id}</code></span>`,
+      `<span class="vtp-pill">${count} voice${count === 1 ? '' : 's'}</span>`
+    ];
+    if (typeof price === 'number') {
+      pills.push(`<span class="vtp-pill">${formatPrice(price)} / 1M chars</span>`);
+    }
+    return `
+      <div class="vtp-pills">${pills.join('')}</div>
+      ${blurb ? `<p class="vtp-blurb">${escapeHtml(blurb)}</p>` : ''}
+    `;
+  }
+
+  function renderVoiceRow(modelId, voiceId) {
+    const id = escapeHtml(voiceId);
+    const meta = modelId === 'tts-kokoro' ? kokoroVoiceMeta(voiceId) : '';
+    return `
+      <button class="vtp-voice" type="button" data-voice="${id}" title="Copy voice ID">
+        <span class="vtp-voice-id">${id}</span>
+        ${meta ? `<span class="vtp-voice-meta">${escapeHtml(meta)}</span>` : '<span class="vtp-voice-meta"></span>'}
+        <span class="vtp-voice-action" aria-hidden="true">
+          <span class="vtp-action-copy">Copy</span>
+          <span class="vtp-action-copied">Copied!</span>
+        </span>
+      </button>
+    `;
+  }
+
+  function refreshVoicePicker(rootEl, ttsModels) {
+    const select = rootEl.querySelector('.vtp-model-select');
+    const search = rootEl.querySelector('.vtp-search');
+    const meta = rootEl.querySelector('[data-target="meta"]');
+    const list = rootEl.querySelector('[data-target="list"]');
+    const count = rootEl.querySelector('[data-target="count"]');
+    if (!select || !meta || !list || !count) return;
+
+    const model = ttsModels.find(m => m.id === select.value) || ttsModels[0];
+    if (!model) return;
+
+    const allVoices = model.model_spec?.voices || [];
+    const q = (search.value || '').trim().toLowerCase();
+    const matches = q
+      ? allVoices.filter(v => v.toLowerCase().includes(q) || (model.id === 'tts-kokoro' && kokoroVoiceMeta(v).toLowerCase().includes(q)))
+      : allVoices;
+
+    meta.innerHTML = renderVoiceMeta(model);
+
+    if (matches.length === 0) {
+      list.innerHTML = '<div class="vtp-empty">No voices match your search.</div>';
+    } else {
+      list.innerHTML = matches.map(v => renderVoiceRow(model.id, v)).join('');
+    }
+
+    count.textContent = q ? `${matches.length} of ${allVoices.length}` : `${allVoices.length} total`;
+  }
+
+  function mountVoicePicker(el, models) {
+    const ttsModels = getTTSModels(models);
+    if (ttsModels.length === 0) {
+      el.innerHTML = '<p class="vtp-empty">No TTS models available.</p>';
+      return;
+    }
+
+    const preferred = ttsModels.find(m => m.id === 'tts-kokoro') || ttsModels[0];
+
+    const existingSelect = el.querySelector('.vtp-model-select');
+    const existingSearch = el.querySelector('.vtp-search');
+    const previousSelected = existingSelect ? existingSelect.value : preferred.id;
+    const previousQuery = existingSearch ? existingSearch.value : '';
+
+    const stillValid = ttsModels.some(m => m.id === previousSelected);
+    const selectedId = stillValid ? previousSelected : preferred.id;
+
+    el.innerHTML = renderVoicePickerShell(ttsModels, selectedId);
+
+    const root = el.querySelector('.vtp-picker');
+    if (!root) return;
+
+    const search = root.querySelector('.vtp-search');
+    if (search && previousQuery) search.value = previousQuery;
+
+    refreshVoicePicker(root, ttsModels);
+
+    const select = root.querySelector('.vtp-model-select');
+    if (select) {
+      select.addEventListener('change', () => refreshVoicePicker(root, ttsModels));
+    }
+    if (search) {
+      search.addEventListener('input', () => refreshVoicePicker(root, ttsModels));
+    }
+  }
+
+  async function initVoicePicker() {
+    const el = document.getElementById('tts-voice-picker-placeholder');
+    if (!el) return;
+
+    el.style.visibility = 'visible';
+    el.style.height = 'auto';
+    el.style.overflow = 'visible';
+
+    mountVoicePicker(el, STATIC_MODELS);
+
+    const cachedModels = getCachedModels();
+    if (cachedModels && cachedModels.length > 0) {
+      mountVoicePicker(el, cachedModels);
+    }
+
+    fetchModelsFromAPI().then(freshModels => {
+      if (freshModels && freshModels.length > 0) {
+        mountVoicePicker(el, freshModels);
+      }
+    }).catch(() => {});
+  }
+
   function renderPricingTables(models) {
     const chatEl = document.getElementById('pricing-chat-placeholder');
     const embeddingEl = document.getElementById('pricing-embedding-placeholder');
@@ -2089,7 +2288,8 @@
     traitsList: { initialized: false, rendered: false, promise: null },
     betaModels: { initialized: false, rendered: false, promise: null },
     cachePricing: { initialized: false, rendered: false, promise: null },
-    reasoningModels: { initialized: false, rendered: false, promise: null }
+    reasoningModels: { initialized: false, rendered: false, promise: null },
+    voicePicker: { initialized: false, rendered: false, promise: null }
   };
 
   // Global copy button handler
@@ -2097,6 +2297,17 @@
     const btn = e.target.closest('.vpt-copy-btn');
     if (!btn) return;
     await navigator.clipboard.writeText(btn.dataset.modelId).catch(() => {});
+    btn.classList.add('copied');
+    setTimeout(() => btn.classList.remove('copied'), 1500);
+  });
+
+  // Voice-row copy handler (TTS voice picker)
+  document.addEventListener('click', async (e) => {
+    const btn = e.target.closest('.vtp-voice');
+    if (!btn) return;
+    const voiceId = btn.dataset.voice;
+    if (!voiceId) return;
+    await navigator.clipboard.writeText(voiceId).catch(() => {});
     btn.classList.add('copied');
     setTimeout(() => btn.classList.remove('copied'), 1500);
   });
@@ -2202,6 +2413,14 @@
     resetCheck: el => el.innerHTML === ''
   });
 
+  const tryInitVoicePicker = createPageInitializer({
+    name: 'voicePicker',
+    pathMatch: 'text-to-speech',
+    elementId: 'tts-voice-picker-placeholder',
+    initFn: initVoicePicker,
+    resetCheck: el => el.textContent.includes('Loading') || el.innerHTML === ''
+  });
+
   function resetAllInitializers() {
     modelsInitialized = false;
     Object.values(pageInitializers).forEach(state => {
@@ -2221,6 +2440,7 @@
     tryInitBetaModels();
     tryInitCachePricing();
     tryInitReasoningModels();
+    tryInitVoicePicker();
   }
 
   function setupObserver() {
@@ -2264,6 +2484,7 @@
     retryInit('beta-models', () => pageInitializers.betaModels.initialized, tryInitBetaModels);
     retryInit('prompt-caching', () => pageInitializers.cachePricing.initialized, tryInitCachePricing);
     retryInit('reasoning-models', () => pageInitializers.reasoningModels.initialized, tryInitReasoningModels);
+    retryInit('text-to-speech', () => pageInitializers.voicePicker.initialized, tryInitVoicePicker);
   }
   
   if (document.readyState === 'loading') {

--- a/model-search.js
+++ b/model-search.js
@@ -1301,9 +1301,9 @@
   };
 
   const TTS_MODEL_BLURBS = {
-    'tts-kokoro': 'Open-weights Kokoro 82M — multilingual coverage across 10 languages.',
+    'tts-kokoro': 'Open-weights Kokoro 82M with multilingual coverage across 10 languages.',
     'tts-elevenlabs-turbo-v2-5': 'Curated voices from the ElevenLabs Turbo v2.5 library.',
-    'tts-minimax-speech-02-hd': 'MiniMax Speech-02 HD — voice names describe persona and style directly.',
+    'tts-minimax-speech-02-hd': 'MiniMax Speech-02 HD. Voice names describe persona and style directly.',
     'tts-inworld-1-5-max': 'Expressive English voices from Inworld AI.',
     'tts-chatterbox-hd': 'High-fidelity English voices from Resemble AI Chatterbox HD.',
     'tts-orpheus': 'Conversational English voices from open-source Orpheus 3B.',
@@ -1340,7 +1340,7 @@
       const name = escapeHtml(m.model_spec?.name || m.id);
       const count = m.model_spec?.voices?.length || 0;
       const sel = m.id === selectedId ? ' selected' : '';
-      return `<option value="${id}"${sel}>${name} — ${count} voice${count === 1 ? '' : 's'}</option>`;
+      return `<option value="${id}"${sel}>${name} (${count} voice${count === 1 ? '' : 's'})</option>`;
     }).join('');
 
     return `

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -8,296 +8,94 @@ description: "Text-to-speech models with multilingual voice support"
 
 ---
 
-## Choosing a model and voice
-
-Voices in the Venice TTS API are **model‑specific**. The value you pass to the
-`voice` parameter must come from the catalog of the `model` you selected — voice
-IDs are not shared across models, and a request that mixes them will return a
-validation error.
-
-Use the table below to pick a model based on language coverage and price, then
-open its tab to see the exact voice IDs.
-
-### Models at a glance
-
-| Model | Voices | Pricing (USD / 1M chars) | Notes |
-|-------|--------|--------------------------|-------|
-| `tts-kokoro` | 54 | $3.50 | Open‑weights Kokoro 82M. Multilingual (10 languages). Cheapest option. |
-| `tts-xai-v1` | 5 | $5.25 | xAI's voice model. English. |
-| `tts-inworld-1-5-max` | 14 | $12.50 | Inworld TTS‑1.5 Max. Expressive English voices. |
-| `tts-chatterbox-hd` | 9 | $50.00 | Resemble AI's Chatterbox HD. High‑fidelity English. |
-| `tts-orpheus` | 8 | $62.50 | Open‑source Orpheus 3B. Conversational English. |
-| `tts-elevenlabs-turbo-v2-5` | 21 | $62.50 | ElevenLabs Turbo v2.5. Curated multilingual voices. |
-| `tts-qwen3-0-6b` | 9 | $87.50 | Qwen3 TTS 0.6B. English + Chinese. |
-| `tts-qwen3-1-7b` | 9 | $112.50 | Qwen3 TTS 1.7B. Larger Qwen3 variant. |
-| `tts-minimax-speech-02-hd` | 15 | $125.00 | MiniMax Speech‑02 HD. Highly expressive. |
-
-<Tip>
-Live pricing and capabilities are also rendered in the model browser at the top
-of this page. Pricing on this page is the per‑million‑character rate (USD).
-</Tip>
-
----
-
 ## Voice catalog
 
-Pick a model tab to see the voices it supports.
+Voices are **model‑specific** — the `voice` you pass must come from the catalog
+of the `model` you selected. Expand a model below to see its voices.
 
-<Tabs>
-  <Tab title="Kokoro (54)">
-    **Model ID:** `tts-kokoro` · **Languages:** 10 · **Pricing:** $3.50 / 1M chars
+<AccordionGroup>
+  <Accordion title="Kokoro · 54 voices · 10 languages · $3.50 / 1M chars" defaultOpen>
+    **Model ID:** `tts-kokoro`
 
-    Kokoro voice IDs follow the pattern `<lang><gender>_<name>` — e.g. `af_*`
-    is American Female, `bm_*` is British Male, `zf_*` is Chinese Female.
+    Voice IDs follow the pattern `<lang><gender>_<name>` — e.g. `af_*` is
+    American Female, `bm_*` is British Male, `zf_*` is Chinese Female. Default
+    voice is `af_sky`.
 
-    #### American English
+    **American English** — `af_alloy`, `af_aoede`, `af_bella`, `af_heart`, `af_jadzia`, `af_jessica`, `af_kore`, `af_nicole`, `af_nova`, `af_river`, `af_sarah`, `af_sky`, `am_adam`, `am_echo`, `am_eric`, `am_fenrir`, `am_liam`, `am_michael`, `am_onyx`, `am_puck`, `am_santa`
 
-    | Voice ID | Description |
-    |----------|-------------|
-    | `af_alloy` | Female, American English |
-    | `af_aoede` | Female, American English |
-    | `af_bella` | Female, American English |
-    | `af_heart` | Female, American English |
-    | `af_jadzia` | Female, American English |
-    | `af_jessica` | Female, American English |
-    | `af_kore` | Female, American English |
-    | `af_nicole` | Female, American English |
-    | `af_nova` | Female, American English |
-    | `af_river` | Female, American English |
-    | `af_sarah` | Female, American English |
-    | `af_sky` | Female, American English (default) |
-    | `am_adam` | Male, American English |
-    | `am_echo` | Male, American English |
-    | `am_eric` | Male, American English |
-    | `am_fenrir` | Male, American English |
-    | `am_liam` | Male, American English |
-    | `am_michael` | Male, American English |
-    | `am_onyx` | Male, American English |
-    | `am_puck` | Male, American English |
-    | `am_santa` | Male, American English |
+    **British English** — `bf_alice`, `bf_emma`, `bf_lily`, `bm_daniel`, `bm_fable`, `bm_george`, `bm_lewis`
 
-    #### British English
+    **Chinese (Mandarin)** — `zf_xiaobei`, `zf_xiaoni`, `zf_xiaoxiao`, `zf_xiaoyi`, `zm_yunjian`, `zm_yunxi`, `zm_yunxia`, `zm_yunyang`
 
-    | Voice ID | Description |
-    |----------|-------------|
-    | `bf_alice` | Female, British English |
-    | `bf_emma` | Female, British English |
-    | `bf_lily` | Female, British English |
-    | `bm_daniel` | Male, British English |
-    | `bm_fable` | Male, British English |
-    | `bm_george` | Male, British English |
-    | `bm_lewis` | Male, British English |
+    **Japanese** — `jf_alpha`, `jf_gongitsune`, `jf_nezumi`, `jf_tebukuro`, `jm_kumo`
 
-    #### Chinese (Mandarin)
+    **Spanish** — `ef_dora`, `em_alex`, `em_santa`
 
-    | Voice ID | Description |
-    |----------|-------------|
-    | `zf_xiaobei` | Female, Chinese |
-    | `zf_xiaoni` | Female, Chinese |
-    | `zf_xiaoxiao` | Female, Chinese |
-    | `zf_xiaoyi` | Female, Chinese |
-    | `zm_yunjian` | Male, Chinese |
-    | `zm_yunxi` | Male, Chinese |
-    | `zm_yunxia` | Male, Chinese |
-    | `zm_yunyang` | Male, Chinese |
+    **French** — `ff_siwis`
 
-    #### Japanese
+    **Hindi** — `hf_alpha`, `hf_beta`, `hm_omega`, `hm_psi`
 
-    | Voice ID | Description |
-    |----------|-------------|
-    | `jf_alpha` | Female, Japanese |
-    | `jf_gongitsune` | Female, Japanese |
-    | `jf_nezumi` | Female, Japanese |
-    | `jf_tebukuro` | Female, Japanese |
-    | `jm_kumo` | Male, Japanese |
+    **Italian** — `if_sara`, `im_nicola`
 
-    #### Spanish
+    **Portuguese (Brazilian)** — `pf_dora`, `pm_alex`, `pm_santa`
+  </Accordion>
 
-    | Voice ID | Description |
-    |----------|-------------|
-    | `ef_dora` | Female, Spanish |
-    | `em_alex` | Male, Spanish |
-    | `em_santa` | Male, Spanish |
+  <Accordion title="ElevenLabs Turbo v2.5 · 21 voices · $62.50 / 1M chars">
+    **Model ID:** `tts-elevenlabs-turbo-v2-5`
 
-    #### French
+    Curated voices from the [ElevenLabs voice library](https://elevenlabs.io/app/voice-library) — visit ElevenLabs for sample previews and language coverage.
 
-    | Voice ID | Description |
-    |----------|-------------|
-    | `ff_siwis` | Female, French |
+    `Alice`, `Aria`, `Bill`, `Brian`, `Callum`, `Charlie`, `Charlotte`, `Chris`, `Daniel`, `Eric`, `George`, `Jessica`, `Laura`, `Liam`, `Lily`, `Matilda`, `Rachel`, `River`, `Roger`, `Sarah`, `Will`
+  </Accordion>
 
-    #### Hindi
+  <Accordion title="MiniMax Speech-02 HD · 15 voices · $125.00 / 1M chars">
+    **Model ID:** `tts-minimax-speech-02-hd`
 
-    | Voice ID | Description |
-    |----------|-------------|
-    | `hf_alpha` | Female, Hindi |
-    | `hf_beta` | Female, Hindi |
-    | `hm_omega` | Male, Hindi |
-    | `hm_psi` | Male, Hindi |
+    Voice names describe the persona and style directly.
 
-    #### Italian
+    `CalmWoman`, `CasualGuy`, `DeepVoiceMan`, `DeterminedMan`, `ElegantMan`, `ExuberantGirl`, `FriendlyPerson`, `ImposingManner`, `InspirationalGirl`, `LivelyGirl`, `LovelyGirl`, `PatientMan`, `SweetGirl`, `WiseWoman`, `YoungKnight`
+  </Accordion>
 
-    | Voice ID | Description |
-    |----------|-------------|
-    | `if_sara` | Female, Italian |
-    | `im_nicola` | Male, Italian |
-
-    #### Portuguese (Brazilian)
-
-    | Voice ID | Description |
-    |----------|-------------|
-    | `pf_dora` | Female, Portuguese |
-    | `pm_alex` | Male, Portuguese |
-    | `pm_santa` | Male, Portuguese |
-  </Tab>
-
-  <Tab title="ElevenLabs Turbo v2.5 (21)">
-    **Model ID:** `tts-elevenlabs-turbo-v2-5` · **Pricing:** $62.50 / 1M chars
-
-    Curated voices from the ElevenLabs library. See the
-    [ElevenLabs voice library](https://elevenlabs.io/app/voice-library) for
-    sample previews and language coverage.
-
-    | Voice ID |
-    |----------|
-    | `Alice` |
-    | `Aria` |
-    | `Bill` |
-    | `Brian` |
-    | `Callum` |
-    | `Charlie` |
-    | `Charlotte` |
-    | `Chris` |
-    | `Daniel` |
-    | `Eric` |
-    | `George` |
-    | `Jessica` |
-    | `Laura` |
-    | `Liam` |
-    | `Lily` |
-    | `Matilda` |
-    | `Rachel` |
-    | `River` |
-    | `Roger` |
-    | `Sarah` |
-    | `Will` |
-  </Tab>
-
-  <Tab title="MiniMax Speech-02 HD (15)">
-    **Model ID:** `tts-minimax-speech-02-hd` · **Pricing:** $125.00 / 1M chars
-
-    MiniMax voice names describe the persona / style directly.
-
-    | Voice ID |
-    |----------|
-    | `CalmWoman` |
-    | `CasualGuy` |
-    | `DeepVoiceMan` |
-    | `DeterminedMan` |
-    | `ElegantMan` |
-    | `ExuberantGirl` |
-    | `FriendlyPerson` |
-    | `ImposingManner` |
-    | `InspirationalGirl` |
-    | `LivelyGirl` |
-    | `LovelyGirl` |
-    | `PatientMan` |
-    | `SweetGirl` |
-    | `WiseWoman` |
-    | `YoungKnight` |
-  </Tab>
-
-  <Tab title="Inworld TTS-1.5 Max (14)">
-    **Model ID:** `tts-inworld-1-5-max` · **Pricing:** $12.50 / 1M chars
+  <Accordion title="Inworld TTS-1.5 Max · 14 voices · $12.50 / 1M chars">
+    **Model ID:** `tts-inworld-1-5-max`
 
     Expressive English voices from Inworld AI.
 
-    | Voice ID |
-    |----------|
-    | `Alex` |
-    | `Ashley` |
-    | `Craig` |
-    | `Edward` |
-    | `Elizabeth` |
-    | `Hades` |
-    | `Luna` |
-    | `Mark` |
-    | `Olivia` |
-    | `Pixie` |
-    | `Priya` |
-    | `Ronald` |
-    | `Sarah` |
-    | `Theodore` |
-  </Tab>
+    `Alex`, `Ashley`, `Craig`, `Edward`, `Elizabeth`, `Hades`, `Luna`, `Mark`, `Olivia`, `Pixie`, `Priya`, `Ronald`, `Sarah`, `Theodore`
+  </Accordion>
 
-  <Tab title="Chatterbox HD (9)">
-    **Model ID:** `tts-chatterbox-hd` · **Pricing:** $50.00 / 1M chars
+  <Accordion title="Chatterbox HD · 9 voices · $50.00 / 1M chars">
+    **Model ID:** `tts-chatterbox-hd`
 
     High‑fidelity English voices from Resemble AI's Chatterbox HD.
 
-    | Voice ID |
-    |----------|
-    | `Aurora` |
-    | `Blade` |
-    | `Britney` |
-    | `Carl` |
-    | `Cliff` |
-    | `Richard` |
-    | `Rico` |
-    | `Siobhan` |
-    | `Vicky` |
-  </Tab>
+    `Aurora`, `Blade`, `Britney`, `Carl`, `Cliff`, `Richard`, `Rico`, `Siobhan`, `Vicky`
+  </Accordion>
 
-  <Tab title="Qwen3 TTS (9)">
-    **Model IDs:** `tts-qwen3-0-6b` (0.6B) · `tts-qwen3-1-7b` (1.7B)
-    **Pricing:** $87.50 / 1M chars (0.6B) · $112.50 / 1M chars (1.7B)
+  <Accordion title="Qwen3 TTS · 9 voices · $87.50–$112.50 / 1M chars">
+    **Model IDs:** `tts-qwen3-0-6b` ($87.50 / 1M chars) · `tts-qwen3-1-7b` ($112.50 / 1M chars)
 
-    Both Qwen3 TTS variants share the same voice catalog. The 1.7B variant
-    produces higher‑quality output at a higher per‑character rate.
+    Both Qwen3 TTS variants share the same voice catalog. The 1.7B variant produces higher‑quality output at a higher per‑character rate.
 
-    | Voice ID |
-    |----------|
-    | `Aiden` |
-    | `Dylan` |
-    | `Eric` |
-    | `Ono_Anna` |
-    | `Ryan` |
-    | `Serena` |
-    | `Sohee` |
-    | `Uncle_Fu` |
-    | `Vivian` |
-  </Tab>
+    `Aiden`, `Dylan`, `Eric`, `Ono_Anna`, `Ryan`, `Serena`, `Sohee`, `Uncle_Fu`, `Vivian`
+  </Accordion>
 
-  <Tab title="Orpheus (8)">
-    **Model ID:** `tts-orpheus` · **Pricing:** $62.50 / 1M chars
+  <Accordion title="Orpheus · 8 voices · $62.50 / 1M chars">
+    **Model ID:** `tts-orpheus`
 
     Conversational English voices from the open‑source Orpheus 3B model.
 
-    | Voice ID |
-    |----------|
-    | `dan` |
-    | `jess` |
-    | `leah` |
-    | `leo` |
-    | `mia` |
-    | `tara` |
-    | `zac` |
-    | `zoe` |
-  </Tab>
+    `dan`, `jess`, `leah`, `leo`, `mia`, `tara`, `zac`, `zoe`
+  </Accordion>
 
-  <Tab title="xAI TTS v1 (5)">
-    **Model ID:** `tts-xai-v1` · **Pricing:** $5.25 / 1M chars
+  <Accordion title="xAI TTS v1 · 5 voices · $5.25 / 1M chars">
+    **Model ID:** `tts-xai-v1`
 
     English voices from xAI's TTS v1 model.
 
-    | Voice ID |
-    |----------|
-    | `ara` |
-    | `eve` |
-    | `leo` |
-    | `rex` |
-    | `sal` |
-  </Tab>
-</Tabs>
+    `ara`, `eve`, `leo`, `rex`, `sal`
+  </Accordion>
+</AccordionGroup>
 
 <Note>
 Voice IDs are case‑sensitive and **only valid for the matching `model`**. Pass
@@ -320,4 +118,4 @@ curl https://api.venice.ai/api/v1/audio/speech \
 ```
 
 To switch models, change **both** `model` and `voice` to a pair listed under
-the same tab above.
+the same model above.

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -10,14 +10,14 @@ description: "Text-to-speech models with multilingual voice support"
 
 ## Voice catalog
 
-Voices are **model‑specific** — the `voice` you pass must come from the catalog
+Voices are **model-specific**. The `voice` you pass must come from the catalog
 of the `model` you selected. Pick a model below to browse its voices.
 
 <div id="tts-voice-picker-placeholder">Loading voices...</div>
 
 <Note>
-Voice IDs are case‑sensitive and **only valid for the matching `model`**. Pass
-both fields together in your request payload — see the
+Voice IDs are case-sensitive and **only valid for the matching `model`**. Pass
+both fields together in your request payload. See the
 [Audio Speech API](/api-reference/endpoint/audio/speech) for examples.
 </Note>
 

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -11,91 +11,9 @@ description: "Text-to-speech models with multilingual voice support"
 ## Voice catalog
 
 Voices are **model‑specific** — the `voice` you pass must come from the catalog
-of the `model` you selected. Expand a model below to see its voices.
+of the `model` you selected. Pick a model below to browse its voices.
 
-<AccordionGroup>
-  <Accordion title="Kokoro · 54 voices · 10 languages · $3.50 / 1M chars" defaultOpen>
-    **Model ID:** `tts-kokoro`
-
-    Voice IDs follow the pattern `<lang><gender>_<name>` — e.g. `af_*` is
-    American Female, `bm_*` is British Male, `zf_*` is Chinese Female. Default
-    voice is `af_sky`.
-
-    **American English** — `af_alloy`, `af_aoede`, `af_bella`, `af_heart`, `af_jadzia`, `af_jessica`, `af_kore`, `af_nicole`, `af_nova`, `af_river`, `af_sarah`, `af_sky`, `am_adam`, `am_echo`, `am_eric`, `am_fenrir`, `am_liam`, `am_michael`, `am_onyx`, `am_puck`, `am_santa`
-
-    **British English** — `bf_alice`, `bf_emma`, `bf_lily`, `bm_daniel`, `bm_fable`, `bm_george`, `bm_lewis`
-
-    **Chinese (Mandarin)** — `zf_xiaobei`, `zf_xiaoni`, `zf_xiaoxiao`, `zf_xiaoyi`, `zm_yunjian`, `zm_yunxi`, `zm_yunxia`, `zm_yunyang`
-
-    **Japanese** — `jf_alpha`, `jf_gongitsune`, `jf_nezumi`, `jf_tebukuro`, `jm_kumo`
-
-    **Spanish** — `ef_dora`, `em_alex`, `em_santa`
-
-    **French** — `ff_siwis`
-
-    **Hindi** — `hf_alpha`, `hf_beta`, `hm_omega`, `hm_psi`
-
-    **Italian** — `if_sara`, `im_nicola`
-
-    **Portuguese (Brazilian)** — `pf_dora`, `pm_alex`, `pm_santa`
-  </Accordion>
-
-  <Accordion title="ElevenLabs Turbo v2.5 · 21 voices · $62.50 / 1M chars">
-    **Model ID:** `tts-elevenlabs-turbo-v2-5`
-
-    Curated voices from the [ElevenLabs voice library](https://elevenlabs.io/app/voice-library) — visit ElevenLabs for sample previews and language coverage.
-
-    `Alice`, `Aria`, `Bill`, `Brian`, `Callum`, `Charlie`, `Charlotte`, `Chris`, `Daniel`, `Eric`, `George`, `Jessica`, `Laura`, `Liam`, `Lily`, `Matilda`, `Rachel`, `River`, `Roger`, `Sarah`, `Will`
-  </Accordion>
-
-  <Accordion title="MiniMax Speech-02 HD · 15 voices · $125.00 / 1M chars">
-    **Model ID:** `tts-minimax-speech-02-hd`
-
-    Voice names describe the persona and style directly.
-
-    `CalmWoman`, `CasualGuy`, `DeepVoiceMan`, `DeterminedMan`, `ElegantMan`, `ExuberantGirl`, `FriendlyPerson`, `ImposingManner`, `InspirationalGirl`, `LivelyGirl`, `LovelyGirl`, `PatientMan`, `SweetGirl`, `WiseWoman`, `YoungKnight`
-  </Accordion>
-
-  <Accordion title="Inworld TTS-1.5 Max · 14 voices · $12.50 / 1M chars">
-    **Model ID:** `tts-inworld-1-5-max`
-
-    Expressive English voices from Inworld AI.
-
-    `Alex`, `Ashley`, `Craig`, `Edward`, `Elizabeth`, `Hades`, `Luna`, `Mark`, `Olivia`, `Pixie`, `Priya`, `Ronald`, `Sarah`, `Theodore`
-  </Accordion>
-
-  <Accordion title="Chatterbox HD · 9 voices · $50.00 / 1M chars">
-    **Model ID:** `tts-chatterbox-hd`
-
-    High‑fidelity English voices from Resemble AI's Chatterbox HD.
-
-    `Aurora`, `Blade`, `Britney`, `Carl`, `Cliff`, `Richard`, `Rico`, `Siobhan`, `Vicky`
-  </Accordion>
-
-  <Accordion title="Qwen3 TTS · 9 voices · $87.50–$112.50 / 1M chars">
-    **Model IDs:** `tts-qwen3-0-6b` ($87.50 / 1M chars) · `tts-qwen3-1-7b` ($112.50 / 1M chars)
-
-    Both Qwen3 TTS variants share the same voice catalog. The 1.7B variant produces higher‑quality output at a higher per‑character rate.
-
-    `Aiden`, `Dylan`, `Eric`, `Ono_Anna`, `Ryan`, `Serena`, `Sohee`, `Uncle_Fu`, `Vivian`
-  </Accordion>
-
-  <Accordion title="Orpheus · 8 voices · $62.50 / 1M chars">
-    **Model ID:** `tts-orpheus`
-
-    Conversational English voices from the open‑source Orpheus 3B model.
-
-    `dan`, `jess`, `leah`, `leo`, `mia`, `tara`, `zac`, `zoe`
-  </Accordion>
-
-  <Accordion title="xAI TTS v1 · 5 voices · $5.25 / 1M chars">
-    **Model ID:** `tts-xai-v1`
-
-    English voices from xAI's TTS v1 model.
-
-    `ara`, `eve`, `leo`, `rex`, `sal`
-  </Accordion>
-</AccordionGroup>
+<div id="tts-voice-picker-placeholder">Loading voices...</div>
 
 <Note>
 Voice IDs are case‑sensitive and **only valid for the matching `model`**. Pass
@@ -117,5 +35,5 @@ curl https://api.venice.ai/api/v1/audio/speech \
   --output speech.mp3
 ```
 
-To switch models, change **both** `model` and `voice` to a pair listed under
-the same model above.
+To switch models, change **both** `model` and `voice` to a pair from the
+selected model above.

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -8,109 +8,316 @@ description: "Text-to-speech models with multilingual voice support"
 
 ---
 
-## Available Voices
+## Choosing a model and voice
 
-Kokoro TTS supports 54 multilingual and stylistic voices across 10 languages:
+Voices in the Venice TTS API are **model‑specific**. The value you pass to the
+`voice` parameter must come from the catalog of the `model` you selected — voice
+IDs are not shared across models, and a request that mixes them will return a
+validation error.
 
-### American English
+Use the table below to pick a model based on language coverage and price, then
+open its tab to see the exact voice IDs.
 
-| Voice ID | Description |
-|----------|-------------|
-| `af_alloy` | Female, American English |
-| `af_aoede` | Female, American English |
-| `af_bella` | Female, American English |
-| `af_heart` | Female, American English |
-| `af_jadzia` | Female, American English |
-| `af_jessica` | Female, American English |
-| `af_kore` | Female, American English |
-| `af_nicole` | Female, American English |
-| `af_nova` | Female, American English |
-| `af_river` | Female, American English |
-| `af_sarah` | Female, American English |
-| `af_sky` | Female, American English (default) |
-| `am_adam` | Male, American English |
-| `am_echo` | Male, American English |
-| `am_eric` | Male, American English |
-| `am_fenrir` | Male, American English |
-| `am_liam` | Male, American English |
-| `am_michael` | Male, American English |
-| `am_onyx` | Male, American English |
-| `am_puck` | Male, American English |
-| `am_santa` | Male, American English |
+### Models at a glance
 
-### British English
+| Model | Voices | Pricing (USD / 1M chars) | Notes |
+|-------|--------|--------------------------|-------|
+| `tts-kokoro` | 54 | $3.50 | Open‑weights Kokoro 82M. Multilingual (10 languages). Cheapest option. |
+| `tts-xai-v1` | 5 | $5.25 | xAI's voice model. English. |
+| `tts-inworld-1-5-max` | 14 | $12.50 | Inworld TTS‑1.5 Max. Expressive English voices. |
+| `tts-chatterbox-hd` | 9 | $50.00 | Resemble AI's Chatterbox HD. High‑fidelity English. |
+| `tts-orpheus` | 8 | $62.50 | Open‑source Orpheus 3B. Conversational English. |
+| `tts-elevenlabs-turbo-v2-5` | 21 | $62.50 | ElevenLabs Turbo v2.5. Curated multilingual voices. |
+| `tts-qwen3-0-6b` | 9 | $87.50 | Qwen3 TTS 0.6B. English + Chinese. |
+| `tts-qwen3-1-7b` | 9 | $112.50 | Qwen3 TTS 1.7B. Larger Qwen3 variant. |
+| `tts-minimax-speech-02-hd` | 15 | $125.00 | MiniMax Speech‑02 HD. Highly expressive. |
 
-| Voice ID | Description |
-|----------|-------------|
-| `bf_alice` | Female, British English |
-| `bf_emma` | Female, British English |
-| `bf_lily` | Female, British English |
-| `bm_daniel` | Male, British English |
-| `bm_fable` | Male, British English |
-| `bm_george` | Male, British English |
-| `bm_lewis` | Male, British English |
+<Tip>
+Live pricing and capabilities are also rendered in the model browser at the top
+of this page. Pricing on this page is the per‑million‑character rate (USD).
+</Tip>
 
-### Chinese (Mandarin)
+---
 
-| Voice ID | Description |
-|----------|-------------|
-| `zf_xiaobei` | Female, Chinese |
-| `zf_xiaoni` | Female, Chinese |
-| `zf_xiaoxiao` | Female, Chinese |
-| `zf_xiaoyi` | Female, Chinese |
-| `zm_yunjian` | Male, Chinese |
-| `zm_yunxi` | Male, Chinese |
-| `zm_yunxia` | Male, Chinese |
-| `zm_yunyang` | Male, Chinese |
+## Voice catalog
 
-### Japanese
+Pick a model tab to see the voices it supports.
 
-| Voice ID | Description |
-|----------|-------------|
-| `jf_alpha` | Female, Japanese |
-| `jf_gongitsune` | Female, Japanese |
-| `jf_nezumi` | Female, Japanese |
-| `jf_tebukuro` | Female, Japanese |
-| `jm_kumo` | Male, Japanese |
+<Tabs>
+  <Tab title="Kokoro (54)">
+    **Model ID:** `tts-kokoro` · **Languages:** 10 · **Pricing:** $3.50 / 1M chars
 
-### French
+    Kokoro voice IDs follow the pattern `<lang><gender>_<name>` — e.g. `af_*`
+    is American Female, `bm_*` is British Male, `zf_*` is Chinese Female.
 
-| Voice ID | Description |
-|----------|-------------|
-| `ff_siwis` | Female, French |
+    #### American English
 
-### Hindi
+    | Voice ID | Description |
+    |----------|-------------|
+    | `af_alloy` | Female, American English |
+    | `af_aoede` | Female, American English |
+    | `af_bella` | Female, American English |
+    | `af_heart` | Female, American English |
+    | `af_jadzia` | Female, American English |
+    | `af_jessica` | Female, American English |
+    | `af_kore` | Female, American English |
+    | `af_nicole` | Female, American English |
+    | `af_nova` | Female, American English |
+    | `af_river` | Female, American English |
+    | `af_sarah` | Female, American English |
+    | `af_sky` | Female, American English (default) |
+    | `am_adam` | Male, American English |
+    | `am_echo` | Male, American English |
+    | `am_eric` | Male, American English |
+    | `am_fenrir` | Male, American English |
+    | `am_liam` | Male, American English |
+    | `am_michael` | Male, American English |
+    | `am_onyx` | Male, American English |
+    | `am_puck` | Male, American English |
+    | `am_santa` | Male, American English |
 
-| Voice ID | Description |
-|----------|-------------|
-| `hf_alpha` | Female, Hindi |
-| `hf_beta` | Female, Hindi |
-| `hm_omega` | Male, Hindi |
-| `hm_psi` | Male, Hindi |
+    #### British English
 
-### Italian
+    | Voice ID | Description |
+    |----------|-------------|
+    | `bf_alice` | Female, British English |
+    | `bf_emma` | Female, British English |
+    | `bf_lily` | Female, British English |
+    | `bm_daniel` | Male, British English |
+    | `bm_fable` | Male, British English |
+    | `bm_george` | Male, British English |
+    | `bm_lewis` | Male, British English |
 
-| Voice ID | Description |
-|----------|-------------|
-| `if_sara` | Female, Italian |
-| `im_nicola` | Male, Italian |
+    #### Chinese (Mandarin)
 
-### Portuguese (Brazilian)
+    | Voice ID | Description |
+    |----------|-------------|
+    | `zf_xiaobei` | Female, Chinese |
+    | `zf_xiaoni` | Female, Chinese |
+    | `zf_xiaoxiao` | Female, Chinese |
+    | `zf_xiaoyi` | Female, Chinese |
+    | `zm_yunjian` | Male, Chinese |
+    | `zm_yunxi` | Male, Chinese |
+    | `zm_yunxia` | Male, Chinese |
+    | `zm_yunyang` | Male, Chinese |
 
-| Voice ID | Description |
-|----------|-------------|
-| `pf_dora` | Female, Portuguese |
-| `pm_alex` | Male, Portuguese |
-| `pm_santa` | Male, Portuguese |
+    #### Japanese
 
-### Spanish
+    | Voice ID | Description |
+    |----------|-------------|
+    | `jf_alpha` | Female, Japanese |
+    | `jf_gongitsune` | Female, Japanese |
+    | `jf_nezumi` | Female, Japanese |
+    | `jf_tebukuro` | Female, Japanese |
+    | `jm_kumo` | Male, Japanese |
 
-| Voice ID | Description |
-|----------|-------------|
-| `ef_dora` | Female, Spanish |
-| `em_alex` | Male, Spanish |
-| `em_santa` | Male, Spanish |
+    #### Spanish
+
+    | Voice ID | Description |
+    |----------|-------------|
+    | `ef_dora` | Female, Spanish |
+    | `em_alex` | Male, Spanish |
+    | `em_santa` | Male, Spanish |
+
+    #### French
+
+    | Voice ID | Description |
+    |----------|-------------|
+    | `ff_siwis` | Female, French |
+
+    #### Hindi
+
+    | Voice ID | Description |
+    |----------|-------------|
+    | `hf_alpha` | Female, Hindi |
+    | `hf_beta` | Female, Hindi |
+    | `hm_omega` | Male, Hindi |
+    | `hm_psi` | Male, Hindi |
+
+    #### Italian
+
+    | Voice ID | Description |
+    |----------|-------------|
+    | `if_sara` | Female, Italian |
+    | `im_nicola` | Male, Italian |
+
+    #### Portuguese (Brazilian)
+
+    | Voice ID | Description |
+    |----------|-------------|
+    | `pf_dora` | Female, Portuguese |
+    | `pm_alex` | Male, Portuguese |
+    | `pm_santa` | Male, Portuguese |
+  </Tab>
+
+  <Tab title="ElevenLabs Turbo v2.5 (21)">
+    **Model ID:** `tts-elevenlabs-turbo-v2-5` · **Pricing:** $62.50 / 1M chars
+
+    Curated voices from the ElevenLabs library. See the
+    [ElevenLabs voice library](https://elevenlabs.io/app/voice-library) for
+    sample previews and language coverage.
+
+    | Voice ID |
+    |----------|
+    | `Alice` |
+    | `Aria` |
+    | `Bill` |
+    | `Brian` |
+    | `Callum` |
+    | `Charlie` |
+    | `Charlotte` |
+    | `Chris` |
+    | `Daniel` |
+    | `Eric` |
+    | `George` |
+    | `Jessica` |
+    | `Laura` |
+    | `Liam` |
+    | `Lily` |
+    | `Matilda` |
+    | `Rachel` |
+    | `River` |
+    | `Roger` |
+    | `Sarah` |
+    | `Will` |
+  </Tab>
+
+  <Tab title="MiniMax Speech-02 HD (15)">
+    **Model ID:** `tts-minimax-speech-02-hd` · **Pricing:** $125.00 / 1M chars
+
+    MiniMax voice names describe the persona / style directly.
+
+    | Voice ID |
+    |----------|
+    | `CalmWoman` |
+    | `CasualGuy` |
+    | `DeepVoiceMan` |
+    | `DeterminedMan` |
+    | `ElegantMan` |
+    | `ExuberantGirl` |
+    | `FriendlyPerson` |
+    | `ImposingManner` |
+    | `InspirationalGirl` |
+    | `LivelyGirl` |
+    | `LovelyGirl` |
+    | `PatientMan` |
+    | `SweetGirl` |
+    | `WiseWoman` |
+    | `YoungKnight` |
+  </Tab>
+
+  <Tab title="Inworld TTS-1.5 Max (14)">
+    **Model ID:** `tts-inworld-1-5-max` · **Pricing:** $12.50 / 1M chars
+
+    Expressive English voices from Inworld AI.
+
+    | Voice ID |
+    |----------|
+    | `Alex` |
+    | `Ashley` |
+    | `Craig` |
+    | `Edward` |
+    | `Elizabeth` |
+    | `Hades` |
+    | `Luna` |
+    | `Mark` |
+    | `Olivia` |
+    | `Pixie` |
+    | `Priya` |
+    | `Ronald` |
+    | `Sarah` |
+    | `Theodore` |
+  </Tab>
+
+  <Tab title="Chatterbox HD (9)">
+    **Model ID:** `tts-chatterbox-hd` · **Pricing:** $50.00 / 1M chars
+
+    High‑fidelity English voices from Resemble AI's Chatterbox HD.
+
+    | Voice ID |
+    |----------|
+    | `Aurora` |
+    | `Blade` |
+    | `Britney` |
+    | `Carl` |
+    | `Cliff` |
+    | `Richard` |
+    | `Rico` |
+    | `Siobhan` |
+    | `Vicky` |
+  </Tab>
+
+  <Tab title="Qwen3 TTS (9)">
+    **Model IDs:** `tts-qwen3-0-6b` (0.6B) · `tts-qwen3-1-7b` (1.7B)
+    **Pricing:** $87.50 / 1M chars (0.6B) · $112.50 / 1M chars (1.7B)
+
+    Both Qwen3 TTS variants share the same voice catalog. The 1.7B variant
+    produces higher‑quality output at a higher per‑character rate.
+
+    | Voice ID |
+    |----------|
+    | `Aiden` |
+    | `Dylan` |
+    | `Eric` |
+    | `Ono_Anna` |
+    | `Ryan` |
+    | `Serena` |
+    | `Sohee` |
+    | `Uncle_Fu` |
+    | `Vivian` |
+  </Tab>
+
+  <Tab title="Orpheus (8)">
+    **Model ID:** `tts-orpheus` · **Pricing:** $62.50 / 1M chars
+
+    Conversational English voices from the open‑source Orpheus 3B model.
+
+    | Voice ID |
+    |----------|
+    | `dan` |
+    | `jess` |
+    | `leah` |
+    | `leo` |
+    | `mia` |
+    | `tara` |
+    | `zac` |
+    | `zoe` |
+  </Tab>
+
+  <Tab title="xAI TTS v1 (5)">
+    **Model ID:** `tts-xai-v1` · **Pricing:** $5.25 / 1M chars
+
+    English voices from xAI's TTS v1 model.
+
+    | Voice ID |
+    |----------|
+    | `ara` |
+    | `eve` |
+    | `leo` |
+    | `rex` |
+    | `sal` |
+  </Tab>
+</Tabs>
 
 <Note>
-Voice is selected using the `voice` parameter in the request payload. See the [Audio Speech API](/api-reference/endpoint/audio/speech) for usage examples.
+Voice IDs are case‑sensitive and **only valid for the matching `model`**. Pass
+both fields together in your request payload — see the
+[Audio Speech API](/api-reference/endpoint/audio/speech) for examples.
 </Note>
+
+### Example request
+
+```bash
+curl https://api.venice.ai/api/v1/audio/speech \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "tts-kokoro",
+    "voice": "af_sky",
+    "input": "Hello from Venice."
+  }' \
+  --output speech.mp3
+```
+
+To switch models, change **both** `model` and `voice` to a pair listed under
+the same tab above.

--- a/style.css
+++ b/style.css
@@ -1502,3 +1502,251 @@
     line-height: 1.5;
   }
 }
+
+/* ===== TTS Voice Picker ===== */
+
+#tts-voice-picker-placeholder {
+  visibility: visible !important;
+  overflow: visible !important;
+  height: auto !important;
+}
+
+.vtp-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 8px;
+  font-family: inherit;
+}
+
+.vtp-row-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(180px, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 640px) {
+  .vtp-row-controls {
+    grid-template-columns: 1fr;
+  }
+}
+
+.vtp-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.vtp-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.vtp-model-select,
+.vtp-search {
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 14px;
+  font-family: inherit;
+  color: inherit;
+  background: rgba(128,128,128,0.06);
+  border: 1px solid rgba(128,128,128,0.25);
+  border-radius: 8px;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.vtp-model-select {
+  font-weight: 500;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 36px;
+}
+
+.vtp-model-select:focus,
+.vtp-search:focus {
+  border-color: rgba(128,128,128,0.45);
+  background-color: rgba(128,128,128,0.09);
+}
+
+.vtp-search::placeholder {
+  color: rgba(128,128,128,0.55);
+}
+
+.vtp-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.vtp-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.vtp-pill {
+  display: inline-flex;
+  align-items: center;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(128,128,128,0.1);
+  color: inherit;
+  white-space: nowrap;
+}
+
+.vtp-pill code {
+  font-size: 12px;
+  background: none;
+  padding: 0;
+  border: none;
+  color: inherit;
+}
+
+.vtp-pill-id {
+  background: rgba(221, 51, 0, 0.1);
+  color: #DD3300;
+}
+
+.vtp-blurb {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.75;
+}
+
+.vtp-list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-top: 4px;
+}
+
+.vtp-list-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.vtp-count {
+  font-size: 12px;
+  opacity: 0.55;
+  white-space: nowrap;
+}
+
+.vtp-voice-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(128,128,128,0.18);
+  border-radius: 10px;
+  overflow: hidden;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.vtp-voice {
+  display: grid;
+  grid-template-columns: minmax(140px, max-content) 1fr auto;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  padding: 10px 14px;
+  border: none;
+  border-bottom: 1px solid rgba(128,128,128,0.12);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.vtp-voice:last-child {
+  border-bottom: none;
+}
+
+.vtp-voice:hover {
+  background: rgba(128,128,128,0.06);
+}
+
+.vtp-voice:focus-visible {
+  outline: 2px solid #DD3300;
+  outline-offset: -2px;
+}
+
+.vtp-voice-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.vtp-voice-meta {
+  font-size: 13px;
+  opacity: 0.6;
+  min-width: 0;
+}
+
+.vtp-voice-action {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  position: relative;
+  color: rgba(128,128,128,0.7);
+}
+
+.vtp-voice:hover .vtp-voice-action {
+  opacity: 1;
+}
+
+.vtp-action-copied {
+  display: none;
+}
+
+.vtp-voice.copied .vtp-voice-action {
+  opacity: 1;
+  color: #DD3300;
+}
+
+.vtp-voice.copied .vtp-action-copy {
+  display: none;
+}
+
+.vtp-voice.copied .vtp-action-copied {
+  display: inline;
+}
+
+.vtp-empty {
+  padding: 24px;
+  text-align: center;
+  font-size: 13px;
+  opacity: 0.55;
+}
+
+.vtp-hint {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.55;
+  line-height: 1.5;
+}
+
+.vtp-hint code {
+  font-size: 12px;
+  background: rgba(128,128,128,0.1);
+  padding: 1px 5px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary

Today the [Text-to-Speech models page](https://docs.venice.ai/models/text-to-speech) only documents Kokoro voices, even though Venice exposes 9 different TTS models — and **voice IDs are model-specific**. This makes the page misleading: pick `tts-elevenlabs-turbo-v2-5` with `af_sky` and the API rejects the request with no easy way to discover what's actually valid for that model.

This PR restructures the page so the voice catalog is organized **per model**:

- New "Models at a glance" summary table at the top with each model's voice count and per-million-character pricing — so users can pick a model based on language, price, and selection size before drilling in.
- Replaces the single static voices section with a Mintlify `<Tabs>` block, one tab per model, listing only the voice IDs valid for that model.
  - Kokoro keeps the language sub-grouping (American English, British English, Chinese, etc.) since 54 voices warrants it.
  - Smaller models (ElevenLabs, MiniMax, Inworld, Chatterbox, Orpheus, Qwen3, xAI) get compact ID-only tables — for several of these the voice name is already the description (e.g. MiniMax's `CalmWoman`, `DeepVoiceMan`).
- Adds a brief intro that explicitly calls out the model/voice pairing rule.
- Adds a short `curl` example and a `<Note>` callout reminding readers to switch **both** `model` and `voice` together.

The dynamic model browser at the top of the page (`<div id="model-search-placeholder" data-filter="tts">`) is unchanged, so the live, API-driven cards still render above this static reference.

## Test plan

- [ ] Mintlify build passes locally / preview deploy renders the page without errors.
- [ ] Each tab displays the correct voice list (cross-checked against `GET /api/v1/models?type=tts`).
- [ ] Switching tabs updates the voice catalog as expected on desktop and mobile widths.
- [ ] "Models at a glance" pricing matches the live API pricing for each TTS model.
- [ ] Internal link to `/api-reference/endpoint/audio/speech` still resolves.
