### PR TITLE
[VEN-5966] guides: add Seedance 2.0 usage guide

### DIFF
--- a/api-reference/endpoint/video/queue.mdx
+++ b/api-reference/endpoint/video/queue.mdx
@@ -7,6 +7,10 @@ openapi: 'POST /video/queue'
 
 Call `/video/quote` to get a price estimate, then poll `/video/retrieve` with the returned `queue_id` until complete.
 
+### Seedance 2.0
+
+For `seedance-2-0-*` models (text-to-video, image-to-video, reference-to-video, plus the `-fast-*` variants), see the [Seedance 2.0 Guide](/guides/media/seedance-2-0) for the four-workflow model (Reference / Edit / Extend / Stitch), canonical prompt patterns, multimodal input limits, and pricing details.
+
 ### Video upscaling
 
 For the `topaz-video-upscale` model, use `upscale_factor` (1, 2, or 4) instead of `resolution`, and provide a `video_url`. Duration and FPS are detected automatically from the video file. See the [Video Upscaling Guide](/guides/media/video-upscaling) for full details and examples.

--- a/docs.json
+++ b/docs.json
@@ -65,6 +65,7 @@
               "guides/media/image-editing",
               "guides/media/video-generation",
               "guides/media/reference-to-video",
+              "guides/media/seedance-2-0",
               "guides/media/video-upscaling"
             ]
           },

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -204,22 +204,9 @@ POST https://api.venice.ai/api/v1/video/quote
 
 **Always call `/video/quote` before submitting — never bake in numbers that may drift.**
 
-### Formula
+### What drives the price
 
-```
-tokens = (referenceVideoTotalDuration + outputVideoDuration) × outputWidth × outputHeight × outputFps / 1024
-priceUSD = tokens × ratePerMTokens / 1_000_000 × 1.25
-```
-
-The 1.25× factor is Venice's margin over the base rate.
-
-### Floor rule
-
-A short reference video at high resolution would otherwise compute *less* than the same job with no references. To prevent that, the final price is floored at the no-reference baseline:
-
-```
-finalPrice = max(rateWithVideo × totalTokens, rateNoVideo × outputOnlyTokens)
-```
+Cost scales with the output's pixel-time volume — resolution, duration, and frame rate — plus the combined duration of any reference videos. A reference video also moves the request to a different pricing tier (cheaper per token), and a floor rule prevents short references at high resolution from undercutting the no-reference baseline. The quote endpoint applies all of this for you.
 
 ### Reference-video field on the quote request
 
@@ -238,19 +225,7 @@ curl -X POST https://api.venice.ai/api/v1/video/quote \
   }'
 ```
 
-The quote uses this to apply the with-video rate and the floor. Without it, the quote falls back to the no-video tier.
-
-### Sample prices (5 s output, 16:9, includes Venice 1.25× margin)
-
-| Variant | Output res | 0 s ref | 5 s ref | 15 s ref (max) |
-|---|---|---|---|---|
-| Seedance 2.0 R2V | 480p | $0.44 | $0.54 | $1.08 |
-| Seedance 2.0 R2V | 720p | $0.95 | $1.16 | $2.32 |
-| Seedance 2.0 R2V | 1080p | $2.34 | $2.86 | $5.71 |
-| Seedance 2.0 Fast R2V | 480p | $0.35 | $0.41 | $0.83 |
-| Seedance 2.0 Fast R2V | 720p | $0.76 | $0.89 | $1.78 |
-
-Numbers as of 2026-05; they may drift. Treat `/video/quote` as the source of truth.
+Without `reference_video_total_duration`, the quote falls back to the no-reference rate tier; a request that actually includes a reference video will then be billed at the with-reference rate when submitted, and the quote won't match the bill.
 
 ---
 
@@ -424,7 +399,7 @@ Use the canonical prefixes exactly as written: `Strictly edit <Video 1>, ...`, `
 
 ### Unexpectedly high charge
 
-If you included a reference video and didn't pass `reference_video_total_duration` to `/video/quote`, the quote returned the **no-reference** rate but the queue submission still billed at the **with-video** rate (after the model detected the video). Always pass `reference_video_total_duration` when reference videos are present so the quote and the bill line up.
+If you included a reference video and didn't pass `reference_video_total_duration` to `/video/quote`, the quote returned the **no-reference** tier but the queue submission still billed at the **with-reference** tier (the reference video was detected at submission). Always pass `reference_video_total_duration` when reference videos are present so the quote and the bill line up.
 
 ---
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -16,9 +16,9 @@ This guide walks through the variants, the four workflows with their canonical p
 | `seedance-2-0-text-to-video` | T2V | 480p / 720p / 1080p | Text prompt only |
 | `seedance-2-0-image-to-video` | I2V | 480p / 720p / 1080p | First-frame (and optionally last-frame) image grounding |
 | `seedance-2-0-reference-to-video` | R2V | 480p / 720p / 1080p | Up to 9 ref images + 3 ref videos + 3 ref audios. Powers Reference / Edit / Extend / Stitch |
-| `seedance-2-0-fast-text-to-video` | Fast T2V | 480p / 720p | Cheaper tier |
-| `seedance-2-0-fast-image-to-video` | Fast I2V | 480p / 720p | Cheaper tier |
-| `seedance-2-0-fast-reference-to-video` | Fast R2V | 480p / 720p | Cheaper tier, same workflow set |
+| `seedance-2-0-fast-text-to-video` | Fast T2V | 480p / 720p | Faster, lower-fidelity tier |
+| `seedance-2-0-fast-image-to-video` | Fast I2V | 480p / 720p | Faster, lower-fidelity tier |
+| `seedance-2-0-fast-reference-to-video` | Fast R2V | 480p / 720p | Faster, lower-fidelity tier; same workflow set |
 
 All variants are async. Submit via `POST /api/v1/video/queue`, then poll `POST /api/v1/video/retrieve` until the response body is `video/mp4`. See [Video Generation](/guides/media/video-generation) for the general queue flow.
 
@@ -196,21 +196,9 @@ The queue endpoint accepts JSON bodies up to **35 MB**. Inline data URLs for lar
 
 ## Pricing
 
-The authoritative pricing oracle is the live quote endpoint:
+Call `POST /api/v1/video/quote` to get a quote for a given request shape before submitting it to `/video/queue`. The quote endpoint is the only authoritative source; pricing details may change and shouldn't be cached or duplicated client-side.
 
-```bash
-POST https://api.venice.ai/api/v1/video/quote
-```
-
-**Always call `/video/quote` before submitting — never bake in numbers that may drift.**
-
-### What drives the price
-
-Cost scales with the output's pixel-time volume — resolution, duration, and frame rate — plus the combined duration of any reference videos. A reference video also moves the request to a different pricing tier (cheaper per token), and a floor rule prevents short references at high resolution from undercutting the no-reference baseline. The quote endpoint applies all of this for you.
-
-### Reference-video field on the quote request
-
-When you have reference video(s), pass the sum of their durations as `reference_video_total_duration`:
+When reference video(s) are part of the request, also pass `reference_video_total_duration` (the sum of all reference clip durations in seconds) so the quote matches what `/video/queue` will charge:
 
 ```bash
 curl -X POST https://api.venice.ai/api/v1/video/quote \
@@ -224,8 +212,6 @@ curl -X POST https://api.venice.ai/api/v1/video/quote \
     "reference_video_total_duration": 5
   }'
 ```
-
-Without `reference_video_total_duration`, the quote falls back to the no-reference rate tier; a request that actually includes a reference video will then be billed at the with-reference rate when submitted, and the quote won't match the bill.
 
 ---
 
@@ -397,9 +383,9 @@ Workflow is inferred from prompt syntax. Common misroutings:
 
 Use the canonical prefixes exactly as written: `Strictly edit <Video 1>, ...`, `Extend <Video 1>, ...`, `<Video 1> + ... + followed by <Video 2>`.
 
-### Unexpectedly high charge
+### Quote doesn't match the queued amount
 
-If you included a reference video and didn't pass `reference_video_total_duration` to `/video/quote`, the quote returned the **no-reference** tier but the queue submission still billed at the **with-reference** tier (the reference video was detected at submission). Always pass `reference_video_total_duration` when reference videos are present so the quote and the bill line up.
+If you included a reference video but didn't pass `reference_video_total_duration` to `/video/quote`, the quote and the queued amount may differ. Always pass `reference_video_total_duration` (sum of all reference clip durations, in seconds) when reference videos are present.
 
 ---
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -28,7 +28,7 @@ The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast s
 
 | Workflow | What it does | Prompt prefix | Inputs |
 |---|---|---|---|
-| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style / audio | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 reference (0-9 images, 0-3 videos, 0-3 audios) |
+| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style / audio | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 image OR video reference (0-9 images, 0-3 videos), plus optionally up to 3 audio donors |
 | **Edit** | Modify a single input video while preserving the rest | `Strictly edit <Video 1>, changing its ...` | 1 input video + text (images optional grounding) |
 | **Extend** | Forward / backward extension of one clip | `Extend <Video 1>, generate ...` | 1 input video + text |
 | **Stitch** | Stitch 2-3 clips with auto-generated transitions | `<Video 1> + <transition description> + followed by <Video 2> + ...` | 2-3 input videos + text |
@@ -55,7 +55,7 @@ Refer to the [tone | timbre] in <Audio N> to generate ...
 
 - `Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character riding a horse through snow.`
 - `Refer to the camera scene in <Video 1> to generate a similar establishing shot of a futuristic city at dawn.`
-- `Refer to the timbre in <Audio 1> to generate a narrator describing the unfolding scene.`
+- `Refer to <Subject 1> in <Image 1> and use the timbre in <Audio 1> for the narrator describing the scene.` (audio donors must be paired with at least one image or video reference — audio alone is rejected)
 
 ### Edit workflow
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -188,7 +188,7 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 | **Total combined duration** | ≤ 15 s across all clips |
 | **Per-clip size** | ≤ 15 MB |
 
-Reference audio is supported on the R2V variants only. The `reference_audio_urls` field is **distinct from the singular `audio_url` field**: `reference_audio_urls` provides vocal-timbre or sound-effect donors that the prompt references as `<Audio N>`; `audio_url` is a single background-music input for the generation.
+Reference audio is supported on the R2V variants only. Each entry is forwarded to the model as a `role: "reference_audio"` content item that the prompt addresses as `<Audio 1>`, `<Audio 2>`, `<Audio 3>` — the model uses each clip for vocal timbre, sound effects, or background music depending on how the prompt frames it. The legacy singular `audio_url` field maps to the same content shape and is now equivalent to passing a one-element `reference_audio_urls`.
 
 ### Request size
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -7,7 +7,7 @@ description: "Seedance 2.0 — Venice's flagship multimodal video model. Text / 
 
 Seedance 2.0 is a flagship multimodal video model exposed on Venice as a family of three variants for text-, image-, and reference-driven video generation. The **reference-to-video** variant is unusually powerful: a single endpoint and a single model ID handle **four distinct workflows** (Reference, Edit, Extend, Stitch) — the workflow is inferred from the **shape of your prompt**.
 
-This guide walks through the variants, the four workflows with verbatim canonical prompts, the multimodal input limits, pricing, and complete `curl` examples.
+This guide walks through the variants, the four workflows with their canonical prompts, the multimodal input limits, pricing, and complete `curl` examples.
 
 ## Variants
 
@@ -91,7 +91,7 @@ The last example combines Edit with an image reference — perfectly legal, the 
 
 ### Extend workflow
 
