### PR TITLE
refactor: rename Augment → Tools, consolidate crypto RPC

### DIFF
--- a/api-reference/endpoint/crypto/networks.mdx
+++ b/api-reference/endpoint/crypto/networks.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'List Crypto RPC Networks'
+title: 'Crypto Networks'
 openapi: 'GET /crypto/rpc/networks'
-"og:title": "List Crypto RPC Networks | Venice API Docs"
+"og:title": "Crypto Networks | Venice API Docs"
 "og:description": "Returns the sorted list of blockchain network slugs supported by the Venice crypto RPC proxy."
 ---
 

--- a/api-reference/endpoint/crypto/rpc.mdx
+++ b/api-reference/endpoint/crypto/rpc.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Crypto RPC Proxy'
+title: 'Crypto RPC'
 openapi: 'POST /crypto/rpc/{network}'
-"og:title": "Crypto RPC Proxy | Venice API Docs"
+"og:title": "Crypto RPC | Venice API Docs"
 "og:description": "Proxy a JSON-RPC request to a supported blockchain node. Pay per credit with no separate RPC-provider signup required."
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -151,11 +151,13 @@
                 ]
               },
               {
-                "group": "Augment",
+                "group": "Tools",
                 "pages": [
                   "api-reference/endpoint/augment/text-parser",
                   "api-reference/endpoint/augment/scrape",
-                  "api-reference/endpoint/augment/search"
+                  "api-reference/endpoint/augment/search",
+                  "api-reference/endpoint/crypto/networks",
+                  "api-reference/endpoint/crypto/rpc"
                 ]
               },
               {
@@ -213,13 +215,6 @@
                   "api-reference/endpoint/x402/balance",
                   "api-reference/endpoint/x402/top-up",
                   "api-reference/endpoint/x402/transactions"
-                ]
-              },
-              {
-                "group": "Crypto RPC",
-                "pages": [
-                  "api-reference/endpoint/crypto/networks",
-                  "api-reference/endpoint/crypto/rpc"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary

- Rename "Augment" navigation group to "Tools" for clarity
- Move Crypto Networks and Crypto RPC into the Tools group
- Shorten page titles to "Crypto Networks" and "Crypto RPC"

The new navigation:

```
Tools
├── Text Parser
├── Scrape
├── Search
├── Crypto Networks
└── Crypto RPC
```

Made with [Cursor](https://cursor.com)