### PR TITLE
docs: update llms.txt with Responses API and missing guides

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,7 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 ### Text & Chat
 - [API Specification](https://docs.venice.ai/api-reference/api-spec): Complete API specification with Venice-specific parameters
 - [Chat Completions](https://docs.venice.ai/api-reference/endpoint/chat/completions): Text generation endpoint with streaming, vision, audio input, video input, and tool calling
+- [Responses API (Alpha)](https://docs.venice.ai/api-reference/api-spec): OpenAI-compatible `POST /responses` endpoint with typed output blocks for reasoning, messages, function calls, and web search. Stateless, supports streaming via SSE, API key or x402 wallet auth. E2EE models not supported — use `/chat/completions` instead.
 - [Model Feature Suffixes](https://docs.venice.ai/api-reference/endpoint/chat/model_feature_suffix): Enable features via model name suffixes (e.g., `model-name:web` for web search)
 
 ### Image
@@ -108,8 +109,11 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Image Generation Guide](https://docs.venice.ai/overview/guides/image-generation): Best practices for image generation
 - [Image Editing Guide](https://docs.venice.ai/overview/guides/image-editing): Image editing and inpainting techniques
 - [Video Generation Guide](https://docs.venice.ai/overview/guides/video-generation): Video generation best practices
+- [Reference to Video](https://docs.venice.ai/overview/guides/reference-to-video): Lock in characters, objects, and scenes across AI video generations using reference images on Kling O3 and Grok Imagine R2V
+- [Video Upscaling](https://docs.venice.ai/overview/guides/video-upscaling): Enhance existing videos to higher resolution (2x/4x) or quality using the Topaz Video Upscale model
 - [x402 Wallet API](https://docs.venice.ai/overview/guides/x402-venice-api): Use Venice API with Ethereum wallet authentication (no API key required)
 - [AI Agents](https://docs.venice.ai/overview/guides/ai-agents): Build autonomous agents with Eliza framework
+- [Autonomous Agent API Key Creation](https://docs.venice.ai/overview/guides/generating-api-key-agent): Let agents programmatically mint their own Venice API key by staking VVV on Base — no human interaction required
 - [LangChain Integration](https://docs.venice.ai/overview/guides/langchain): Use Venice with LangChain
 - [Vercel AI SDK](https://docs.venice.ai/overview/guides/vercel-ai-sdk): Use Venice with Vercel AI SDK
 - [CrewAI Integration](https://docs.venice.ai/overview/guides/crewai): Use Venice with CrewAI
@@ -117,6 +121,8 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Claude Code](https://docs.venice.ai/overview/guides/claude-code): Use Venice with Claude Code CLI
 - [Cursor IDE](https://docs.venice.ai/overview/guides/cursor): Use Venice with Cursor IDE
 - [Codex CLI](https://docs.venice.ai/overview/guides/codex-cli): Use Venice with OpenAI Codex CLI
+- [OpenClaw](https://docs.venice.ai/overview/guides/openclaw-bot): Self-hosted AI gateway connecting Venice to WhatsApp, Telegram, Discord, iMessage, and Slack
+- [NanoClaw](https://docs.venice.ai/overview/guides/nanoclaw-venice): Lightweight self-hosted personal AI assistant for WhatsApp and Telegram powered by Venice
 - [Integrations](https://docs.venice.ai/overview/guides/integrations): Third-party integrations (Brave Leo, etc.)
 - [Postman Collection](https://docs.venice.ai/overview/guides/postman): Import ready-to-use API examples
 


### PR DESCRIPTION
Adds the Alpha POST /responses endpoint under Text and Chat, plus five guides that were already in docs.json but missing from llms.txt: Reference to Video, Video Upscaling, Autonomous Agent API Key Creation, OpenClaw, and NanoClaw.