-Continue a single clip forward or backward in time. **By default Seedance returns only the new content** — not the original input concatenated with the extension. This is a documented design choice for transition continuity; if you want the input clip preserved alongside the extension, say so explicitly:
+Continue a single clip forward or backward in time. **By default Seedance returns only the new content** — not the original input concatenated with the extension. This is by design, for transition continuity; if you want the input clip preserved alongside the extension, say so explicitly:
 
 ```
 Extend <Video 1>, generate [description of extended content]
@@ -439,7 +439,7 @@ Workflow is inferred from prompt syntax. Common misroutings:
 - Wanting to **Stitch** but writing `Refer to ...` → model picks one as the donor, ignores the others
 - Wanting to **Edit** but writing `Generate a video based on <Video 1>` → ambiguous; model may default to Reference
 
-Use the canonical prefixes verbatim: `Strictly edit <Video 1>, ...`, `Extend <Video 1>, ...`, `<Video 1> + ... + followed by <Video 2>`.
+Use the canonical prefixes exactly as written: `Strictly edit <Video 1>, ...`, `Extend <Video 1>, ...`, `<Video 1> + ... + followed by <Video 2>`.
 
 ### Aspect ratio or pixel count out of range on a video
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -1,0 +1,481 @@
+---
+title: "Seedance 2.0"
+description: "BytePlus Dreamina Seedance 2.0 — Venice's flagship multimodal video model. Text / image / reference-to-video on one endpoint, with four workflows (Reference, Edit, Extend, Stitch) inferred from prompt shape."
+'og:title': "Seedance 2.0 Guide | Venice API Docs"
+'og:description': "Generate, edit, extend and stitch videos with BytePlus Dreamina Seedance 2.0 via the Venice API. Workflow patterns, multimodal limits, pricing, and worked examples."
+---
+
+Seedance 2.0 is BytePlus's flagship Dreamina video model, exposed on Venice as a family of three variants for text-, image-, and reference-driven video generation. The **reference-to-video** variant is unusually powerful: a single endpoint and a single model ID handle **four distinct workflows** (Reference, Edit, Extend, Stitch) — the workflow is inferred from the **shape of your prompt**.
+
+This guide walks through the variants, the four workflows with verbatim canonical prompts, the multimodal input limits, pricing, and complete `curl` examples.
+
+<Warning>
+**Real human faces are not supported as direct inputs.** Seedance 2.0 rejects reference images and reference videos that contain identifiable human faces. See [Real human face policy](#real-human-face-policy) below for details.
+</Warning>
+
+## Variants
+
+| Model ID | Variant | Output resolutions | Notes |
+|---|---|---|---|
+| `seedance-2-0-text-to-video` | T2V | 480p / 720p / 1080p | Text prompt only |
+| `seedance-2-0-image-to-video` | I2V | 480p / 720p / 1080p | First-frame (and optionally last-frame) image grounding |
+| `seedance-2-0-reference-to-video` | R2V | 480p / 720p / 1080p | Up to 9 ref images + 3 ref videos + 3 ref audios. Powers Reference / Edit / Extend / Stitch |
+| `seedance-2-0-fast-text-to-video` | Fast T2V | 480p / 720p | Cheaper tier |
+| `seedance-2-0-fast-image-to-video` | Fast I2V | 480p / 720p | Cheaper tier |
+| `seedance-2-0-fast-reference-to-video` | Fast R2V | 480p / 720p | Cheaper tier, same workflow set |
+
+All variants are async. Submit via `POST /api/v1/video/queue`, then poll `POST /api/v1/video/retrieve` until the response body is `video/mp4`. See [Video Generation](/guides/media/video-generation) for the general queue flow.
+
+## The "one model, four workflows" model
+
+The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast sibling) is the same BytePlus model serving four different tasks. **BytePlus infers the task from the prompt prefix and the shape of your `content[]` inputs.** There is no `task` or `workflow` field — the prompt syntax is the routing.
+
+| Workflow | What it does | Prompt prefix | Inputs |
+|---|---|---|---|
+| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style / audio | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 reference (0-9 images, 0-3 videos, 0-3 audios) |
+| **Edit** | Modify a single input video while preserving the rest | `Strictly edit <Video 1>, changing its ...` | 1 input video + text (images/audio optional grounding) |
+| **Extend** | Forward / backward extension of one clip | `Extend <Video 1>, generate ...` | 1 input video + text |
+| **Stitch** | Stitch 2-3 clips with auto-generated transitions | `<Video 1> + <transition description> + followed by <Video 2> + ...` | 2-3 input videos + text |
+
+The **prompt syntax is canonical and case-sensitive**: angle brackets, capital first letter, single space before the number. `<Video 1>` ✅. `video1`, `Video1`, `[Video 1]`, `@Video1` will not route reliably.
+
+---
+
+## Workflow patterns
+
+### Reference workflow
+
+Use the reference assets as **donors** — subject, scene, motion, style, or audio tone — to generate a brand-new video.
+
+**Canonical prompt patterns** (from BytePlus's Prompt Guide §2.4):
+
+```
+Refer to <Subject N> in <Image N> to generate ...
+Refer to the [action | camera scene | style | sound effect] in <Video N> to generate ...
+Refer to the [tone | timbre] in <Audio N> to generate ...
+```
+
+**Examples**:
+
+- `Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character riding a horse through snow.`
+- `Refer to the camera scene in <Video 1> to generate a similar establishing shot of a futuristic city at dawn.`
+- `Refer to the timbre in <Audio 1> to generate a narrator describing the unfolding scene.`
+
+### Edit workflow
+
+Modify a single input video. **Anything not explicitly named in the prompt is preserved.** Use this when you want a localized change (subject swap, weather/color change, element add/remove) rather than a wholly new video.
+
+**Canonical prompt pattern** (from BytePlus's Prompt Guide §2.5.1):
+
+```
+Strictly edit <Video 1>, changing its [original feature] to [new feature] ...
+```
+
+**Sub-patterns for finer control**:
+
+```
+Add Elements:
+  At [timestamp / timing] and [spatial location] of <Video 1>, add [description of intended element].
+
+Remove Elements:
+  Remove [element to be deleted] from <Video 1>, keeping the rest of the video content unchanged.
+
+Modify Elements:
+  Replace [description of element to be changed] in <Video 1> with [description of intended element].
+```
+
+**Examples**:
+
+- `Strictly edit <Video 1>, changing its weather from sunny to a heavy rainstorm.`
+- `Add snacks such as fried chicken and pizza to the countertop in <Video 1>.`
+- `Remove the red car from <Video 1>, keeping the rest of the video content unchanged.`
+- `Replace the perfume featured in <Video 1> with the face cream from <Image 1>, with all original motions and camera work preserved.`
+
+The last example combines Edit with an image reference — perfectly legal, the model uses `<Image 1>` as a visual donor for the replacement.
+
+### Extend workflow
+
+Continue a single clip forward or backward in time. **By default Seedance returns only the new content** — not the original input concatenated with the extension. This is BytePlus's documented design choice for transition continuity; if you want the input clip preserved alongside the extension, say so explicitly:
+
+```
+Extend <Video 1>, generate [description of extended content]
+Extend <Video 1> backward, [description of extended content]
+Extend <Video 1>, start with <Video 1>, then [description of extended content]      ← preserves input at start
+Extend <Video 1> backward, [description], and then end with <Video 1>               ← preserves input at end
+```
+
+BytePlus's transition note (from Prompt Guide §2.5.2):
+
+> *"The model will automatically extract the transition frames for seamless blending. The original segments of the input video will not be re-generated, ensuring perfect continuity."*
+
+**Examples**:
+
+- `Extend <Video 1>, generate a dramatic chase scene through narrow alleys at dusk.`
+- `Extend <Video 1> backward, the same character walking toward the camera before the original shot begins.`
+- `Extend <Video 1>, start with <Video 1>, then the camera pulls back to reveal a vast landscape.`
+
+### Stitch workflow (Track Completion)
+
+Connect 2-3 input clips with AI-generated transitions. Total combined input duration must be ≤ 15 s.
+
+**Canonical prompt pattern** (from BytePlus's Prompt Guide §2.5.3):
+
+```
+<Video 1> + [transition description] + followed by <Video 2> [+ [transition description] + followed by <Video 3>]
+```
+
+**Examples**:
+
+- `<Video 1> + a smooth seamless cut + followed by <Video 2>`
+- `<Video 1>. The moment a leaf falls to the ground, it sets off a special effect of golden particles. A gust of wind blows by, leading into <Video 2>.`
+- `<Video 1> + a wisp of smoke transforms into a flock of birds + followed by <Video 2> + a slow dolly-in + followed by <Video 3>`
+
+The model auto-trims connecting segments at the join points for continuity.
+
+---
+
+## Universal prompt formula
+
+Across all four workflows, BytePlus's authoring guidance (Prompt Guide §1.1) is:
+
+```
+Subject + Motion + Environment (Optional)
+       + Camera Movement / Cut (Optional)
+       + Aesthetic Description (Optional)
+       + Audio (Optional)
+```
+
+- **Subject + Motion**: the logical foundation — define "Who" is performing "What action"
+- **Environment + Aesthetics**: spatial background, lighting, visual style
+- **Camera**: explicit shot type or movement
+- **Audio**: ambient sound effects for immersive output
+
+Layering this on top of a workflow prefix (e.g., `Strictly edit <Video 1>, changing its <subject + motion + environment + ...>`) produces the highest-quality outputs.
+
+---
+
+## Multimodal input limits
+
+These are BytePlus's hard limits; requests outside them are rejected at the model layer (typically as a generic 400). Venice enforces most of them at the schema and pre-charge layers, but a few (image-side aspect ratio, FPS, total-pixel-count on videos) pass through.
+
+### Images
+
+| Constraint | Value |
+|---|---|
+| Input methods | URL, Base64 data URL, or asset ID |
+| Formats | `.jpeg`, `.png`, `.webp`, `.bmp`, `.tiff`, `.gif`, `.heic`, `.heif` |
+| Aspect ratio (W / H) | exclusive `(0.4, 2.5)` |
+| Width / height per side | exclusive `(300, 6000)` px |
+| Per-image size | ≤ 30 MB |
+| Image count: I2V first-frame | 1 |
+| Image count: I2V first + last frame | 2 |
+| **Image count: R2V (V2 / Fast)** | **1 – 9** |
+
+<Note>
+Avoid Base64 for large images. Base64 inflates payload by ~33% and pushes against BytePlus's 64 MB total request body cap quickly.
+</Note>
+
+### Videos
+
+| Constraint | Value |
+|---|---|
+| Input methods | **URL or asset ID only** (Base64 not accepted) |
+| Formats | `.mp4`, `.mov` |
+| Video codecs | H.264 / AVC, H.265 / HEVC |
+| Audio codecs (in container) | AAC, MP3 |
+| **Duration per clip** | `[2, 15]` s (inclusive) |
+| **Max clip count** | 3 (R2V / Stitch / Extend) |
+| **Total combined duration** | ≤ 15 s across all clips |
+| Aspect ratio (W / H) | `[0.4, 2.5]` |
+| Width / height per side | `[300, 6000]` px |
+| Total pixel count | `[640 × 640, 2206 × 946]` |
+| **Per-clip size** | ≤ 50 MB |
+| Frame rate (FPS) | `[24, 60]` |
+
+### Audio
+
+| Constraint | Value |
+|---|---|
+| Input methods | URL, Base64, or asset ID |
+| Formats | `.wav`, `.mp3` |
+| **Duration per clip** | `[2, 15]` s |
+| **Max clip count** | 3 |
+| **Total combined duration** | ≤ 15 s |
+| **Per-clip size** | ≤ 15 MB |
+
+### Request body cap
+
+Venice's queue endpoint accepts JSON bodies up to **35 MB**. Inline data URLs for large videos can push past this — for multi-clip Stitch in particular, prefer URLs over inline base64. (Image inputs almost never trigger this.)
+
+---
+
+## Real human face policy
+
+Verbatim from BytePlus (public doc 2298881):
+
+> *"Seedance 2.0 series models do not support direct upload of reference images or videos containing real human faces. A series of solutions are provided to make it easier for creatives to use portraits."*
+
+In practice, requests with identifiable real human faces in `reference_image_urls` or `reference_video_urls` will be rejected by BytePlus's content-moderation layer. For Venice web UI users, the [face-asset orchestrator](https://venice.ai/video) handles the proper consent / library workflow transparently. **For API consumers, this orchestrator is not yet exposed** — do not pass identifiable human faces as references via the API. Use stylized characters, animals, products, scenes, or AI-generated subjects instead.
+
+---
+
+## Pricing
+
+The authoritative pricing oracle is the live quote endpoint:
+
+```bash
+POST https://api.venice.ai/api/v1/video/quote
+```
+
+**Always call `/video/quote` before submitting — never bake in numbers that may drift.**
+
+### Formula
+
+```
+tokens = (referenceVideoTotalDuration + outputVideoDuration) × outputWidth × outputHeight × outputFps / 1024
+priceUSD = tokens × ratePerMTokens / 1_000_000 × 1.25
+```
+
+The 1.25× factor is Venice's margin over the BytePlus base rate.
+
+### Rate tiers
+
+Seedance switches to a cheaper "input with video" rate when **any** reference video is included (T2V/I2V at `refDuration=0` use the higher no-ref rate):
+
+| Variant | Output resolution | Rate without video | Rate with video |
+|---|---|---|---|
+| Seedance 2.0 | 480p / 720p | $7.0 / M tokens | $4.3 / M tokens |
+| Seedance 2.0 | 1080p | $7.7 / M tokens | $4.7 / M tokens |
+| Seedance 2.0 Fast | 480p / 720p | $5.6 / M tokens | $3.3 / M tokens |
+
+### Floor rule
+
+A short reference video at high resolution would otherwise compute *less* than the same job with no references. To prevent that, the final price is floored at the no-reference baseline:
+
+```
+finalPrice = max(rateWithVideo × totalTokens, rateNoVideo × outputOnlyTokens)
+```
+
+### Reference-video field on the quote request
+
+When you have reference video(s), pass the sum of their durations as `reference_video_total_duration`:
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/quote \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "duration": "5s",
+    "resolution": "1080p",
+    "aspect_ratio": "16:9",
+    "reference_video_total_duration": 5
+  }'
+```
+
+The quote uses this to apply the with-video rate and the floor. Without it, the quote falls back to the no-video tier.
+
+### Sample prices (5 s output, 16:9, includes Venice 1.25× margin)
+
+| Variant | Output res | 0 s ref | 5 s ref | 15 s ref (max) |
+|---|---|---|---|---|
+| Seedance 2.0 R2V | 480p | $0.44 | $0.54 | $1.08 |
+| Seedance 2.0 R2V | 720p | $0.95 | $1.16 | $2.32 |
+| Seedance 2.0 R2V | 1080p | $2.34 | $2.86 | $5.71 |
+| Seedance 2.0 Fast R2V | 480p | $0.35 | $0.41 | $0.83 |
+| Seedance 2.0 Fast R2V | 720p | $0.76 | $0.89 | $1.78 |
+
+Numbers as of 2026-05; they may drift. Treat `/video/quote` as the source of truth.
+
+---
+
+## Complete examples
+
+All examples assume `VENICE_API_KEY` is set in the environment.
+
+### Text-to-video
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-text-to-video",
+    "prompt": "A golden retriever frolicking through a sunlit meadow at sunset, slow camera dolly-in, shallow depth of field, warm cinematic lighting.",
+    "duration": "5s",
+    "aspect_ratio": "16:9",
+    "resolution": "1080p"
+  }'
+```
+
+### Image-to-video (first frame)
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-image-to-video",
+    "prompt": "The lighthouse keeper turns toward the storm, lantern raised, waves crashing against the rocks.",
+    "image_url": "https://example.com/lighthouse.jpg",
+    "duration": "5s",
+    "aspect_ratio": "16:9",
+    "resolution": "720p"
+  }'
+```
+
+### Reference workflow — subject + audio donor
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "prompt": "Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character walking through a neon-lit Tokyo street at night. Refer to the timbre in <Audio 1> for a soft female voiceover describing the scene.",
+    "reference_image_urls": ["https://example.com/character.png"],
+    "reference_audio_urls": ["https://example.com/voice-sample.mp3"],
+    "duration": "5s",
+    "aspect_ratio": "9:16",
+    "resolution": "1080p"
+  }'
+```
+
+### Edit workflow
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "prompt": "Strictly edit <Video 1>, changing its weather from sunny to a heavy rainstorm, with all original motions and camera work preserved.",
+    "reference_video_urls": ["https://example.com/sunny-scene.mp4"],
+    "reference_video_total_duration": 5,
+    "duration": "5s",
+    "aspect_ratio": "16:9",
+    "resolution": "1080p"
+  }'
+```
+
+### Edit workflow with image grounding
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "prompt": "Replace the perfume featured in <Video 1> with the face cream from <Image 1>, with all original motions and camera work preserved.",
+    "reference_video_urls": ["https://example.com/perfume-ad.mp4"],
+    "reference_image_urls": ["https://example.com/face-cream.png"],
+    "reference_video_total_duration": 4,
+    "duration": "5s",
+    "aspect_ratio": "16:9",
+    "resolution": "1080p"
+  }'
+```
+
+### Extend forward
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "prompt": "Extend <Video 1>, generate a dramatic chase scene through narrow alleys at dusk, with neon signs flickering and rain on the pavement.",
+    "reference_video_urls": ["https://example.com/alley-intro.mp4"],
+    "reference_video_total_duration": 4,
+    "duration": "5s",
+    "aspect_ratio": "16:9",
+    "resolution": "1080p"
+  }'
+```
+
+### Stitch (3 clips)
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "prompt": "<Video 1> + a wisp of smoke transforms into a flock of birds + followed by <Video 2> + a slow dolly-in + followed by <Video 3>",
+    "reference_video_urls": [
+      "https://example.com/clip-1.mp4",
+      "https://example.com/clip-2.mp4",
+      "https://example.com/clip-3.mp4"
+    ],
+    "reference_video_total_duration": 12,
+    "duration": "5s",
+    "aspect_ratio": "16:9",
+    "resolution": "1080p"
+  }'
+```
+
+### Polling for completion
+
+After every queue submission, save the returned `queue_id` and poll `/video/retrieve` until the response body is `video/mp4`:
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/retrieve \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "queue_id": "123e4567-e89b-12d3-a456-426614174000"
+  }' \
+  -o output.mp4
+```
+
+The response is JSON (`{ "status": "queued" | "running" | "failed", ... }`) until the job completes, at which point the response body switches to `video/mp4` bytes. See [Video Generation](/guides/media/video-generation) for the full polling pattern.
+
+---
+
+## Troubleshooting
+
+### `At least one reference is required for this model`
+
+Reference-to-video submissions must include at least one of `reference_image_urls`, `reference_video_urls`, `reference_audio_urls`, or `typed_references`. Pure text-only generation isn't a valid R2V workflow — use `seedance-2-0-text-to-video` instead.
+
+### `reference_video_urls must have at most 3 videos`
+
+BytePlus caps reference videos at 3. If you need more clips, run a Stitch first (3 → 1), then use the output as a reference for a follow-up.
+
+### `Per clip must be 2–15s` / aggregate `> 15s`
+
+Per-clip duration is `[2, 15]` seconds **inclusive**; the sum across all reference videos is also capped at 15 seconds. Trim clips client-side before submission.
+
+### Prompt routes to the wrong workflow
+
+Workflow is inferred from prompt syntax. Common misroutings:
+
+- Wanting to **Extend** but writing `Refer to ...` → model treats your video as a *donor*, not a canvas to continue
+- Wanting to **Stitch** but writing `Refer to ...` → model picks one as the donor, ignores the others
+- Wanting to **Edit** but writing `Generate a video based on <Video 1>` → ambiguous; model may default to Reference
+
+Use the canonical prefixes verbatim: `Strictly edit <Video 1>, ...`, `Extend <Video 1>, ...`, `<Video 1> + ... + followed by <Video 2>`.
+
+### Real-human-face rejection
+
+If you see a generic 400 or a content-moderation error and your reference media includes a recognisable real human face, that's the cause. Replace with stylized characters, products, animals, or AI-generated subjects.
+
+### Aspect ratio or pixel count out of range on a video
+
+Common when uploading vertical phone video to an R2V flow that maxes at `2206 × 946`. Re-encode or crop the input clip so each side is in `[300, 6000]` px and the total pixel count fits in `[640×640, 2206×946]`.
+
+### Unexpectedly high charge
+
+If you included a reference video and didn't pass `reference_video_total_duration` to `/video/quote`, the quote returned the **no-reference** rate but the queue submission still billed at the **with-video** rate (after BytePlus detected the video). Always pass `reference_video_total_duration` when reference videos are present so the quote and the bill line up.
+
+---
+
+## References
+
+- BytePlus public doc 2291680: [Dreamina Seedance 2.0 series tutorial](https://www.byteplus.com/en/learn)
+- BytePlus public doc 2298881: Video generation tutorial (multimodal input limits)
+- Venice video queue endpoint: [`POST /api/v1/video/queue`](/api-reference/endpoint/video/queue)
+- Venice quote endpoint: [`POST /api/v1/video/quote`](/api-reference/endpoint/video/quote)
+- Companion guide: [Reference to Video](/guides/media/reference-to-video) (covers Kling O3 + Grok Imagine R2V)
+- Companion guide: [Video Generation](/guides/media/video-generation) (queue / polling overview)

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -33,7 +33,7 @@ The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast s
 | **Extend** | Forward / backward extension of one clip | `Extend <Video 1>, generate ...` | 1 input video + text |
 | **Stitch** | Stitch 2-3 clips with auto-generated transitions | `<Video 1> + <transition description> + followed by <Video 2> + ...` | 2-3 input videos + text |
 
-The **prompt syntax is canonical and case-sensitive**: angle brackets, capital first letter, single space before the number. `<Video 1>` ✅. `video1`, `Video1`, `[Video 1]`, `@Video1` will not route reliably.
+The **prompt syntax is canonical and case-sensitive**: angle brackets, capital first letter, single space before the number — `<Video 1>`, `<Image 1>`, `<Audio 1>`.
 
 ---
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -28,7 +28,7 @@ The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast s
 
 | Workflow | What it does | Prompt prefix | Inputs |
 |---|---|---|---|
-| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style / vocal timbre | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 reference (0-9 images, 0-3 videos, 0-3 audios) |
+| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style / audio | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 reference (0-9 images, 0-3 videos, 0-3 audios) |
 | **Edit** | Modify a single input video while preserving the rest | `Strictly edit <Video 1>, changing its ...` | 1 input video + text (images optional grounding) |
 | **Extend** | Forward / backward extension of one clip | `Extend <Video 1>, generate ...` | 1 input video + text |
 | **Stitch** | Stitch 2-3 clips with auto-generated transitions | `<Video 1> + <transition description> + followed by <Video 2> + ...` | 2-3 input videos + text |

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -15,7 +15,7 @@ This guide walks through the variants, the four workflows with their canonical p
 |---|---|---|---|
 | `seedance-2-0-text-to-video` | T2V | 480p / 720p / 1080p | Text prompt only |
 | `seedance-2-0-image-to-video` | I2V | 480p / 720p / 1080p | First-frame (and optionally last-frame) image grounding |
-| `seedance-2-0-reference-to-video` | R2V | 480p / 720p / 1080p | Up to 9 reference images + 3 reference videos. Powers Reference / Edit / Extend / Stitch |
+| `seedance-2-0-reference-to-video` | R2V | 480p / 720p / 1080p | Up to 9 reference images + 3 reference videos + 3 reference audio donors. Powers Reference / Edit / Extend / Stitch |
 | `seedance-2-0-fast-text-to-video` | Fast T2V | 480p / 720p | Faster, lower-fidelity tier |
 | `seedance-2-0-fast-image-to-video` | Fast I2V | 480p / 720p | Faster, lower-fidelity tier |
 | `seedance-2-0-fast-reference-to-video` | Fast R2V | 480p / 720p | Faster, lower-fidelity tier; same workflow set |
@@ -28,12 +28,12 @@ The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast s
 
 | Workflow | What it does | Prompt prefix | Inputs |
 |---|---|---|---|
-| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style | `Refer to ... in <Image\|Video N> to generate ...` | Text + ≥1 reference (0-9 images, 0-3 videos) |
+| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style / vocal timbre | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 reference (0-9 images, 0-3 videos, 0-3 audios) |
 | **Edit** | Modify a single input video while preserving the rest | `Strictly edit <Video 1>, changing its ...` | 1 input video + text (images optional grounding) |
 | **Extend** | Forward / backward extension of one clip | `Extend <Video 1>, generate ...` | 1 input video + text |
 | **Stitch** | Stitch 2-3 clips with auto-generated transitions | `<Video 1> + <transition description> + followed by <Video 2> + ...` | 2-3 input videos + text |
 
-The **prompt syntax is canonical and case-sensitive**: angle brackets, capital first letter, single space before the number — `<Video 1>`, `<Image 1>`.
+The **prompt syntax is canonical and case-sensitive**: angle brackets, capital first letter, single space before the number — `<Video 1>`, `<Image 1>`, `<Audio 1>`.
 
 ---
 
@@ -41,19 +41,21 @@ The **prompt syntax is canonical and case-sensitive**: angle brackets, capital f
 
 ### Reference workflow
 
-Use the reference assets as **donors** — subject, scene, motion, style — to generate a brand-new video.
+Use the reference assets as **donors** — subject, scene, motion, style, vocal timbre — to generate a brand-new video.
 
 **Canonical prompt patterns**:
 
 ```
 Refer to <Subject N> in <Image N> to generate ...
 Refer to the [action | camera scene | style | sound effect] in <Video N> to generate ...
+Refer to the [tone | timbre] in <Audio N> to generate ...
 ```
 
 **Examples**:
 
 - `Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character riding a horse through snow.`
 - `Refer to the camera scene in <Video 1> to generate a similar establishing shot of a futuristic city at dawn.`
+- `Refer to the timbre in <Audio 1> to generate a narrator describing the unfolding scene.`
 
 ### Edit workflow
 
@@ -134,11 +136,13 @@ Across all four workflows, the recommended authoring formula is:
 Subject + Motion + Environment (Optional)
        + Camera Movement / Cut (Optional)
        + Aesthetic Description (Optional)
+       + Audio (Optional)
 ```
 
 - **Subject + Motion**: the logical foundation — define "Who" is performing "What action"
 - **Environment + Aesthetics**: spatial background, lighting, visual style
 - **Camera**: explicit shot type or movement
+- **Audio**: ambient sound effects or vocal direction for immersive output
 
 Layering this on top of a workflow prefix (e.g., `Strictly edit <Video 1>, changing its <subject + motion + environment + ...>`) produces the highest-quality outputs.
 
@@ -172,6 +176,19 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 | **Max clip count** | 3 (R2V / Stitch / Extend) |
 | **Total combined duration** | ≤ 15 s across all clips |
 | **Per-clip size** | ≤ 50 MB |
+
+### Audio
+
+| Constraint | Value |
+|---|---|
+| Input methods | URL or Base64 data URL |
+| Formats | `.wav`, `.mp3` |
+| **Duration per clip** | `[2, 15]` s |
+| **Max clip count** | 3 |
+| **Total combined duration** | ≤ 15 s across all clips |
+| **Per-clip size** | ≤ 15 MB |
+
+Reference audio is supported on the R2V variants only. The `reference_audio_urls` field is **distinct from the singular `audio_url` field**: `reference_audio_urls` provides vocal-timbre or sound-effect donors that the prompt references as `<Audio N>`; `audio_url` is a single background-music input for the generation.
 
 ### Request size
 
@@ -245,6 +262,23 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
     "model": "seedance-2-0-reference-to-video",
     "prompt": "Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character walking through a neon-lit Tokyo street at night.",
     "reference_image_urls": ["https://example.com/character.png"],
+    "duration": "5s",
+    "aspect_ratio": "9:16",
+    "resolution": "1080p"
+  }'
+```
+
+### Reference workflow — subject + audio donor
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "prompt": "Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character walking through a neon-lit Tokyo street at night. Refer to the timbre in <Audio 1> for a soft female voiceover describing the scene.",
+    "reference_image_urls": ["https://example.com/character.png"],
+    "reference_audio_urls": ["https://example.com/voice-sample.mp3"],
     "duration": "5s",
     "aspect_ratio": "9:16",
     "resolution": "1080p"
@@ -347,7 +381,7 @@ The response is JSON (`{ "status": "queued" | "running" | "failed", ... }`) unti
 
 ### `At least one reference is required for this model`
 
-Reference-to-video submissions must include at least one of `reference_image_urls` or `reference_video_urls`. Pure text-only generation isn't a valid R2V workflow — use `seedance-2-0-text-to-video` instead.
+Reference-to-video submissions must include at least one of `reference_image_urls`, `reference_video_urls`, or `reference_audio_urls`. Pure text-only generation isn't a valid R2V workflow — use `seedance-2-0-text-to-video` instead.
 
 ### `reference_video_urls must have at most 3 videos`
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -190,6 +190,10 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 
 Reference audio is supported on the R2V variants only. Each entry is forwarded to the model as a `role: "reference_audio"` content item that the prompt addresses as `<Audio 1>`, `<Audio 2>`, `<Audio 3>` — the model uses each clip for vocal timbre, sound effects, or background music depending on how the prompt frames it. The legacy singular `audio_url` field maps to the same content shape and is now equivalent to passing a one-element `reference_audio_urls`.
 
+<Warning>
+**`reference_audio_urls` cannot be the only reference input.** The model requires at least one image or video reference alongside any audio donor. Pair `reference_audio_urls` with `reference_image_urls`, `reference_video_urls`, `image_url`, or `video_url` — audio-only submissions are rejected.
+</Warning>
+
 ### Request size
 
 The queue endpoint accepts JSON bodies up to **35 MB**. Inline data URLs for large videos can push past this — for multi-clip Stitch in particular, prefer URLs over inline base64.
@@ -381,7 +385,7 @@ The response is JSON (`{ "status": "queued" | "running" | "failed", ... }`) unti
 
 ### `At least one reference is required for this model`
 
-Reference-to-video submissions must include at least one of `reference_image_urls`, `reference_video_urls`, or `reference_audio_urls`. Pure text-only generation isn't a valid R2V workflow — use `seedance-2-0-text-to-video` instead.
+Reference-to-video submissions must include at least one of `reference_image_urls`, `reference_video_urls`, `image_references`, or `video_references`. Pure text-only generation isn't a valid R2V workflow — use `seedance-2-0-text-to-video` instead. `reference_audio_urls` alone is not sufficient (see the Audio section above).
 
 ### `reference_video_urls must have at most 3 videos`
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -251,10 +251,13 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
     "prompt": "The lighthouse keeper turns toward the storm, lantern raised, waves crashing against the rocks.",
     "image_url": "https://example.com/lighthouse.jpg",
     "duration": "5s",
-    "aspect_ratio": "16:9",
     "resolution": "720p"
   }'
 ```
+
+<Note>
+`seedance-2-0-image-to-video` (and its Fast variant) **do not accept `aspect_ratio`** — the output aspect ratio is auto-derived from the input image's dimensions. Passing the field returns a 400 with *"This model does not support aspect_ratio"*. Use the T2V or R2V variants if you need explicit aspect-ratio control.
+</Note>
 
 ### Reference workflow — subject donor
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -150,7 +150,7 @@ Layering this on top of a workflow prefix (e.g., `Strictly edit <Video 1>, chang
 
 ## Multimodal input limits
 
