### PR TITLE
Replace Llama 3.3 70B references with GLM 5 in API docs

### DIFF
--- a/api-reference/api-spec.mdx
+++ b/api-reference/api-spec.mdx
@@ -158,7 +158,7 @@ The `venice_parameters` object allows you to access Venice-specific features not
 | `include_venice_system_prompt` | boolean | Whether to include Venice's default system prompts alongside specified system prompts | `true` |
 
 <Note>
-These parameters can also be specified as model suffixes appended to the model name (e.g., `llama-3.3-70b:enable_web_search=auto`). See [Model Feature Suffixes](/api-reference/endpoint/chat/model_feature_suffix) for details.
+These parameters can also be specified as model suffixes appended to the model name (e.g., `zai-org-glm-5:enable_web_search=auto`). See [Model Feature Suffixes](/api-reference/endpoint/chat/model_feature_suffix) for details.
 </Note>
 
 ### Prompt Caching

--- a/api-reference/endpoint/billing/usage-analytics.mdx
+++ b/api-reference/endpoint/billing/usage-analytics.mdx
@@ -34,7 +34,7 @@ Daily usage totals for the requested period.
 ### byModel
 Usage breakdown by model, sorted by total spend (highest first).
 
-- **modelName**: Display name of the model (e.g., "Llama 3.3 70B")
+- **modelName**: Display name of the model (e.g., "GLM 5")
 - **unitType**: Type of units consumed (tokens, images, chars, minutes, seconds)
 - **modelType**: Type of model (LLM, IMAGE, TTS, ASR, VIDEO), or null
 - **totalUsd**: Total USD spent on this model

--- a/api-reference/rate-limiting.mdx
+++ b/api-reference/rate-limiting.mdx
@@ -39,7 +39,7 @@ Text models are grouped into tiers based on size. Each model card on the [Models
 
 **S** `mistral-31-24b` `venice-uncensored`
 
-**M** `llama-3.3-70b` `qwen3-next-80b` `google-gemma-3-27b-it`
+**M** `zai-org-glm-5` `qwen3-next-80b` `google-gemma-3-27b-it`
 
 **L** `qwen3-235b-a22b-instruct-2507` `qwen3-235b-a22b-thinking-2507` `deepseek-ai-DeepSeek-R1` `grok-41-fast` `kimi-k2-thinking` `gemini-3-pro-preview` `hermes-3-llama-3.1-405b` `qwen3-coder-480b-a35b-instruct` `zai-org-glm-4.7` `openai-gpt-oss-120b`
 

--- a/overview/deprecations.mdx
+++ b/overview/deprecations.mdx
@@ -52,7 +52,7 @@ All Venice models are identified by a unique, permanent ID. For example:
 
 ```venice-uncensored```
 ```zai-org-glm-4.7```
-```llama-3.3-70b```
+```zai-org-glm-5```
 ```qwen3-vl-235b-a22b```
 
 Model IDs are stable. If there's a breaking change, we will release a new model ID (for example, add a version like v2). If there are no breaking changes, we may update the existing model and will communicate significant changes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates example model references from Llama 3.3 70B to GLM 5 throughout the API documentation, while preserving the actual model entries on the pricing page and static models list.

## Changes

Updated the following files:
- **`api-reference/endpoint/billing/usage-analytics.mdx`** - Changed example model name in the `modelName` field description
- **`api-reference/api-spec.mdx`** - Updated model feature suffix example (`zai-org-glm-5:enable_web_search=auto`)
- **`overview/deprecations.mdx`** - Replaced versioning example model ID
- **`api-reference/rate-limiting.mdx`** - Updated rate limit tier "M" listing

## Not Changed (as requested)
- `overview/pricing.mdx` - Pricing table entries preserved
- `model-search.js` - Static models list preserved
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://veniceai.slack.com/archives/C0AHY115YNA/p1777668937827909?thread_ts=1777668937.827909&cid=C0AHY115YNA)

<div><a href="https://cursor.com/agents/bc-621af6f1-e0c0-5d3d-a120-ec91b3ad7e0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-621af6f1-e0c0-5d3d-a120-ec91b3ad7e0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

