### PR TITLE
[VEN-5966] guides: drop misleading 'asset ID' mentions + fix Base64 claim for video

### DIFF
--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -156,7 +156,7 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 
 | Constraint | Value |
 |---|---|
-| Input methods | URL, Base64 data URL, or asset ID |
+| Input methods | URL (`http://`, `https://`) or Base64 data URL (`data:image/...`) |
 | Formats | `.jpeg`, `.png`, `.webp`, `.bmp`, `.tiff`, `.gif`, `.heic`, `.heif` |
 | Aspect ratio (W / H) | exclusive `(0.4, 2.5)` |
 | Minimum side | ≥ 300 px |
@@ -168,7 +168,7 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 
 | Constraint | Value |
 |---|---|
-| Input methods | **URL or asset ID only** (Base64 not accepted) |
+| Input methods | URL (`http://`, `https://`) or Base64 data URL (`data:video/...`) |
 | Formats | `.mp4`, `.mov` |
 | Video codecs | H.264 / AVC, H.265 / HEVC |
 | Audio codecs (in container) | AAC, MP3 |
@@ -181,7 +181,7 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 
 | Constraint | Value |
 |---|---|
-| Input methods | URL or Base64 data URL |
+| Input methods | URL (`http://`, `https://`) or Base64 data URL (`data:audio/...`) |
 | Formats | `.wav`, `.mp3` |
 | **Duration per clip** | `[2, 15]` s |
 | **Max clip count** | 3 |

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -28,7 +28,7 @@ The reference-to-video variant (`seedance-2-0-reference-to-video` and its Fast s
 
 | Workflow | What it does | Prompt prefix | Inputs |
 |---|---|---|---|
-| **Reference** | Generate a new video using uploaded assets as donors for subject / motion / style / audio | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 image OR video reference (0-9 images, 0-3 videos), plus optionally up to 3 audio donors |
+| **Reference** | Generate a new video using uploaded reference files as donors for subject / motion / style / audio | `Refer to ... in <Image\|Video\|Audio N> to generate ...` | Text + ≥1 image OR video reference (0-9 images, 0-3 videos), plus optionally up to 3 audio donors |
 | **Edit** | Modify a single input video while preserving the rest | `Strictly edit <Video 1>, changing its ...` | 1 input video + text (images optional grounding) |
 | **Extend** | Forward / backward extension of one clip | `Extend <Video 1>, generate ...` | 1 input video + text |
 | **Stitch** | Stitch 2-3 clips with auto-generated transitions | `<Video 1> + <transition description> + followed by <Video 2> + ...` | 2-3 input videos + text |
@@ -41,7 +41,7 @@ The **prompt syntax is canonical and case-sensitive**: angle brackets, capital f
 
 ### Reference workflow
 
-Use the reference assets as **donors** — subject, scene, motion, style, vocal timbre — to generate a brand-new video.
+Use the uploaded reference files as **donors** — subject, scene, motion, style, vocal timbre — to generate a brand-new video.
 
 **Canonical prompt patterns**:
 


### PR DESCRIPTION
## Summary

Followup to [#256](https://github.com/veniceai/api-docs/pull/256). Three corrections to the **Multimodal input limits** tables in the Seedance 2.0 guide.

## What was wrong

| Row | Old text | Problem |
|---|---|---|
| **Image** | `URL, Base64 data URL, or asset ID` | "asset ID" is misleading — Venice's public API rejects `asset://` URIs. The scheme exists only as a server-side internal pass-through for the face-asset orchestrator ([VEN-5886](https://linear.app/venice/issue/VEN-5886)) and is never accepted from clients. |
| **Video** | `URL or asset ID only (Base64 not accepted)` | Doubly wrong: (1) same "asset ID" leak as above. (2) "Base64 not accepted" was lifted verbatim from BytePlus's internal-model docs but is wrong at the **Venice API layer** — our schema accepts `data:video/...` URLs; outerface materializes them server-side, VPS-stages them, and sends only the VPS URL to BytePlus. So BytePlus never sees the Base64, but the Venice consumer can absolutely submit it. |
| **Audio** | `URL or Base64 data URL` | Already correct, just normalized wording to match the other two rows. |

## What it says now

Same form across all three rows:

```
URL (http://, https://) or Base64 data URL (data:image/...)
URL (http://, https://) or Base64 data URL (data:video/...)
URL (http://, https://) or Base64 data URL (data:audio/...)
```

## Verified against schema

```ts
// outerface/src/api/v1/video/queue/api-video-queue-schema.ts
.refine(urls => urls.every(url =>
  url.startsWith('data:') || url.startsWith('http://') || url.startsWith('https://')
))
```

`asset://` rejected. `data:` accepted. Confirmed in the linked schema files for all three reference fields (image, video, audio).

## What stayed

The colloquial "uploaded assets" / "reference assets" phrases in the section intros (lines 31, 44) — those use "asset" in the everyday-English sense ("the files you uploaded as references"), not the technical `asset://` URI sense. Not misleading.

## Linear

[VEN-5966](https://linear.app/venice/issue/VEN-5966) — followup to the original guide PR which was merged this morning.