-These are the model's hard limits; requests outside them are rejected at the model layer (typically as a generic 400). Venice enforces most of them at the schema and pre-charge layers, but a few (image-side aspect ratio, FPS, total-pixel-count on videos) pass through.
+Values below are what the Venice API accepts. Requests outside these ranges are rejected at the schema layer with a 400 before reaching inference.
 
 ### Images
 
@@ -159,15 +159,10 @@ These are the model's hard limits; requests outside them are rejected at the mod
 | Input methods | URL, Base64 data URL, or asset ID |
 | Formats | `.jpeg`, `.png`, `.webp`, `.bmp`, `.tiff`, `.gif`, `.heic`, `.heif` |
 | Aspect ratio (W / H) | exclusive `(0.4, 2.5)` |
-| Width / height per side | exclusive `(300, 6000)` px |
-| Per-image size | ≤ 30 MB |
+| Minimum side | ≥ 300 px |
 | Image count: I2V first-frame | 1 |
 | Image count: I2V first + last frame | 2 |
 | **Image count: R2V (V2 / Fast)** | **1 – 9** |
-
-<Note>
-Avoid Base64 for large images. Base64 inflates payload by ~33% and pushes against the 64 MB total request body cap quickly.
-</Note>
 
 ### Videos
 
@@ -180,11 +175,7 @@ Avoid Base64 for large images. Base64 inflates payload by ~33% and pushes agains
 | **Duration per clip** | `[2, 15]` s (inclusive) |
 | **Max clip count** | 3 (R2V / Stitch / Extend) |
 | **Total combined duration** | ≤ 15 s across all clips |
