### PR TITLE
docs(pricing): drop output column for embeddings, rename label

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -571,8 +571,7 @@
           <div class="vpt-row-right">${privacyTag}</div>
         </div>
         <div class="vpt-row-bottom">
-          <span class="vpt-price-item"><span class="vpt-price-label">Input (per 1M tokens)</span><span class="vpt-price-value">${formatPrice(pricing.input?.usd)}</span></span>
-          <span class="vpt-price-item"><span class="vpt-price-label">Output (per 1M tokens)</span><span class="vpt-price-value">${formatPrice(pricing.output?.usd)}</span></span>
+          <span class="vpt-price-item"><span class="vpt-price-label">Per 1M tokens</span><span class="vpt-price-value">${formatPrice(pricing.input?.usd)}</span></span>
         </div>
       </div>`;
     }).join('');
@@ -1915,6 +1914,8 @@
           priceStr = `${formatPrice(pricing.generation.usd)}/image`;
         } else if (model.type === 'inpaint' && pricing.inpaint) {
           priceStr = `${formatPrice(pricing.inpaint.usd)}/edit`;
+        } else if (model.type === 'embedding' && pricing.input) {
+          priceStr = `${formatPrice(pricing.input.usd)}/M tokens`;
         } else if (pricing.input && pricing.output) {
           priceStr = `${formatPrice(pricing.input.usd)}/M input <span class="vmb-pipe">|</span> ${formatPrice(pricing.output.usd)}/M output`;
           if (pricing.cache_input?.usd && pricing.cache_write?.usd) {

--- a/overview/pricing.mdx
+++ b/overview/pricing.mdx
@@ -85,9 +85,9 @@ Prices per 1M tokens unless noted. All prices in USD. 1 Diem = $1/day of compute
 
 <div id="pricing-embedding-placeholder">
 
-| Model | ID | Input (per 1M tokens) | Output (per 1M tokens) | Privacy |
-|---|---|---|---|---|
-| BGE-M3 | `text-embedding-bge-m3` | $0.15 | $0.60 | Private |
+| Model | ID | Per 1M tokens | Privacy |
+|---|---|---|---|
+| BGE-M3 | `text-embedding-bge-m3` | $0.15 | Private |
 
 </div>
 


### PR DESCRIPTION
## Summary

Embeddings only consume input tokens, so the embeddings pricing UI showing both `Input (per 1M tokens)` and `Output (per 1M tokens)` columns was misleading. Most providers (OpenAI, Cohere, Voyage) just label embedding pricing as "per 1M tokens" without an input/output distinction since it doesn't apply.

This PR:

- **Drops the Output column** from the embeddings pricing tables (both the dynamic `renderPricingEmbeddingTable` in `model-search.js` and the static fallback in `overview/pricing.mdx`).
- **Renames `Input (per 1M tokens)` to `Per 1M tokens`** to match how OpenAI / Cohere / Voyage label embedding pricing.
- **Adds an embedding-specific branch to the model card pricing logic** so embeddings on the `/models` browser stop rendering as `$X/M input | $Y/M output` (which they were, by falling through to the generic chat-model branch). They now render as `$X/M tokens`.

The underlying `pricing.output` field on each embedding model is left untouched in the API/cache data; it's just no longer surfaced in the UI.

## Test plan

- [ ] `/overview/pricing` Embeddings table renders with three columns (Model, ID, Per 1M tokens, Privacy) and no Output column.
- [ ] `/models` browser embedding cards show `$X/M tokens` instead of `$X/M input | $Y/M output`.
- [ ] BGE-M3 still shows $0.15 (the previous "Input" price), other embedding models (Qwen3, BGE-EN-ICL, Nemotron, OpenAI text-embedding-3-*, Gemini Embedding) all show their correct token price.
- [ ] No JS errors in the console on either page.
