### PR TITLE
docs(crypto-rpc): remove daily credit cap from rate limits

### DIFF
--- a/api-reference/endpoint/crypto/rpc.mdx
+++ b/api-reference/endpoint/crypto/rpc.mdx
@@ -115,14 +115,14 @@ The first item (success) bills 20 credits, the second (RPC-level error) bills 5,
 
 ## Rate limits
 
-Two caps apply per authenticated caller:
+Per-minute request cap per authenticated caller:
 
-| Tier | Requests/minute | Credits per 24h |
-|---|---|---|
-| Standard | 100 | 10,000,000 (~$6.25 cap) |
-| Staff | 1,000 | 100,000,000 |
+| Tier | Requests/minute |
+|---|---|
+| Standard | 100 |
+| Staff | 1,000 |
 
-When either cap is exceeded the endpoint returns `429` with a `customMessage` identifying which cap tripped. The per-minute cap also sets the standard `X-RateLimit-*` response headers.
+When the cap is exceeded the endpoint returns `429` with a `customMessage` and standard `X-RateLimit-*` response headers.
 
 ## Idempotency
 


### PR DESCRIPTION
## Summary

- Update rate limits section to remove daily credit cap (removed in outerface PR #6487)
- Only per-minute rate limiting remains (100 rpm standard, 1000 rpm staff)

## Related

- veniceai/outerface#6487

Made with [Cursor](https://cursor.com)