-| Aspect ratio (W / H) | `[0.4, 2.5]` |
-| Width / height per side | `[300, 6000]` px |
-| Total pixel count | `[640 × 640, 2206 × 946]` |
 | **Per-clip size** | ≤ 50 MB |
-| Frame rate (FPS) | `[24, 60]` |
 
 ### Audio
 
@@ -197,9 +188,9 @@ Avoid Base64 for large images. Base64 inflates payload by ~33% and pushes agains
 | **Total combined duration** | ≤ 15 s |
 | **Per-clip size** | ≤ 15 MB |
 
-### Request body cap
+### Request size
 
-Venice's queue endpoint accepts JSON bodies up to **35 MB**. Inline data URLs for large videos can push past this — for multi-clip Stitch in particular, prefer URLs over inline base64. (Image inputs almost never trigger this.)
+The queue endpoint accepts JSON bodies up to **35 MB**. Inline data URLs for large videos can push past this — for multi-clip Stitch in particular, prefer URLs over inline base64.
 
 ---
 
@@ -440,10 +431,6 @@ Workflow is inferred from prompt syntax. Common misroutings:
 - Wanting to **Edit** but writing `Generate a video based on <Video 1>` → ambiguous; model may default to Reference
 
 Use the canonical prefixes exactly as written: `Strictly edit <Video 1>, ...`, `Extend <Video 1>, ...`, `<Video 1> + ... + followed by <Video 2>`.
