### PR TITLE
docs(reasoning): document max_tokens behavior on reasoning models

### DIFF
--- a/guides/features/reasoning-models.mdx
+++ b/guides/features/reasoning-models.mdx
@@ -245,6 +245,48 @@ curl https://api.venice.ai/api/v1/chat/completions \
 ```
 </CodeGroup>
 
+## Token limits
+
+Reasoning models generate two kinds of tokens — visible answer tokens (in `content`) and reasoning tokens (in `reasoning_content`, sometimes encrypted). Both count toward your `max_tokens` budget on Venice.
+
+### How the cap is enforced
+
+| Field | Behavior on reasoning models |
+|-------|------------------------------|
+| `max_tokens` | Strict cap on **total** completion tokens (visible + reasoning). |
+| `max_completion_tokens` | Same — strict cap on total completion tokens. Takes precedence when both are set. |
+
+Both fields are accepted; `max_completion_tokens` is the OpenAI-spec field and is preferred for new code. If you send both, `max_tokens` is ignored.
+
+### What this means for you
+
+Because reasoning tokens count against the cap, a small `max_tokens` value can be entirely consumed by thinking, leaving little room for the visible answer. If you previously sent `max_tokens: 500` expecting ~500 visible tokens of output, you may need to raise it.
+
+The `usage` object breaks down where your tokens went so you can size the cap appropriately:
+
+```json
+"usage": {
+  "completion_tokens": 501,
+  "completion_tokens_details": {
+    "reasoning_tokens": 169
+  },
+  "prompt_tokens": 13,
+  "total_tokens": 514
+}
+```
+
+Here, 169 of the 501 generated tokens were spent on reasoning, leaving 332 visible tokens.
+
+<Tip>
+To get more visible output, either raise `max_tokens` / `max_completion_tokens`, lower `reasoning_effort`, or disable reasoning entirely (see [Disabling reasoning](#disabling-reasoning)).
+</Tip>
+
+When the cap is hit, `finish_reason` is `length`. Each model exposes its upper bound as `maxCompletionTokens` on the [`/v1/models`](/api-reference/endpoint/models/list) endpoint.
+
+### Non-reasoning models
+
+On non-reasoning models, `max_tokens` behaves as you'd expect — there are no reasoning tokens, so it caps visible output directly.
+
 ## Capability discovery
 
 Check what a model supports via the [`/v1/models`](/api-reference/endpoint/models/list) endpoint:

--- a/guides/features/reasoning-models.mdx
+++ b/guides/features/reasoning-models.mdx
@@ -247,45 +247,44 @@ curl https://api.venice.ai/api/v1/chat/completions \
 
 ## Token limits
 
-Reasoning models generate two kinds of tokens — visible answer tokens (in `content`) and reasoning tokens (in `reasoning_content`, sometimes encrypted). Both count toward your `max_tokens` budget on Venice.
+Reasoning models generate visible answer tokens (in `content`) and reasoning tokens (in `reasoning_content`). Both count toward your token budget.
 
-### How the cap is enforced
+### Setting a token cap
 
-| Field | Behavior on reasoning models |
-|-------|------------------------------|
-| `max_tokens` | Strict cap on **total** completion tokens (visible + reasoning). |
-| `max_completion_tokens` | Same — strict cap on total completion tokens. Takes precedence when both are set. |
+Use `max_completion_tokens` to cap the total number of tokens the model generates, including reasoning:
 
-Both fields are accepted; `max_completion_tokens` is the OpenAI-spec field and is preferred for new code. If you send both, `max_tokens` is ignored.
+```json
+{
+  "model": "deepseek-v4-flash",
+  "messages": [...],
+  "max_completion_tokens": 500
+}
+```
 
-### What this means for you
+`max_tokens` is also accepted and behaves the same way. If both are set, `max_completion_tokens` takes precedence.
 
-Because reasoning tokens count against the cap, a small `max_tokens` value can be entirely consumed by thinking, leaving little room for the visible answer. If you previously sent `max_tokens: 500` expecting ~500 visible tokens of output, you may need to raise it.
+To get more visible output, raise the cap, lower `reasoning_effort`, or [disable reasoning](#disabling-reasoning).
 
-The `usage` object breaks down where your tokens went so you can size the cap appropriately:
+### Reading the breakdown
+
+The `usage` object shows how your budget was spent:
 
 ```json
 "usage": {
   "completion_tokens": 501,
-  "completion_tokens_details": {
-    "reasoning_tokens": 169
-  },
+  "completion_tokens_details": { "reasoning_tokens": 169 },
   "prompt_tokens": 13,
   "total_tokens": 514
 }
 ```
 
-Here, 169 of the 501 generated tokens were spent on reasoning, leaving 332 visible tokens.
+In this example, 169 tokens were spent on reasoning and 332 on the visible answer. When the cap is reached, `finish_reason` is `length`.
 
-<Tip>
-To get more visible output, either raise `max_tokens` / `max_completion_tokens`, lower `reasoning_effort`, or disable reasoning entirely (see [Disabling reasoning](#disabling-reasoning)).
-</Tip>
-
-When the cap is hit, `finish_reason` is `length`. Each model exposes its upper bound as `maxCompletionTokens` on the [`/v1/models`](/api-reference/endpoint/models/list) endpoint.
+Each model's upper bound is available as `maxCompletionTokens` on the [`/v1/models`](/api-reference/endpoint/models/list) endpoint.
 
 ### Non-reasoning models
 
-On non-reasoning models, `max_tokens` behaves as you'd expect — there are no reasoning tokens, so it caps visible output directly.
+`max_tokens` and `max_completion_tokens` behave the same on non-reasoning models, capping visible output directly.
 
 ## Capability discovery
 


### PR DESCRIPTION
Adds a Token limits section to the reasoning-models guide explaining that both max_tokens and max_completion_tokens cap total completion (visible + reasoning) on reasoning models, with a worked example from the usage breakdown. Closes the gap between the swagger reference (which already documents both fields) and the conceptual guide that users actually read.