### PR TITLE
docs(crypto-rpc): add Authentication section with x402 support

### DIFF
--- a/api-reference/endpoint/crypto/rpc.mdx
+++ b/api-reference/endpoint/crypto/rpc.mdx
@@ -5,7 +5,16 @@ openapi: 'POST /crypto/rpc/{network}'
 "og:description": "Proxy a JSON-RPC request to a supported blockchain node. Pay per credit with no separate RPC-provider signup required."
 ---
 
-Forward a JSON-RPC 2.0 request (single or batch) to a supported blockchain node. Billing is per credit and denominated in your Venice balance — one API key, one invoice, every chain below.
+Forward a JSON-RPC 2.0 request (single or batch) to a supported blockchain node. Supports both API key and x402 wallet authentication. Billing is per credit and denominated in your Venice balance — one credential, one invoice, every chain below.
+
+## Authentication
+
+This endpoint supports two authentication methods:
+
+- **API Key**: Standard Bearer token authentication via the `Authorization: Bearer <key>` header.
+- **x402 Wallet**: Pay-as-you-go with USDC credits from your Ethereum wallet — no Venice account required. See the [x402 guide](/overview/guides/x402-venice-api) for setup.
+
+Both methods share the same rate limits and billing (Venice credits).
 
 ## Supported networks
 


### PR DESCRIPTION
## Summary

Add Authentication section to the Crypto RPC documentation, documenting both authentication methods:

- **API Key**: Standard Bearer token authentication
- **x402 Wallet**: Pay-as-you-go with USDC credits from Ethereum wallet

This matches the dual-auth pattern used by other Venice inference endpoints (chat, image, audio, video).

## Changes

- Add Authentication section to `api-reference/endpoint/crypto/rpc.mdx`
- Update intro to mention dual auth support
- Link to x402 guide for setup details

Made with [Cursor](https://cursor.com)