-
-### Aspect ratio or pixel count out of range on a video
-
-Common when uploading vertical phone video to an R2V flow that maxes at `2206 × 946`. Re-encode or crop the input clip so each side is in `[300, 6000]` px and the total pixel count fits in `[640×640, 2206×946]`.
 
 ### Unexpectedly high charge
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Seedance 2.0"
-description: "BytePlus Dreamina Seedance 2.0 — Venice's flagship multimodal video model. Text / image / reference-to-video on one endpoint, with four workflows (Reference, Edit, Extend, Stitch) inferred from prompt shape."
+description: "Seedance 2.0 — Venice's flagship multimodal video model. Text / image / reference-to-video on one endpoint, with four workflows (Reference, Edit, Extend, Stitch) inferred from prompt shape."
 'og:title': "Seedance 2.0 Guide | Venice API Docs"
-'og:description': "Generate, edit, extend and stitch videos with BytePlus Dreamina Seedance 2.0 via the Venice API. Workflow patterns, multimodal limits, pricing, and worked examples."
+'og:description': "Generate, edit, extend and stitch videos with Seedance 2.0 via the Venice API. Workflow patterns, multimodal limits, pricing, and worked examples."
 ---
 
-Seedance 2.0 is BytePlus's flagship Dreamina video model, exposed on Venice as a family of three variants for text-, image-, and reference-driven video generation. The **reference-to-video** variant is unusually powerful: a single endpoint and a single model ID handle **four distinct workflows** (Reference, Edit, Extend, Stitch) — the workflow is inferred from the **shape of your prompt**.
+Seedance 2.0 is a flagship multimodal video model exposed on Venice as a family of three variants for text-, image-, and reference-driven video generation. The **reference-to-video** variant is unusually powerful: a single endpoint and a single model ID handle **four distinct workflows** (Reference, Edit, Extend, Stitch) — the workflow is inferred from the **shape of your prompt**.
 
 This guide walks through the variants, the four workflows with verbatim canonical prompts, the multimodal input limits, pricing, and complete `curl` examples.
 
@@ -24,7 +24,7 @@ All variants are async. Submit via `POST /api/v1/video/queue`, then poll `POST /
 
 ## The "one model, four workflows" model
 
-The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast sibling) is the same BytePlus model serving four different tasks. **BytePlus infers the task from the prompt prefix and the shape of your `content[]` inputs.** There is no `task` or `workflow` field — the prompt syntax is the routing.
+The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast sibling) is the same underlying model serving four different tasks. **The model infers the task from the prompt prefix and the shape of your inputs.** There is no `task` or `workflow` field — the prompt syntax is the routing.
 
 | Workflow | What it does | Prompt prefix | Inputs |
 |---|---|---|---|
@@ -43,7 +43,7 @@ The **prompt syntax is canonical and case-sensitive**: angle brackets, capital f
 
 Use the reference assets as **donors** — subject, scene, motion, style, or audio tone — to generate a brand-new video.
 
-**Canonical prompt patterns** (from BytePlus's Prompt Guide §2.4):
+**Canonical prompt patterns**:
 
 ```
 Refer to <Subject N> in <Image N> to generate ...
@@ -61,7 +61,7 @@ Refer to the [tone | timbre] in <Audio N> to generate ...
 
 Modify a single input video. **Anything not explicitly named in the prompt is preserved.** Use this when you want a localized change (subject swap, weather/color change, element add/remove) rather than a wholly new video.
 
