### PR TITLE
feat: private models download link

### DIFF
--- a/api-reference/endpoint/video/queue.mdx
+++ b/api-reference/endpoint/video/queue.mdx
@@ -7,6 +7,8 @@ openapi: 'POST /video/queue'
 
 Call `/video/quote` to get a price estimate, then poll `/video/retrieve` with the returned `queue_id` until complete.
 
+Private models also return a `download_url` from this endpoint. That URL is one-time delivery with limited retries for broken transfers; use `DELETE` on the URL when finished for best privacy. See the [Video Generation guide](/guides/media/video-generation#private-download-links).
+
 ### Seedance 2.0
 
 For `seedance-2-0-*` models (text-to-video, image-to-video, reference-to-video, plus the `-fast-*` variants), see the [Seedance 2.0 Guide](/guides/media/seedance-2-0) for the four-workflow model (Reference / Edit / Extend / Stitch), canonical prompt patterns, multimodal input limits, and pricing details.
@@ -16,4 +18,3 @@ For `seedance-2-0-*` models (text-to-video, image-to-video, reference-to-video, 
 For the `topaz-video-upscale` model, use `upscale_factor` (1, 2, or 4) instead of `resolution`, and provide a `video_url`. Duration and FPS are detected automatically from the video file. See the [Video Upscaling Guide](/guides/media/video-upscaling) for full details and examples.
 
 -------
-

--- a/api-reference/endpoint/video/queue.mdx
+++ b/api-reference/endpoint/video/queue.mdx
@@ -7,7 +7,7 @@ openapi: 'POST /video/queue'
 
 Call `/video/quote` to get a price estimate, then poll `/video/retrieve` with the returned `queue_id` until complete.
 
-Private models also return a `download_url` from this endpoint. That URL is one-time delivery with limited retries for broken transfers; use `DELETE` on the URL when finished for best privacy. See the [Video Generation guide](/guides/media/video-generation#private-download-links).
+Private models also return a `download_url` for the finished video. It is a short-lived delivery URL (a few retries are fine if a download drops); see the [Video Generation guide](/guides/media/video-generation#private-download-links) for details and optional `DELETE` for privacy.
 
 ### Seedance 2.0
 

--- a/api-reference/endpoint/video/retrieve.mdx
+++ b/api-reference/endpoint/video/retrieve.mdx
@@ -5,7 +5,7 @@ openapi: 'POST /video/retrieve'
 "og:description": "Documentation covering Venice's video retrieval API."
 ---
 
-For private models, the finished file is downloaded from the `download_url` returned by `/video/queue` (not as binary from this endpoint). Read [Private download links](/guides/media/video-generation#private-download-links) for one-time semantics, IP limits, and revoking the link with `DELETE`.
+For private models, the finished file is downloaded from the `download_url` returned by `/video/queue` (not as binary from this endpoint). See [Private download links](/guides/media/video-generation#private-download-links) for how the link works, retries, and optional `DELETE`.
 
 -------
 

--- a/api-reference/endpoint/video/retrieve.mdx
+++ b/api-reference/endpoint/video/retrieve.mdx
@@ -5,5 +5,7 @@ openapi: 'POST /video/retrieve'
 "og:description": "Documentation covering Venice's video retrieval API."
 ---
 
+For private models, the finished file is downloaded from the `download_url` returned by `/video/queue` (not as binary from this endpoint). Read [Private download links](/guides/media/video-generation#private-download-links) for one-time semantics, IP limits, and revoking the link with `DELETE`.
+
 -------
 

--- a/guides/media/video-generation.mdx
+++ b/guides/media/video-generation.mdx
@@ -51,7 +51,7 @@ For Grok Imagine Private models, the queue response includes an extra `download_
 }
 ```
 
-`download_url` is a pre-signed URL you use to download the finished video instead of reading it from the retrieve response. It is only returned once, so persist it alongside `queue_id`. This applies to all four Grok Imagine Private variants:
+`download_url` is a pre-signed URL you use to download the finished video instead of reading it from the retrieve response. It is only returned once in the queue response, so persist it alongside `queue_id`. This applies to all four Grok Imagine Private variants:
 
 - `grok-imagine-text-to-video-private`
 - `grok-imagine-image-to-video-private`
@@ -61,6 +61,28 @@ For Grok Imagine Private models, the queue response includes an extra `download_
 Unlike the public `grok-imagine-*-video` variants, Grok Imagine Private models are not billed for content-moderation rejections, so you only pay for successful generations.
 
 Save `model`, `queue_id`, and `download_url` (if present) for all subsequent calls.
+
+### Private download links
+
+For private models, `download_url` is how you fetch the finished file. Treat it as a **one-time delivery link**, not permanent hosting or a CDN URL. A small number of `GET` retries are allowed so clients can finish a download if the connection drops partway through—**not** so the same link can be fetched many times, shared across users, or embedded as a long-lived media URL. Using the link that way can produce `429` or `410` responses that look confusing if you expected unlimited reuse.
+
+Downloads are **bound to a single client IP** with only a little slack for normal situations (for example you retried after toggling a VPN or switching networks). Requests from many different IPs against the same link are not allowed.
+
+The URL stays valid for up to **24 hours**, or until the object is removed.
+
+<Warning>
+Do not use `download_url` as a way to host or redistribute the video. Persist the bytes to your own storage if you need a stable or public URL.
+</Warning>
+
+**Privacy: revoke the link with `DELETE`**
+
+After you have successfully downloaded the file (or if you abandon the download and want the link gone), call **`DELETE`** on the same `download_url`. No Venice API key is required on that request. We recommend this whenever you care about privacy: many proxies and middleboxes outside Venice log full URLs, so revoking the pre-signed link as soon as you are done is the most reliable way to limit exposure.
+
+```bash
+curl -X DELETE "$DOWNLOAD_URL"
+```
+
+**Flow:** poll `/video/retrieve` until `COMPLETED` → `GET` the `download_url` (retry sparingly if the transfer is interrupted) → copy the file where you need it → `DELETE` the `download_url` → optionally call `/video/complete` if you still use queue-based cleanup.
 
 ## Step 2: Poll for Completion
 
@@ -99,7 +121,7 @@ Times are in milliseconds. Use `average_execution_time` to estimate remaining wa
 Response body is raw binary video data. Save to file.
 
 **Complete response (200, application/json with `"COMPLETED"`):**
-For models that returned a `download_url` at queue time, retrieve always returns JSON. Fetch the video with `GET download_url`. The URL is pre-signed (no auth header needed) and valid for 24 hours.
+For models that returned a `download_url` at queue time, retrieve always returns JSON. Fetch the video with `GET download_url` (no auth header). See [Private download links](#private-download-links) for one-time use, IP limits, and revoking the URL with `DELETE`.
 
 ## Step 3: Cleanup (Optional)
 
@@ -325,7 +347,8 @@ Quote is in USD.
 | 401 | `queue`, `retrieve`, `complete` | Auth failed | Check API key |
 | 402 | `queue` | Insufficient balance | Add funds |
 | 404 | `retrieve`, `download_url` | Media not found (invalid, expired, or deleted) | Verify `model`/`queue_id` or re-queue |
-| 410 | `download_url` | Pre-signed URL expired (>24h) | Re-queue the generation |
+| 410 | `download_url` | Pre-signed URL expired, already consumed, or revoked (for example after `DELETE`) | Re-queue if you still need the asset; do not treat the link as reusable hosting |
+| 429 | `download_url` | Too many attempts or abuse of a one-time link | Download once (with limited retries for interrupted transfers), then `DELETE` the URL; persist the file to your own storage if you need repeat access |
 | 413 | `queue` | Payload too large | Reduce image/audio size |
 | 422 | `queue`, `retrieve` | Content violation | Modify prompt |
 | 500 | `queue`, `retrieve`, `complete` | Inference/processing failed | Retry with backoff; contact support if persistent |
@@ -338,8 +361,8 @@ Quote is in USD.
 1. Poll `/video/retrieve` on an interval (for example, every 5 seconds)
 2. If `Content-Type` is `application/json` and `status` is `"PROCESSING"`, wait and poll again. Use `average_execution_time` and `execution_duration` (milliseconds) to estimate remaining time
 3. If `Content-Type` is `video/mp4`, save the response body as your output file
-4. If `Content-Type` is `application/json` and `status` is `"COMPLETED"`, `GET` the `download_url` from the queue response to fetch the video
-5. Optional cleanup: set `delete_media_on_completion: true` on retrieve, or call `/video/complete` after download
+4. If `Content-Type` is `application/json` and `status` is `"COMPLETED"`, `GET` the `download_url` from the queue response to fetch the video (see [Private download links](#private-download-links))
+5. If you used `download_url`, call `DELETE` on that URL after a successful download (or to discard the link) for best privacy; then optionally set `delete_media_on_completion: true` on retrieve or call `/video/complete` for queue-based cleanup
 6. Handle `404` as invalid, expired, or deleted media; handle `500/503` with retries/backoff
 
 ---

--- a/guides/media/video-generation.mdx
+++ b/guides/media/video-generation.mdx
@@ -64,25 +64,27 @@ Save `model`, `queue_id`, and `download_url` (if present) for all subsequent cal
 
 ### Private download links
 
-For private models, `download_url` is how you fetch the finished file. Treat it as a **one-time delivery link**, not permanent hosting or a CDN URL. A small number of `GET` retries are allowed so clients can finish a download if the connection drops partway through—**not** so the same link can be fetched many times, shared across users, or embedded as a long-lived media URL. Using the link that way can produce `429` or `410` responses that look confusing if you expected unlimited reuse.
+For private models, `download_url` is how you fetch the finished file once the job is complete. The link is **short-lived and single-purpose**: it is there to deliver the MP4 to you, not to serve as a long-term or widely shared URL.
 
-Downloads are **bound to a single client IP** with only a little slack for normal situations (for example you retried after toggling a VPN or switching networks). Requests from many different IPs against the same link are not allowed.
+If a download is interrupted, you can **retry the same `GET` a few times** from the same environment until the file finishes. Those retries are for recovering from network blips—not for polling the same link indefinitely, sharing it across many clients, or embedding it like a permanent media URL. Patterns like that often show up as **`429`** or **`410`**, which can be surprising if you expected the link to behave like regular file hosting.
+
+For reliability, **`GET` requests should originate from one client network**. There is some flexibility if your IP changes once (for example you disconnect a VPN and try again), but wide variation in source IPs usually will not work.
 
 The URL stays valid for up to **24 hours**, or until the object is removed.
 
-<Warning>
-Do not use `download_url` as a way to host or redistribute the video. Persist the bytes to your own storage if you need a stable or public URL.
-</Warning>
+<Note>
+If you need a stable URL, public playback, or repeated access over time, save the file to **your own storage** first and serve it from there.
+</Note>
 
 **Privacy: revoke the link with `DELETE`**
 
-After you have successfully downloaded the file (or if you abandon the download and want the link gone), call **`DELETE`** on the same `download_url`. No Venice API key is required on that request. We recommend this whenever you care about privacy: many proxies and middleboxes outside Venice log full URLs, so revoking the pre-signed link as soon as you are done is the most reliable way to limit exposure.
+When you are done fetching the file—or if you decide not to keep it—you can call **`DELETE`** on the same `download_url`. No Venice API key is required on that request. This is optional but **recommended when privacy matters**, because some proxies and middleboxes outside Venice keep logs of full URLs, and deleting the link is the simplest way to narrow the window where the pre-signed URL exists.
 
 ```bash
 curl -X DELETE "$DOWNLOAD_URL"
 ```
 
-**Flow:** poll `/video/retrieve` until `COMPLETED` → `GET` the `download_url` (retry sparingly if the transfer is interrupted) → copy the file where you need it → `DELETE` the `download_url` → optionally call `/video/complete` if you still use queue-based cleanup.
+**Flow:** poll `/video/retrieve` until `COMPLETED` → `GET` the `download_url` (retry lightly if the transfer drops) → save the file where you need it → `DELETE` the `download_url` if you want the link invalidated → optionally call `/video/complete` if you still use queue-based cleanup.
 
 ## Step 2: Poll for Completion
 
@@ -121,7 +123,7 @@ Times are in milliseconds. Use `average_execution_time` to estimate remaining wa
 Response body is raw binary video data. Save to file.
 
 **Complete response (200, application/json with `"COMPLETED"`):**
-For models that returned a `download_url` at queue time, retrieve always returns JSON. Fetch the video with `GET download_url` (no auth header). See [Private download links](#private-download-links) for one-time use, IP limits, and revoking the URL with `DELETE`.
+For models that returned a `download_url` at queue time, retrieve always returns JSON. Fetch the video with `GET download_url` (no auth header). See [Private download links](#private-download-links) for how these URLs work, retries, and optional `DELETE`.
 
 ## Step 3: Cleanup (Optional)
 
@@ -347,8 +349,8 @@ Quote is in USD.
 | 401 | `queue`, `retrieve`, `complete` | Auth failed | Check API key |
 | 402 | `queue` | Insufficient balance | Add funds |
 | 404 | `retrieve`, `download_url` | Media not found (invalid, expired, or deleted) | Verify `model`/`queue_id` or re-queue |
-| 410 | `download_url` | Pre-signed URL expired, already consumed, or revoked (for example after `DELETE`) | Re-queue if you still need the asset; do not treat the link as reusable hosting |
-| 429 | `download_url` | Too many attempts or abuse of a one-time link | Download once (with limited retries for interrupted transfers), then `DELETE` the URL; persist the file to your own storage if you need repeat access |
+| 410 | `download_url` | Pre-signed URL expired, fully used, or revoked (for example after `DELETE`) | Start a new generation if you need another file; each link is intentionally short-lived |
+| 429 | `download_url` | Rate limited—often from many retries or repeated fetches of the same link | Finish the download (a few retries are fine if the connection drops), save a local copy, and use `DELETE` if you want to clear the link; keep ongoing access on your own storage |
 | 413 | `queue` | Payload too large | Reduce image/audio size |
 | 422 | `queue`, `retrieve` | Content violation | Modify prompt |
 | 500 | `queue`, `retrieve`, `complete` | Inference/processing failed | Retry with backoff; contact support if persistent |
@@ -362,7 +364,7 @@ Quote is in USD.
 2. If `Content-Type` is `application/json` and `status` is `"PROCESSING"`, wait and poll again. Use `average_execution_time` and `execution_duration` (milliseconds) to estimate remaining time
 3. If `Content-Type` is `video/mp4`, save the response body as your output file
 4. If `Content-Type` is `application/json` and `status` is `"COMPLETED"`, `GET` the `download_url` from the queue response to fetch the video (see [Private download links](#private-download-links))
-5. If you used `download_url`, call `DELETE` on that URL after a successful download (or to discard the link) for best privacy; then optionally set `delete_media_on_completion: true` on retrieve or call `/video/complete` for queue-based cleanup
+5. If you used `download_url`, consider `DELETE` on that URL when you are done to narrow how long the pre-signed URL exists; then optionally set `delete_media_on_completion: true` on retrieve or call `/video/complete` for queue-based cleanup
 6. Handle `404` as invalid, expired, or deleted media; handle `500/503` with retries/backoff
 
 ---

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -10729,15 +10729,15 @@ paths:
                       Pre-signed URL for the completed video (private models only). When
                       present, `/video/retrieve` returns JSON status only; after
                       status is `COMPLETED`, download with `GET` (no auth header on this
-                      URL). Valid up to 24 hours or until the object is removed. The link is
-                      for one-time delivery: a small number of `GET` retries are allowed to
-                      recover interrupted downloads—not for repeated serving, embedding as
-                      permanent media, or CDN-style hosting (misuse can yield `429`/`410`).
-                      Downloads are tied to a single client IP with limited tolerance for
-                      brief network changes (for example retrying after VPN on/off). Call
-                      `DELETE` on this same URL after download (or to discard the link) to
-                      revoke it immediately; recommended for privacy because proxies outside
-                      Venice may log URLs.
+                      URL). Valid up to 24 hours or until the object is removed. Intended as
+                      a short-lived delivery URL after the job completes; a few `GET` retries
+                      are supported if a transfer is interrupted. For ongoing or widely
+                      distributed access, copy the file to your own storage first—frequent or
+                      repeated fetching can return `429` or `410`. Requests should come from one client IP,
+                      with flexibility for small network changes (for example VPN on/off).
+                      Optional: call `DELETE` on this URL when finished to invalidate it
+                      sooner; helpful for privacy because some proxies outside Venice log
+                      full URLs.
                 required:
                   - model
                   - queue_id
@@ -10874,7 +10874,7 @@ paths:
         For private models that return a `download_url` from `/video/queue`,
         the completed asset is fetched with `GET` on that URL (not as `video/mp4`
         from this endpoint). See the `download_url` field description on the
-        queue response for one-time use, IP binding, and `DELETE` semantics.
+        queue response for retries, how client IP is handled, and optional `DELETE`.
 
 
         **Authentication:** This endpoint accepts either a Bearer API key or an

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -10725,11 +10725,19 @@ paths:
                     example: 123e4567-e89b-12d3-a456-426614174000
                   download_url:
                     type: string
-                    description: Pre-signed URL to download the completed video. Only present for
-                      VPS-backed models. When provided, the retrieve endpoint
-                      returns JSON status only (no video stream). Fetch this URL
-                      after status is COMPLETED to get the video/mp4 file. Valid
-                      for 24 hours.
+                    description: >-
+                      Pre-signed URL for the completed video (private models only). When
+                      present, `/video/retrieve` returns JSON status only; after
+                      status is `COMPLETED`, download with `GET` (no auth header on this
+                      URL). Valid up to 24 hours or until the object is removed. The link is
+                      for one-time delivery: a small number of `GET` retries are allowed to
+                      recover interrupted downloads—not for repeated serving, embedding as
+                      permanent media, or CDN-style hosting (misuse can yield `429`/`410`).
+                      Downloads are tied to a single client IP with limited tolerance for
+                      brief network changes (for example retrying after VPN on/off). Call
+                      `DELETE` on this same URL after download (or to discard the link) to
+                      revoke it immediately; recommended for privacy because proxies outside
+                      Venice may log URLs.
                 required:
                   - model
                   - queue_id
@@ -10861,6 +10869,12 @@ paths:
       description: >-
         Retrieve a video generation result. Returns the video file if completed,
         or a status if the request is still processing.
+
+
+        For private models that return a `download_url` from `/video/queue`,
+        the completed asset is fetched with `GET` on that URL (not as `video/mp4`
+        from this endpoint). See the `download_url` field description on the
+        queue response for one-time use, IP binding, and `DELETE` semantics.
 
 
         **Authentication:** This endpoint accepts either a Bearer API key or an


### PR DESCRIPTION
Updates docs with documentation around `download_url` link.