### PR TITLE
docs: add Hermes Agent with Venice guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -32,6 +32,7 @@
             "pages": [
               "overview/guides/ai-agents",
               "overview/guides/openclaw-bot",
+              "overview/guides/hermes-agent",
               "overview/guides/nanoclaw-venice",
               "overview/guides/x402-venice-api",
               "overview/guides/integrations"

--- a/llms.txt
+++ b/llms.txt
@@ -122,6 +122,7 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Cursor IDE](https://docs.venice.ai/overview/guides/cursor): Use Venice with Cursor IDE
 - [Codex CLI](https://docs.venice.ai/overview/guides/codex-cli): Use Venice with OpenAI Codex CLI
 - [OpenClaw](https://docs.venice.ai/overview/guides/openclaw-bot): Self-hosted AI gateway connecting Venice to WhatsApp, Telegram, Discord, iMessage, and Slack
+- [Hermes Agent](https://docs.venice.ai/overview/guides/hermes-agent): Self-improving AI agent by Nous Research with persistent memory, skills, and 15+ messaging platforms, powered by Venice as a custom provider
 - [NanoClaw](https://docs.venice.ai/overview/guides/nanoclaw-venice): Lightweight self-hosted personal AI assistant for WhatsApp and Telegram powered by Venice
 - [Integrations](https://docs.venice.ai/overview/guides/integrations): Third-party integrations (Brave Leo, etc.)
 - [Postman Collection](https://docs.venice.ai/overview/guides/postman): Import ready-to-use API examples

--- a/overview/guides/hermes-agent.mdx
+++ b/overview/guides/hermes-agent.mdx
@@ -1,0 +1,205 @@
+---
+title: Hermes Agent
+description: Use Venice AI as your model provider in Hermes Agent
+"og:title": "Hermes Agent with Venice | Venice API Docs"
+"og:description": "Set up Venice AI as a provider in Hermes Agent for privacy-focused, uncensored AI with persistent memory, skills, and multi-platform messaging."
+---
+
+[Hermes Agent](https://hermes-agent.nousresearch.com) is an open-source, self-hosted AI agent built by [Nous Research](https://nousresearch.com). It features persistent memory, autonomous skill creation, and a built-in learning loop that gets more capable the longer it runs. Point it at the Venice API and your agent gets access to 230+ models and tools across text, image, video, audio, embeddings, and more.
+
+<Card title="Hermes Agent Docs" icon="arrow-up-right-from-square" href="https://hermes-agent.nousresearch.com/docs/">
+  Full documentation, provider setup, and configuration options on the official Hermes Agent docs.
+</Card>
+
+## Why Venice + Hermes Agent?
+
+The Venice API gives your Hermes Agent access to the full Venice platform through a single OpenAI-compatible endpoint.
+
+| Capability | What you get |
+|---|---|
+| **Text and chat** | Private and anonymized models (GLM, Qwen, Claude, GPT, and more) |
+| **Image** | Generation, editing, upscaling, and background removal |
+| **Video** | Generation and transcription |
+| **Audio** | Speech synthesis (TTS), music generation, and speech-to-text |
+| **Embeddings** | Vector embeddings for RAG and semantic search |
+| **Tools** | Web scraping, web search, text parsing, and crypto RPC |
+
+<CardGroup cols={3}>
+  <Card title="Private Inference" icon="shield-halved">
+    Zero data retention. Prompts are never stored or logged
+  </Card>
+  <Card title="Persistent Memory" icon="brain">
+    Hermes remembers context across sessions and restarts
+  </Card>
+  <Card title="15+ Platforms" icon="comments">
+    Reach your agent on Telegram, Discord, Slack, WhatsApp, and more
+  </Card>
+</CardGroup>
+
+## Setup
+
+### 1. Install Hermes Agent
+
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+    ```
+  </Tab>
+
+  <Tab title="WSL2 (Windows)">
+    Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) first, then run the same command:
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+    ```
+  </Tab>
+</Tabs>
+
+After installation, reload your shell:
+
+```bash
+source ~/.zshrc   # or: source ~/.bashrc
+```
+
+### 2. Configure Venice as your provider
+
+Run the model setup wizard:
+
+```bash
+hermes model
+```
+
+Select **Custom endpoint (self-hosted / VLLM / etc.)** and enter the following when prompted:
+
+| Field | Value |
+|---|---|
+| **API base URL** | `https://api.venice.ai/api/v1` |
+| **API key** | Your Venice API key |
+| **Model name** | A Venice model ID (see below) |
+
+Get an API key from [venice.ai/settings/api](https://venice.ai/settings/api) if you don't have one yet.
+
+<Tip>
+You can also configure Venice directly in `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  default: zai-org-glm-5
+  provider: custom
+  base_url: https://api.venice.ai/api/v1
+  api_key: ${VENICE_API_KEY}
+```
+
+And set the key in `~/.hermes/.env`:
+
+```bash
+VENICE_API_KEY=your-key-here
+```
+</Tip>
+
+### 3. Pick a model
+
+When the wizard asks for a model, choose one based on your use case:
+
+| Use case | Model | Privacy |
+|---|---|---|
+| General | `zai-org-glm-5` | Private |
+| Reasoning | `kimi-k2-5` | Private |
+| Coding | `claude-opus-4-6` | Anonymized |
+| Vision | `qwen3-vl-235b-a22b` | Private |
+| Uncensored | `venice-uncensored` | Private |
+
+Change your model anytime with no restart needed:
+
+```bash
+hermes model              # full wizard
+```
+
+Or switch mid-session:
+
+```text
+/model custom:claude-opus-4-6
+```
+
+### 4. Start chatting
+
+Open the classic CLI or the modern TUI:
+
+```bash
+hermes            # classic CLI
+hermes --tui      # modern TUI (recommended)
+```
+
+Try a prompt to verify everything works:
+
+```text
+Summarize this repo in 5 bullets and tell me what the main entrypoint is.
+```
+
+## Connect messaging platforms
+
+Once the CLI works, connect your messaging apps through the gateway:
+
+```bash
+hermes gateway setup
+```
+
+This walks you through connecting Telegram, Discord, Slack, WhatsApp, Signal, and other platforms. Your agent becomes reachable from any connected channel, all powered by Venice.
+
+```bash
+hermes gateway      # start the messaging gateway
+```
+
+## Privacy modes
+
+Venice models in Hermes Agent follow the same [privacy tiers](/overview/privacy) as the Venice API:
+
+- **Private** models (GLM, Qwen, DeepSeek, Llama, Venice Uncensored) run on Venice's GPU fleet. Prompts are never stored or logged.
+- **Anonymized** models (Claude, GPT, Gemini, Grok) are proxied through Venice with all identifying information stripped. The third-party provider sees Venice as the customer, not you.
+
+## Venice API skills
+
+Hermes Agent has a built-in skills system compatible with the [Agent Skills](https://github.com/veniceai/skills) format. Venice publishes official skills that teach your agent how to use every Venice endpoint (chat, image generation, video, audio, embeddings, augment tools, and more).
+
+Install Venice skills directly from GitHub:
+
+```bash
+hermes skills install veniceai/skills
+```
+
+Or search for individual skills:
+
+```bash
+hermes skills search venice
+```
+
+Hermes will discover each skill by its `SKILL.md` frontmatter and load it on demand.
+
+## Key commands
+
+| Command | Description |
+|---|---|
+| `hermes` | Start chatting |
+| `hermes model` | Change provider or model |
+| `hermes tools` | Configure which tools are enabled |
+| `hermes gateway` | Start the messaging gateway |
+| `hermes --continue` | Resume your last session |
+| `hermes doctor` | Diagnose issues |
+| `hermes update` | Update to the latest version |
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Hermes Agent Docs" icon="book" href="https://hermes-agent.nousresearch.com/docs/">
+    Official documentation
+  </Card>
+  <Card title="GitHub" icon="github" href="https://github.com/NousResearch/hermes-agent">
+    Source code and releases
+  </Card>
+  <Card title="Venice Model Catalog" icon="list" href="/models/text">
+    Browse available models
+  </Card>
+  <Card title="Venice Privacy" icon="shield-halved" href="/overview/privacy">
+    How Venice protects your data
+  </Card>
+</CardGroup>

--- a/overview/guides/hermes-agent.mdx
+++ b/overview/guides/hermes-agent.mdx
@@ -104,10 +104,10 @@ When the wizard asks for a model, choose one based on your use case:
 | Use case | Model | Privacy |
 |---|---|---|
 | General | `zai-org-glm-5` | Private |
-| Reasoning | `kimi-k2-5` | Private |
-| Coding | `claude-opus-4-6` | Anonymized |
-| Vision | `qwen3-vl-235b-a22b` | Private |
-| Uncensored | `venice-uncensored` | Private |
+| Reasoning | `kimi-k2-6` | Private |
+| Coding | `claude-opus-4-7` | Anonymized |
+| Vision | `z-ai-glm-5v-turbo` | Anonymized |
+| Uncensored | `venice-uncensored-1-2` | Private |
 
 Change your model anytime with no restart needed:
 
@@ -118,7 +118,7 @@ hermes model              # full wizard
 Or switch mid-session:
 
 ```text
-/model custom:claude-opus-4-6
+/model custom:claude-opus-4-7
 ```
 
 ### 4. Start chatting


### PR DESCRIPTION
New guide for using Venice AI as a provider in Hermes Agent (Nous Research). Covers installation, custom endpoint setup, model recommendations, messaging gateway, privacy modes, and Venice API skills integration.

Made-with: Cursor