-**Canonical prompt pattern** (from BytePlus's Prompt Guide §2.5.1):
+**Canonical prompt pattern**:
 
 ```
 Strictly edit <Video 1>, changing its [original feature] to [new feature] ...
@@ -91,7 +91,7 @@ The last example combines Edit with an image reference — perfectly legal, the 
 
 ### Extend workflow
 
-Continue a single clip forward or backward in time. **By default Seedance returns only the new content** — not the original input concatenated with the extension. This is BytePlus's documented design choice for transition continuity; if you want the input clip preserved alongside the extension, say so explicitly:
+Continue a single clip forward or backward in time. **By default Seedance returns only the new content** — not the original input concatenated with the extension. This is a documented design choice for transition continuity; if you want the input clip preserved alongside the extension, say so explicitly:
 
 ```
 Extend <Video 1>, generate [description of extended content]
@@ -100,9 +100,7 @@ Extend <Video 1>, start with <Video 1>, then [description of extended content]  
 Extend <Video 1> backward, [description], and then end with <Video 1>               ← preserves input at end
 ```
 
-BytePlus's transition note (from Prompt Guide §2.5.2):
-
-> *"The model will automatically extract the transition frames for seamless blending. The original segments of the input video will not be re-generated, ensuring perfect continuity."*
+Transition handling: the model automatically extracts the transition frames for seamless blending, and the original segments of the input video are not re-generated.
 
 **Examples**:
 
@@ -114,7 +112,7 @@ BytePlus's transition note (from Prompt Guide §2.5.2):
 
 Connect 2-3 input clips with AI-generated transitions. Total combined input duration must be ≤ 15 s.
 
-**Canonical prompt pattern** (from BytePlus's Prompt Guide §2.5.3):
+**Canonical prompt pattern**:
 
 ```
 <Video 1> + [transition description] + followed by <Video 2> [+ [transition description] + followed by <Video 3>]
@@ -132,7 +130,7 @@ The model auto-trims connecting segments at the join points for continuity.
 
 ## Universal prompt formula
 
-Across all four workflows, BytePlus's authoring guidance (Prompt Guide §1.1) is:
+Across all four workflows, the recommended authoring formula is:
 
 ```
 Subject + Motion + Environment (Optional)
@@ -152,7 +150,7 @@ Layering this on top of a workflow prefix (e.g., `Strictly edit <Video 1>, chang
 
 ## Multimodal input limits
 
-These are BytePlus's hard limits; requests outside them are rejected at the model layer (typically as a generic 400). Venice enforces most of them at the schema and pre-charge layers, but a few (image-side aspect ratio, FPS, total-pixel-count on videos) pass through.
+These are the model's hard limits; requests outside them are rejected at the model layer (typically as a generic 400). Venice enforces most of them at the schema and pre-charge layers, but a few (image-side aspect ratio, FPS, total-pixel-count on videos) pass through.
 
 ### Images
 
@@ -168,7 +166,7 @@ These are BytePlus's hard limits; requests outside them are rejected at the mode
 | **Image count: R2V (V2 / Fast)** | **1 – 9** |
 
 <Note>
-Avoid Base64 for large images. Base64 inflates payload by ~33% and pushes against BytePlus's 64 MB total request body cap quickly.
+Avoid Base64 for large images. Base64 inflates payload by ~33% and pushes against the 64 MB total request body cap quickly.
 </Note>
 
 ### Videos
@@ -222,7 +220,7 @@ tokens = (referenceVideoTotalDuration + outputVideoDuration) × outputWidth × o
 priceUSD = tokens × ratePerMTokens / 1_000_000 × 1.25
 ```
 
-The 1.25× factor is Venice's margin over the BytePlus base rate.
+The 1.25× factor is Venice's margin over the base rate.
 
 ### Rate tiers
 
@@ -427,7 +425,7 @@ Reference-to-video submissions must include at least one of `reference_image_url
 
 ### `reference_video_urls must have at most 3 videos`
 
-BytePlus caps reference videos at 3. If you need more clips, run a Stitch first (3 → 1), then use the output as a reference for a follow-up.
+The model caps reference videos at 3. If you need more clips, run a Stitch first (3 → 1), then use the output as a reference for a follow-up.
 
 ### `Per clip must be 2–15s` / aggregate `> 15s`
 
@@ -449,14 +447,12 @@ Common when uploading vertical phone video to an R2V flow that maxes at `2206 ×
 
 ### Unexpectedly high charge
 
-If you included a reference video and didn't pass `reference_video_total_duration` to `/video/quote`, the quote returned the **no-reference** rate but the queue submission still billed at the **with-video** rate (after BytePlus detected the video). Always pass `reference_video_total_duration` when reference videos are present so the quote and the bill line up.
+If you included a reference video and didn't pass `reference_video_total_duration` to `/video/quote`, the quote returned the **no-reference** rate but the queue submission still billed at the **with-video** rate (after the model detected the video). Always pass `reference_video_total_duration` when reference videos are present so the quote and the bill line up.
 
 ---
 
 ## References
 
-- BytePlus public doc 2291680: [Dreamina Seedance 2.0 series tutorial](https://www.byteplus.com/en/learn)
-- BytePlus public doc 2298881: Video generation tutorial (multimodal input limits)
 - Venice video queue endpoint: [`POST /api/v1/video/queue`](/api-reference/endpoint/video/queue)
 - Venice quote endpoint: [`POST /api/v1/video/quote`](/api-reference/endpoint/video/quote)
 - Companion guide: [Reference to Video](/guides/media/reference-to-video) (covers Kling O3 + Grok Imagine R2V)

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -213,16 +213,6 @@ priceUSD = tokens × ratePerMTokens / 1_000_000 × 1.25
 
 The 1.25× factor is Venice's margin over the base rate.
 
-### Rate tiers
-
-Seedance switches to a cheaper "input with video" rate when **any** reference video is included (T2V/I2V at `refDuration=0` use the higher no-ref rate):
-
-| Variant | Output resolution | Rate without video | Rate with video |
-|---|---|---|---|
-| Seedance 2.0 | 480p / 720p | $7.0 / M tokens | $4.3 / M tokens |
-| Seedance 2.0 | 1080p | $7.7 / M tokens | $4.7 / M tokens |
-| Seedance 2.0 Fast | 480p / 720p | $5.6 / M tokens | $3.3 / M tokens |
-
 ### Floor rule
 
 A short reference video at high resolution would otherwise compute *less* than the same job with no references. To prevent that, the final price is floored at the no-reference baseline:

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -9,10 +9,6 @@ Seedance 2.0 is BytePlus's flagship Dreamina video model, exposed on Venice as a
 
 This guide walks through the variants, the four workflows with verbatim canonical prompts, the multimodal input limits, pricing, and complete `curl` examples.
 
-<Warning>
-**Real human faces are not supported as direct inputs.** Seedance 2.0 rejects reference images and reference videos that contain identifiable human faces. See [Real human face policy](#real-human-face-policy) below for details.
-</Warning>
-
 ## Variants
 
 | Model ID | Variant | Output resolutions | Notes |
@@ -206,16 +202,6 @@ Avoid Base64 for large images. Base64 inflates payload by ~33% and pushes agains
 ### Request body cap
 
 Venice's queue endpoint accepts JSON bodies up to **35 MB**. Inline data URLs for large videos can push past this — for multi-clip Stitch in particular, prefer URLs over inline base64. (Image inputs almost never trigger this.)
-
----
-
-## Real human face policy
-
-Verbatim from BytePlus (public doc 2298881):
-
-> *"Seedance 2.0 series models do not support direct upload of reference images or videos containing real human faces. A series of solutions are provided to make it easier for creatives to use portraits."*
-
-In practice, requests with identifiable real human faces in `reference_image_urls` or `reference_video_urls` will be rejected by BytePlus's content-moderation layer. For Venice web UI users, the [face-asset orchestrator](https://venice.ai/video) handles the proper consent / library workflow transparently. **For API consumers, this orchestrator is not yet exposed** — do not pass identifiable human faces as references via the API. Use stylized characters, animals, products, scenes, or AI-generated subjects instead.
 
 ---
 
@@ -456,10 +442,6 @@ Workflow is inferred from prompt syntax. Common misroutings:
 - Wanting to **Edit** but writing `Generate a video based on <Video 1>` → ambiguous; model may default to Reference
 
 Use the canonical prefixes verbatim: `Strictly edit <Video 1>, ...`, `Extend <Video 1>, ...`, `<Video 1> + ... + followed by <Video 2>`.
-
-### Real-human-face rejection
-
-If you see a generic 400 or a content-moderation error and your reference media includes a recognisable real human face, that's the cause. Replace with stylized characters, products, animals, or AI-generated subjects.
 
 ### Aspect ratio or pixel count out of range on a video
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -15,7 +15,7 @@ This guide walks through the variants, the four workflows with their canonical p
 |---|---|---|---|
 | `seedance-2-0-text-to-video` | T2V | 480p / 720p / 1080p | Text prompt only |
 | `seedance-2-0-image-to-video` | I2V | 480p / 720p / 1080p | First-frame (and optionally last-frame) image grounding |
-| `seedance-2-0-reference-to-video` | R2V | 480p / 720p / 1080p | Up to 9 ref images + 3 ref videos + 3 ref audios. Powers Reference / Edit / Extend / Stitch |
+| `seedance-2-0-reference-to-video` | R2V | 480p / 720p / 1080p | Up to 9 reference images + 3 reference videos. Powers Reference / Edit / Extend / Stitch |
 | `seedance-2-0-fast-text-to-video` | Fast T2V | 480p / 720p | Faster, lower-fidelity tier |
 | `seedance-2-0-fast-image-to-video` | Fast I2V | 480p / 720p | Faster, lower-fidelity tier |
 | `seedance-2-0-fast-reference-to-video` | Fast R2V | 480p / 720p | Faster, lower-fidelity tier; same workflow set |
@@ -28,12 +28,12 @@ The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast s
 
 | Workflow | What it does | Prompt prefix | Inputs |
 |---|---|---|---|
-| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style / audio | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 reference (0-9 images, 0-3 videos, 0-3 audios) |
-| **Edit** | Modify a single input video while preserving the rest | `Strictly edit <Video 1>, changing its ...` | 1 input video + text (images/audio optional grounding) |
+| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style | `Refer to ... in <Image\|Video N> to generate ...` | Text + ≥1 reference (0-9 images, 0-3 videos) |
+| **Edit** | Modify a single input video while preserving the rest | `Strictly edit <Video 1>, changing its ...` | 1 input video + text (images optional grounding) |
 | **Extend** | Forward / backward extension of one clip | `Extend <Video 1>, generate ...` | 1 input video + text |
 | **Stitch** | Stitch 2-3 clips with auto-generated transitions | `<Video 1> + <transition description> + followed by <Video 2> + ...` | 2-3 input videos + text |
 
-The **prompt syntax is canonical and case-sensitive**: angle brackets, capital first letter, single space before the number — `<Video 1>`, `<Image 1>`, `<Audio 1>`.
+The **prompt syntax is canonical and case-sensitive**: angle brackets, capital first letter, single space before the number — `<Video 1>`, `<Image 1>`.
 
 ---
 
@@ -41,21 +41,19 @@ The **prompt syntax is canonical and case-sensitive**: angle brackets, capital f
 
 ### Reference workflow
 
-Use the reference assets as **donors** — subject, scene, motion, style, or audio tone — to generate a brand-new video.
+Use the reference assets as **donors** — subject, scene, motion, style — to generate a brand-new video.
 
 **Canonical prompt patterns**:
 
 ```
 Refer to <Subject N> in <Image N> to generate ...
 Refer to the [action | camera scene | style | sound effect] in <Video N> to generate ...
-Refer to the [tone | timbre] in <Audio N> to generate ...
 ```
 
 **Examples**:
 
 - `Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character riding a horse through snow.`
 - `Refer to the camera scene in <Video 1> to generate a similar establishing shot of a futuristic city at dawn.`
-- `Refer to the timbre in <Audio 1> to generate a narrator describing the unfolding scene.`
 
 ### Edit workflow
 
@@ -136,13 +134,11 @@ Across all four workflows, the recommended authoring formula is:
 Subject + Motion + Environment (Optional)
        + Camera Movement / Cut (Optional)
        + Aesthetic Description (Optional)
-       + Audio (Optional)
 ```
 
 - **Subject + Motion**: the logical foundation — define "Who" is performing "What action"
 - **Environment + Aesthetics**: spatial background, lighting, visual style
 - **Camera**: explicit shot type or movement
-- **Audio**: ambient sound effects for immersive output
 
 Layering this on top of a workflow prefix (e.g., `Strictly edit <Video 1>, changing its <subject + motion + environment + ...>`) produces the highest-quality outputs.
 
@@ -176,17 +172,6 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 | **Max clip count** | 3 (R2V / Stitch / Extend) |
 | **Total combined duration** | ≤ 15 s across all clips |
 | **Per-clip size** | ≤ 50 MB |
-
-### Audio
-
-| Constraint | Value |
-|---|---|
-| Input methods | URL, Base64, or asset ID |
-| Formats | `.wav`, `.mp3` |
-| **Duration per clip** | `[2, 15]` s |
-| **Max clip count** | 3 |
-| **Total combined duration** | ≤ 15 s |
-| **Per-clip size** | ≤ 15 MB |
 
 ### Request size
 
@@ -250,7 +235,7 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
   }'
 ```
 
-### Reference workflow — subject + audio donor
+### Reference workflow — subject donor
 
 ```bash
 curl -X POST https://api.venice.ai/api/v1/video/queue \
