### PR TITLE
docs(pricing): clarify Flux 2 Max Edit per-megapixel upstream cost

### DIFF
--- a/overview/pricing.mdx
+++ b/overview/pricing.mdx
@@ -162,7 +162,7 @@ Prices per 1M tokens unless noted. All prices in USD. 1 Diem = $1/day of compute
 | Model | ID | Per Edit |
 |---|---|---|
 | FireRed Image Edit 1.1 | `firered-image-edit` | $0.04 |
-| Flux 2 Max | `flux-2-max-edit` | $0.19 |
+| Flux 2 Max | `flux-2-max-edit` | $0.19 [^flux2max-edit-billing] |
 | GPT Image 1.5 | `gpt-image-1-5-edit` | $0.36 |
 | GPT Image 2 | `gpt-image-2-edit` | $0.35 |
 | Grok Imagine | `grok-imagine-edit` | $0.03 |
@@ -175,6 +175,14 @@ Prices per 1M tokens unless noted. All prices in USD. 1 Diem = $1/day of compute
 | Seedream V5 Lite | `seedream-v5-lite-edit` | $0.05 |
 | Wan 2.7 Pro Edit | `wan-2-7-pro-edit` | $0.09 |
 | Qwen Image | `qwen-image` | $0.04 |
+
+[^flux2max-edit-billing]: Flux 2 Max upstream pricing (FAL) is `$0.07` for the first processed
+megapixel and `$0.03` for each additional processed megapixel, with every input image counted as
+a processed megapixel (FAL defines 1 MP = 1024×1024 and rounds up to the next MP per image).
+Venice pre-resizes each input image to stay at or under 1 MP, so the effective upstream cost
+scales as `1 input → $0.10`, `2 inputs → $0.13`, `3 inputs → $0.16`. The `$0.19` flat API price
+shown above covers the worst case (3 inputs); use the
+[Image Quote API](/api-reference/endpoint/image/quote) for exact per-request quotes.
 
 </div>
 


### PR DESCRIPTION
Adds a footnote to flux-2-max-edit explaining FAL's per-megapixel billing model (first MP $0.07 + each additional MP $0.03, inputs counted as MPs, 1 MP = 1024×1024, rounded up per image) and the resulting per-input-count cost scaling ($0.10 / $0.13 / $0.16).

Also notes that the flat $0.19 API price covers the 3-input worst case and points users to the Image Quote API for exact quotes.