@@ -258,9 +243,8 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
   -H "Content-Type: application/json" \
   -d '{
     "model": "seedance-2-0-reference-to-video",
-    "prompt": "Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character walking through a neon-lit Tokyo street at night. Refer to the timbre in <Audio 1> for a soft female voiceover describing the scene.",
+    "prompt": "Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same character walking through a neon-lit Tokyo street at night.",
     "reference_image_urls": ["https://example.com/character.png"],
-    "reference_audio_urls": ["https://example.com/voice-sample.mp3"],
     "duration": "5s",
     "aspect_ratio": "9:16",
     "resolution": "1080p"
@@ -363,7 +347,7 @@ The response is JSON (`{ "status": "queued" | "running" | "failed", ... }`) unti
 
 ### `At least one reference is required for this model`
 
-Reference-to-video submissions must include at least one of `reference_image_urls`, `reference_video_urls`, `reference_audio_urls`, or `typed_references`. Pure text-only generation isn't a valid R2V workflow — use `seedance-2-0-text-to-video` instead.
+Reference-to-video submissions must include at least one of `reference_image_urls` or `reference_video_urls`. Pure text-only generation isn't a valid R2V workflow — use `seedance-2-0-text-to-video` instead.
 
 ### `reference_video_urls must have at most 3 videos`
 


### PR DESCRIPTION
## Summary

Adds a Seedance 2.0 usage guide for Venice API consumers, covering BytePlus Dreamina Seedance 2.0 end-to-end: variants, the four-workflow model (Reference / Edit / Extend / Stitch), multimodal input limits, pricing, complete curl examples, and troubleshooting.

Closes [VEN-5966](https://linear.app/venice/issue/VEN-5966). Follow-up to the merged Seedance R2V outerface work ([outerface#7330](https://github.com/veniceai/outerface/pull/7330)) and the interface chat/Studio UX work ([interface#11478](https://github.com/veniceai/interface/pull/11478) / [#11494](https://github.com/veniceai/interface/pull/11494) / [#11495](https://github.com/veniceai/interface/pull/11495)).

## Why now

The outerface PR exposed Seedance 2.0's three R2V workflows (Edit / Extend / Stitch) to API consumers via the model's `use_case` copy, but external developers had no docs explaining the canonical prompt patterns, multimodal limits, or pricing structure. Per the product decision, **API consumers write their own prompts** — they need self-contained documentation here rather than digging through BytePlus's internal Lark wiki.

## What's in the guide

The new `guides/media/seedance-2-0.mdx` (481 lines) covers:

| Section | Content |
|---|---|
| **Variants** | All 6 Venice model IDs (T2V / I2V / R2V × standard / Fast) with their output-resolution capabilities |
| **One model, four workflows** | The mental model that the same `seedance-2-0-reference-to-video` endpoint handles Reference / Edit / Extend / Stitch, with workflow inferred from prompt syntax |
| **Workflow patterns** | Verbatim canonical prompts from BytePlus's Prompt Guide §2.4 / §2.5, with 2-3 worked examples per workflow |
| **Universal prompt formula** | Subject + Motion + Environment + Camera + Aesthetic + Audio (BytePlus §1.1) |
| **Multimodal input limits** | Hard limits for images / videos / audio (per BytePlus public doc 2298881), plus Venice's 35 MB request body cap |
| **Real human face policy** | Flagged in opening `<Warning>` and again in dedicated section — Seedance rejects identifiable real faces in references; orchestrator not yet exposed via API |
| **Pricing** | Formula, rate tiers, floor rule, sample prices, with `/video/quote` framed as the authoritative live oracle (no baked-in numbers that could drift) |
| **Complete examples** | 7 copy-pasteable `curl` commands: T2V minimal, I2V first-frame, Reference (image+audio donor), Edit, Edit with image grounding, Extend forward, 3-clip Stitch — each with full `reference_video_total_duration` plumbing where relevant |
| **Polling** | Brief refresher + cross-link to the existing Video Generation guide |
| **Troubleshooting** | 7 most common rejection causes with concrete remediation: missing reference, 3-clip cap, duration ranges, prompt-routing misfires, real-face rejection, aspect-ratio range, quote/bill mismatch |

## Conventions used

All examples use BytePlus's documented mention form: angle brackets, capital initial, space before number — `<Video 1>`, `<Image 1>`, `<Audio 1>`, `<Subject 1>`. This is the canonical form BytePlus's prompt-routing relies on; `video1` / `[Video 1]` / `@Video1` are explicitly called out as non-canonical.

## Navigation

Added under **Guides → Image & Video** in `docs.json` (between `reference-to-video` and `video-upscaling`):

```diff
   "pages": [
     "guides/media/image-generation",
     "guides/media/image-editing",
     "guides/media/video-generation",
     "guides/media/reference-to-video",
+    "guides/media/seedance-2-0",
     "guides/media/video-upscaling"
   ]
```

## Cross-link from the queue endpoint

`api-reference/endpoint/video/queue.mdx` gets a "Seedance 2.0" callout right above the existing "Video upscaling" callout, pointing readers to the guide for the four-workflow model details.

## Acceptance criteria (per VEN-5966)

- [x] New file at `guides/media/seedance-2-0.mdx`
- [x] Sidebar navigation entry under Guides → Image & Video
- [x] Cross-linked from `/api-reference/endpoint/video/queue`
- [x] Examples use the canonical `<Video N>` / `<Image N>` / `<Audio N>` format (angle brackets, capital, space)
- [x] Pricing section quotes `/video/quote` as authoritative; doesn't bake in numbers
- [x] Face-restriction policy flagged early (opening `<Warning>` + dedicated section, not buried)
- [x] All test prompts use the patterns we ship in the chat slash-menu — no empty `typedReferences: []` foot-guns
- [ ] **curl examples copy-pasteable and verified against staging** — needs a separate dogfooding pass with a staging API key. Not a code change; will be done before merging.

## What's intentionally NOT in this PR (per ticket out-of-scope)

- Mobile SDK examples — Venice doesn't publish iOS/Android SDKs today
- Python / Go / Java snippets — `curl` only for the first pass; full SDK examples can be a follow-up if customer demand emerges
- Competitor comparisons (Pika, Runway, etc.) — marketing copy, not API docs
- Edit/Extend chip UX walkthroughs — that's interface UX, not API surface

## Source material

Written from these workspace-internal references (kept for reviewer accountability; not linked from the public docs):

- `_docs/bytedance/reference-edit-extend-prompt-patterns.md` — canonical workflow patterns
- `_docs/bytedance/multimodal-input-limits.md` — image/video/audio constraint tables
- `_docs/bytedance/FINDINGS.md §11, §12` — pricing math, BytePlus wiki cross-references
- `_docs/bytedance/2291680-dreamina-seedance-2-0-series-tutorial.md` — BytePlus's own examples
- `_docs/bytedance/JqECwTRd1iVYmwkAjGkcudHUnvc-prompt-guide.md` — Lark prompt guide
