### PR TITLE
guides: add Agent Tooling section (Venice MCP, Skills, Video Harness)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -83,6 +83,15 @@
             ]
           },
           {
+            "group": "Agent Tooling",
+            "icon": "screwdriver-wrench",
+            "pages": [
+              "guides/integrations/venice-mcp",
+              "guides/integrations/venice-skills",
+              "guides/integrations/venice-video-harness"
+            ]
+          },
+          {
             "group": "Coding Tools",
             "icon": "terminal",
             "pages": [

--- a/guides/integrations/venice-mcp.mdx
+++ b/guides/integrations/venice-mcp.mdx
@@ -1,0 +1,218 @@
+---
+title: Venice MCP Server
+description: The official Venice Model Context Protocol server — 31 Venice tools for any MCP host
+"og:title": "Venice MCP Server | Venice API Docs"
+"og:description": "Plug Venice's chat, image, video, audio, music, and character models into Claude Desktop, Cursor, LM Studio, and any other MCP host."
+---
+
+The [Venice MCP Server](https://github.com/veniceai/venice-mcp-server) is the official [Model Context Protocol](https://modelcontextprotocol.io/) server for Venice. It exposes the full Venice API — chat, image, video, audio, music, embeddings, web augment, and characters — as **31 tools** that any MCP-compatible agent can call.
+
+<Card title="GitHub: veniceai/venice-mcp-server" icon="github" href="https://github.com/veniceai/venice-mcp-server">
+  Published as [`@veniceai/mcp-server`](https://www.npmjs.com/package/@veniceai/mcp-server) on npm. MIT licensed.
+</Card>
+
+<CardGroup cols={3}>
+  <Card title="31 Tools" icon="toolbox">
+    Every Venice modality in one config block
+  </Card>
+  <Card title="Any MCP Host" icon="plug">
+    Claude Desktop, Cursor, ChatGPT, LM Studio, Continue, and more
+  </Card>
+  <Card title="Wallet Auth (Optional)" icon="wallet">
+    Bring an API key, or pay per call with a SIWE-signed wallet via x402
+  </Card>
+</CardGroup>
+
+## Quick start
+
+<Steps>
+  <Step title="Get a Venice API key">
+    Generate one from [venice.ai/settings/api](https://venice.ai/settings/api). See the [API key guide](/guides/getting-started/generating-api-key) for step-by-step instructions.
+  </Step>
+
+  <Step title="Add Venice to your MCP host config">
+    Drop this into your MCP host's config file:
+
+    ```json
+    {
+      "mcpServers": {
+        "venice": {
+          "command": "npx",
+          "args": ["-y", "@veniceai/mcp-server@0.2.0"],
+          "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
+        }
+      }
+    }
+    ```
+
+    Common config paths:
+
+    | Host | Path |
+    |---|---|
+    | Claude Desktop (macOS) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+    | Claude Desktop (Windows) | `%APPDATA%\Claude\claude_desktop_config.json` |
+    | Cursor | `~/.cursor/mcp.json` |
+    | LM Studio | `mcp.json` (from the app's MCP settings) |
+  </Step>
+
+  <Step title="Restart your MCP host">
+    Your agent now has chat, image, video, music, TTS, ASR, and 25 more Venice tools available.
+  </Step>
+</Steps>
+
+<Note>
+Most MCP hosts only pass environment variables that are **explicitly listed** in the `env` block — system-level env vars are not inherited. If you see 402 errors with an API key set, double-check that `VENICE_API_KEY` is inside `env` in your config.
+</Note>
+
+## What you get
+
+**31 tools** spanning every Venice modality, **3 resources** (`venice://models`, `venice://styles`, `venice://voices`), and **3 prompt templates**.
+
+### Chat & embeddings
+
+| Tool | Description |
+|---|---|
+| `venice_chat` | OpenAI-compatible chat completion against Venice's full LLM catalog. |
+| `venice_responses` | OpenAI-compatible Responses API with single- or multi-turn tool support. |
+| `venice_embeddings` | Compute embeddings for text input. |
+| `venice_chat_with_character` | Chat with a Venice character by slug. |
+
+### Image
+
+| Tool | Description |
+|---|---|
+| `venice_image_generate` | Generate an image (Flux 2, Lustify SDXL, Anime/WAI, Qwen Image, GPT Image, Nano Banana Pro, and more). |
+| `venice_image_edit` | Edit an image with a prompt. |
+| `venice_image_multi_edit` | Edit multiple images together with one prompt. |
+| `venice_image_upscale` | Upscale an image up to 4×. |
+| `venice_image_remove_bg` | Remove an image background. |
+| `venice_image_styles` | List image style presets. |
+
+### Video
+
+| Tool | Description |
+|---|---|
+| `venice_video_generate` | Queue a video generation (Sora 2, Veo 3.1, Kling, Wan, LTX 2, Seedance, Runway Gen-4, and more). |
+| `venice_video_status` | Check status of a queued video job. |
+| `venice_video_complete` | Mark a completed video as downloaded; deletes server-side media. |
+| `venice_video_transcriptions` | Transcribe a YouTube video URL. |
+| `venice_video_quote` | Get a price quote before queuing. |
+
+### Audio (TTS / ASR)
+
+| Tool | Description |
+|---|---|
+| `venice_tts` | Text-to-speech with cloned voices and emotion tags. |
+| `venice_asr` | Transcribe audio from a URL. |
+| `venice_voice_clone` | List built-in voices or clone a voice from a sample. |
+| `venice_audio_quote` | Get a price quote for music generation. |
+
+### Music
+
+| Tool | Description |
+|---|---|
+| `venice_music_generate` | Queue music generation (`ace-step-15`, `elevenlabs-music`, `minimax-music-v2/v25/v26`, `stable-audio-25`, `mmaudio-v2`, `elevenlabs-sound-effects-v2`). |
+| `venice_music_status` | Check status of a queued music job. |
+| `venice_music_complete` | Mark a completed music job as downloaded. |
+
+### Web augment, catalog, and crypto
+
+| Tool | Description |
+|---|---|
+| `venice_web_search` | Search the web (Firecrawl-backed). |
+| `venice_web_scrape` | Scrape one URL into markdown. |
+| `venice_text_parser` | Extract text from PDF/DOCX/EPUB/PPTX/XLSX. |
+| `venice_list_models` | List the live model catalog with prices. |
+| `venice_list_characters` | List public Venice characters. |
+| `venice_crypto_rpc` | Proxy JSON-RPC calls to Base, Ethereum, Polygon, Arbitrum, or Optimism. |
+
+### x402 wallet helpers
+
+Only relevant if you authenticate with a wallet via [x402](/guides/integrations/x402-venice-api) instead of an API key.
+
+| Tool | Description |
+|---|---|
+| `venice_x402_balance` | Check prepaid x402 credit balance for a wallet. |
+| `venice_x402_top_up_info` | Fetch top-up requirements (network, USDC token, receiver, min amount). |
+| `venice_x402_transactions` | List recent x402 top-up and debit transactions. |
+
+## Configuration
+
+The server is configured entirely through environment variables.
+
+| Env var | Default | Notes |
+|---|---|---|
+| `VENICE_API_KEY` | _(none)_ | Your Venice API key. The simplest setup. |
+| `VENICE_DEFAULT_CHAT_MODEL` | `venice-uncensored` | |
+| `VENICE_DEFAULT_IMAGE_MODEL` | `flux-2-pro` | |
+| `VENICE_DEFAULT_TTS_MODEL` | `tts-kokoro` | |
+| `VENICE_DEFAULT_ASR_MODEL` | `openai/whisper-large-v3` | |
+| `VENICE_DISABLE_NSFW` | `0` | Set to `1` to remove NSFW capability notes from tool descriptions. |
+| `VENICE_HTTP_TIMEOUT_MS` | `60000` | |
+| `VENICE_SIWX_TOKEN` | _(none)_ | x402 wallet-mode auth token. See [x402 below](#x402-wallet-mode). |
+
+If both `VENICE_API_KEY` and `VENICE_SIWX_TOKEN` are set, the API key wins.
+
+## x402 wallet mode
+
+Venice supports authenticating with a [SIWE-signed wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on Base mainnet, in addition to the normal API key flow. No email, phone, or KYC — your wallet is the only identity.
+
+```json
+{
+  "mcpServers": {
+    "venice": {
+      "command": "npx",
+      "args": ["-y", "@veniceai/mcp-server@0.2.0"],
+      "env": { "VENICE_SIWX_TOKEN": "<base64 SIWE payload>" }
+    }
+  }
+}
+```
+
+The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on every Venice API call. The server never sees your private key — SIWE signing and USDC top-up authorizations happen in your own wallet.
+
+| Flow | What happens |
+|---|---|
+| **One-time setup** | Sign a SIWE message in your wallet → produces a SIWX token (base64 JSON). |
+| **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC EIP-3009 transfer in your wallet, resubmit, and Venice credits your balance. |
+| **Every inference call** | MCP server sends `X-Sign-In-With-X: <SIWX>`; Venice debits your prepaid balance. |
+
+Minimum top-up is **$5 USD**. Minimum balance to call inference is **$0.10**. Once topped up, calls are sub-100ms — settlement happens off-chain on a fast credit account.
+
+<Tip>
+Wallets linked to a Venice account with DIEM staked consume from the staking balance instead of USDC credits — no top-up needed.
+</Tip>
+
+## Self-hosting (Streamable HTTP)
+
+For team or workspace deployments, run the MCP server over HTTP instead of stdio:
+
+```bash
+docker run -p 3333:3333 \
+  -e VENICE_API_KEY=<your-venice-api-key> \
+  -e VENICE_MCP_AUTH_TOKEN=<choose-a-long-random-token> \
+  ghcr.io/veniceai/venice-mcp-server:latest
+```
+
+The server is now available at `http://localhost:3333/mcp`. HTTP clients must send `Authorization: Bearer <VENICE_MCP_AUTH_TOKEN>`.
+
+<Warning>
+`/mcp` is a credential-backed tool execution endpoint: callers can spend the configured Venice API key or x402 balance. When HTTP mode binds outside loopback, startup fails unless `VENICE_MCP_AUTH_TOKEN` is set. For production, pin the npm package version explicitly instead of relying on `latest`.
+</Warning>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="GitHub" icon="github" href="https://github.com/veniceai/venice-mcp-server">
+    Source code, issues, and releases
+  </Card>
+  <Card title="npm" icon="npm" href="https://www.npmjs.com/package/@veniceai/mcp-server">
+    `@veniceai/mcp-server`
+  </Card>
+  <Card title="Venice Skills" icon="book" href="/guides/integrations/venice-skills">
+    Companion skills that teach agents how to use these tools
+  </Card>
+  <Card title="MCP Spec" icon="arrow-up-right-from-square" href="https://modelcontextprotocol.io/">
+    Learn more about the Model Context Protocol
+  </Card>
+</CardGroup>

--- a/guides/integrations/venice-mcp.mdx
+++ b/guides/integrations/venice-mcp.mdx
@@ -177,7 +177,7 @@ The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on 
 | **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC EIP-3009 transfer in your wallet, resubmit, and Venice credits your balance. |
 | **Every inference call** | MCP server sends `X-Sign-In-With-X: <SIWX>`; Venice debits your prepaid balance. |
 
-Minimum top-up is **$5 USD**. Minimum balance to call inference is **$0.10**. Once topped up, calls are sub-100ms because settlement happens off-chain on a fast credit account.
+Minimum top-up is **\$5 USD**. Minimum balance to call inference is **\$0.10**. Once topped up, calls are sub-100ms because settlement happens off-chain on a fast credit account.
 
 <Tip>
 Wallets linked to a Venice account with DIEM staked consume from the staking balance instead of USDC credits, so no top-up is needed.

--- a/guides/integrations/venice-mcp.mdx
+++ b/guides/integrations/venice-mcp.mdx
@@ -1,11 +1,11 @@
 ---
 title: Venice MCP Server
-description: The official Venice Model Context Protocol server — 31 Venice tools for any MCP host
+description: The official Venice Model Context Protocol server with 31 Venice tools for any MCP host
 "og:title": "Venice MCP Server | Venice API Docs"
 "og:description": "Plug Venice's chat, image, video, audio, music, and character models into Claude Desktop, Cursor, LM Studio, and any other MCP host."
 ---
 
-The [Venice MCP Server](https://github.com/veniceai/venice-mcp-server) is the official [Model Context Protocol](https://modelcontextprotocol.io/) server for Venice. It exposes the full Venice API — chat, image, video, audio, music, embeddings, web augment, and characters — as **31 tools** that any MCP-compatible agent can call.
+The [Venice MCP Server](https://github.com/veniceai/venice-mcp-server) is the official [Model Context Protocol](https://modelcontextprotocol.io/) server for Venice. It exposes the full Venice API (chat, image, video, audio, music, embeddings, web augment, and characters) as **31 tools** that any MCP-compatible agent can call.
 
 <Card title="GitHub: veniceai/venice-mcp-server" icon="github" href="https://github.com/veniceai/venice-mcp-server">
   Published as [`@veniceai/mcp-server`](https://www.npmjs.com/package/@veniceai/mcp-server) on npm. MIT licensed.
@@ -61,7 +61,7 @@ The [Venice MCP Server](https://github.com/veniceai/venice-mcp-server) is the of
 </Steps>
 
 <Note>
-Most MCP hosts only pass environment variables that are **explicitly listed** in the `env` block — system-level env vars are not inherited. If you see 402 errors with an API key set, double-check that `VENICE_API_KEY` is inside `env` in your config.
+Most MCP hosts only pass environment variables that are **explicitly listed** in the `env` block. System-level env vars are not inherited. If you see 402 errors with an API key set, double-check that `VENICE_API_KEY` is inside `env` in your config.
 </Note>
 
 ## What you get
@@ -155,7 +155,7 @@ If both `VENICE_API_KEY` and `VENICE_SIWX_TOKEN` are set, the API key wins.
 
 ## x402 wallet mode
 
-Venice supports authenticating with a [SIWE-signed wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on Base mainnet, in addition to the normal API key flow. No email, phone, or KYC — your wallet is the only identity.
+Venice supports authenticating with a [SIWE-signed wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on Base mainnet, in addition to the normal API key flow. No email, phone, or KYC required: your wallet is the only identity.
 
 ```json
 {
@@ -169,7 +169,7 @@ Venice supports authenticating with a [SIWE-signed wallet token](/guides/integra
 }
 ```
 
-The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on every Venice API call. The server never sees your private key — SIWE signing and USDC top-up authorizations happen in your own wallet.
+The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on every Venice API call. The server never sees your private key. SIWE signing and USDC top-up authorizations happen in your own wallet.
 
 | Flow | What happens |
 |---|---|
@@ -177,10 +177,10 @@ The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on 
 | **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC EIP-3009 transfer in your wallet, resubmit, and Venice credits your balance. |
 | **Every inference call** | MCP server sends `X-Sign-In-With-X: <SIWX>`; Venice debits your prepaid balance. |
 
-Minimum top-up is **$5 USD**. Minimum balance to call inference is **$0.10**. Once topped up, calls are sub-100ms — settlement happens off-chain on a fast credit account.
+Minimum top-up is **$5 USD**. Minimum balance to call inference is **$0.10**. Once topped up, calls are sub-100ms because settlement happens off-chain on a fast credit account.
 
 <Tip>
-Wallets linked to a Venice account with DIEM staked consume from the staking balance instead of USDC credits — no top-up needed.
+Wallets linked to a Venice account with DIEM staked consume from the staking balance instead of USDC credits, so no top-up is needed.
 </Tip>
 
 ## Self-hosting (Streamable HTTP)

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -1,0 +1,208 @@
+---
+title: Venice Skills
+description: Official Agent Skills for the Venice API — load Venice knowledge into Claude Code, Cursor, Codex, OpenCode, Hermes, and Cline
+"og:title": "Venice Skills | Venice API Docs"
+"og:description": "Drop-in Agent Skills that teach your coding agent how to use every Venice endpoint correctly."
+---
+
+[Venice Skills](https://github.com/veniceai/skills) is the canonical collection of [Agent Skills](https://www.anthropic.com/news/agent-skills) for the Venice API. Each skill is a self-contained folder with a `SKILL.md` that an LLM agent loads on demand to work correctly against a specific surface area of the API.
+
+<Card title="GitHub: veniceai/skills" icon="github" href="https://github.com/veniceai/skills">
+  19 skills covering the full Venice API. MIT licensed. Kept in sync with the public [`swagger.yaml`](/api-reference/api-spec).
+</Card>
+
+<CardGroup cols={3}>
+  <Card title="19 Skills" icon="layer-group">
+    One per Venice API surface area
+  </Card>
+  <Card title="Runtime-agnostic" icon="plug">
+    Works with Claude Code, Cursor, Codex, OpenCode, Hermes, Cline, and any other Agent Skills host
+  </Card>
+  <Card title="Spec-synced" icon="rotate">
+    Derived from Venice's OpenAPI spec, with CI checks for drift
+  </Card>
+</CardGroup>
+
+## Why skills?
+
+Without skills, your agent has to discover Venice's quirks the hard way — `venice_parameters`, model-type enums, 402 payment-required flows, video queue/retrieve lifecycle, character slugs, and so on. Skills bundle that knowledge into focused, on-demand files so the agent only loads what it needs for the current task.
+
+Each `SKILL.md` includes:
+
+- The endpoint(s) it covers
+- Required headers, parameters, and response shapes
+- A curl example plus a minimal SDK example
+- A "gotchas" section with the things real integrators trip over
+
+## Skill catalog
+
+| Skill | Covers |
+|---|---|
+| `venice-api-overview` | Base URL, auth modes, response headers, pricing model, versioning |
+| `venice-auth` | Bearer API keys + SIWE / x402 wallet authentication |
+| `venice-chat` | `/chat/completions` — `venice_parameters`, multimodal, tools, reasoning, streaming |
+| `venice-responses` | `/responses` — OpenAI-compatible Responses API (Alpha) |
+| `venice-embeddings` | `/embeddings` — models, encoding formats, dimensions |
+| `venice-image-generate` | `/image/generate`, `/images/generations`, `/image/styles` |
+| `venice-image-edit` | `/image/edit`, `/image/multi-edit`, `/image/upscale`, `/image/background-remove` |
+| `venice-audio-speech` | `/audio/speech` — TTS models, voices, formats, streaming |
+| `venice-audio-music` | `/audio/quote`, `/audio/queue`, `/audio/retrieve`, `/audio/complete` |
+| `venice-audio-transcription` | `/audio/transcriptions` — Whisper, Parakeet, Scribe, Wizper, xAI STT |
+| `venice-video` | `/video/*` generation + transcription |
+| `venice-models` | `/models`, `/models/traits`, `/models/compatibility_mapping` |
+| `venice-characters` | `/characters*` + `venice_parameters.character_slug` |
+| `venice-api-keys` | CRUD `/api_keys`, rate limits, Web3 key generation |
+| `venice-billing` | `/billing/balance`, `/billing/usage`, `/billing/usage-analytics` |
+| `venice-x402` | `/x402/*` — wallet credits, USDC on Base |
+| `venice-crypto-rpc` | `/crypto/rpc/*` — JSON-RPC proxy with 1×/2×/4× pricing |
+| `venice-augment` | `/augment/text-parser`, `/augment/scrape`, `/augment/search` |
+| `venice-errors` | Error shapes, 402 payment required, 422 content policy, 429 rate limits, retry strategy |
+
+## Install
+
+Each skill is just a folder with a `SKILL.md` that starts with YAML frontmatter:
+
+```yaml
+---
+name: venice-chat
+description: When the agent should load this skill and what's in it
+---
+```
+
+Drop the `skills/` folder (or any subset) into whichever path your runtime watches.
+
+<Tabs>
+  <Tab title="Claude Code">
+    Project-local:
+
+    ```bash
+    git clone https://github.com/veniceai/skills.git
+    cp -r skills/skills/* .claude/skills/
+    ```
+
+    Or global, for every project on your machine:
+
+    ```bash
+    git clone https://github.com/veniceai/skills.git ~/src/venice-skills
+    ln -s ~/src/venice-skills/skills ~/.claude/skills/venice
+    ```
+  </Tab>
+
+  <Tab title="Cursor">
+    Project-local:
+
+    ```bash
+    git clone https://github.com/veniceai/skills.git .cursor/skills-venice
+    ```
+
+    Or copy individual skills:
+
+    ```bash
+    cp -r skills/venice-chat .cursor/skills/
+    ```
+  </Tab>
+
+  <Tab title="Codex">
+    ```bash
+    git clone https://github.com/veniceai/skills.git ~/src/venice-skills
+    ln -s ~/src/venice-skills/skills ~/.codex/skills/venice
+    ```
+
+    For project-local installs, target `.codex/skills/` instead.
+  </Tab>
+
+  <Tab title="OpenCode">
+    ```bash
+    git clone https://github.com/veniceai/skills.git ~/src/venice-skills
+    ln -s ~/src/venice-skills/skills ~/.config/opencode/skills/venice
+    ```
+
+    OpenCode also reads `.opencode/skills/`, `.claude/skills/`, and `.agents/skills/` from the project root.
+  </Tab>
+
+  <Tab title="Hermes Agent">
+    Hermes has a built-in installer for Venice skills:
+
+    ```bash
+    hermes skills install veniceai/skills
+    ```
+
+    Or symlink directly:
+
+    ```bash
+    git clone https://github.com/veniceai/skills.git ~/src/venice-skills
+    ln -s ~/src/venice-skills/skills ~/.hermes/skills/venice
+    ```
+  </Tab>
+
+  <Tab title="Cline">
+    ```bash
+    git clone https://github.com/veniceai/skills.git .clinerules/skills-venice
+    ```
+  </Tab>
+</Tabs>
+
+### Path reference
+
+| Runtime | Project-local | Global |
+|---|---|---|
+| Claude Code | `.claude/skills/` | `~/.claude/skills/` |
+| Codex | `.codex/skills/` | `~/.codex/skills/` (or `$CODEX_HOME/skills/`) |
+| OpenCode | `.opencode/skills/` (also `.claude/skills/`, `.agents/skills/`) | `~/.config/opencode/skills/` |
+| Hermes Agent | — | `~/.hermes/skills/` (or `$HERMES_OPTIONAL_SKILLS_DIR`) |
+| Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
+| Cline | `.clinerules/skills/` | — |
+| Other runtimes | `.agents/skills/` (convention) | `~/.agents/skills/` |
+
+<Tip>
+Runtimes that define extra frontmatter fields (`version`, `platforms`, `metadata.*`, `compatibility`, …) are required by spec to ignore unknown fields, so the same skill file works everywhere without forks.
+</Tip>
+
+### As a git submodule
+
+If you want pinned versions in your own repo:
+
+```bash
+git submodule add https://github.com/veniceai/skills.git vendor/venice-skills
+```
+
+Then symlink or copy the subsets you want into your agent's skill path.
+
+## How agents load them
+
+The agent discovers each `SKILL.md` by its frontmatter `name` and `description`. When the user asks something that matches a skill's purpose, the agent loads that one file into context — not the whole catalog — so the prompt stays small and the answer stays accurate.
+
+For example, an agent that needs to generate music will load `venice-audio-music` and immediately know:
+
+- That music goes through the queue/retrieve/complete lifecycle, not a synchronous endpoint
+- Which models are available and their per-minute pricing
+- How to call `/audio/quote` for cost estimation first
+- What the polling backoff should look like
+
+Without the skill, the agent might try to call `/audio/speech` for music and get a useless response.
+
+## Authoring a new skill
+
+1. Copy `template/` to `skills/<your-skill>/`.
+2. Fill in the frontmatter and body. Keep `description` concrete — it's what an agent uses to decide when to load the skill.
+3. Link related skills at the bottom for cross-navigation.
+4. Open a PR against [`veniceai/skills`](https://github.com/veniceai/skills).
+
+See the repository's `CONTRIBUTING.md` for style conventions (short first paragraph, explicit endpoint tables, curl + one SDK example, "gotchas" section, ≤ 500 lines).
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="GitHub" icon="github" href="https://github.com/veniceai/skills">
+    Source code, contributing guide, and skill template
+  </Card>
+  <Card title="Venice MCP Server" icon="plug" href="/guides/integrations/venice-mcp">
+    Pair skills with the official MCP server for runtime tool access
+  </Card>
+  <Card title="Agent Skills Spec" icon="arrow-up-right-from-square" href="https://www.anthropic.com/news/agent-skills">
+    Learn the underlying format
+  </Card>
+  <Card title="Venice API Spec" icon="book" href="/api-reference/api-spec">
+    The OpenAPI source of truth these skills are derived from
+  </Card>
+</CardGroup>

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -149,7 +149,7 @@ Drop the `skills/` folder (or any subset) into whichever path your runtime watch
 | Claude Code | `.claude/skills/` | `~/.claude/skills/` |
 | Codex | `.codex/skills/` | `~/.codex/skills/` (or `$CODEX_HOME/skills/`) |
 | OpenCode | `.opencode/skills/` (also `.claude/skills/`, `.agents/skills/`) | `~/.config/opencode/skills/` |
-| Hermes Agent | n/a | `~/.hermes/skills/` (or `$HERMES_OPTIONAL_SKILLS_DIR`) |
+| Hermes Agent | `$HERMES_OPTIONAL_SKILLS_DIR` | `~/.hermes/skills/` |
 | Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
 | Cline | `.clinerules/skills/` | n/a |
 | Other runtimes | `.agents/skills/` (convention) | `~/.agents/skills/` |

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Venice Skills
-description: Official Agent Skills for the Venice API — load Venice knowledge into Claude Code, Cursor, Codex, OpenCode, Hermes, and Cline
+description: Official Agent Skills for the Venice API that load Venice knowledge into Claude Code, Cursor, Codex, OpenCode, Hermes, and Cline
 "og:title": "Venice Skills | Venice API Docs"
 "og:description": "Drop-in Agent Skills that teach your coding agent how to use every Venice endpoint correctly."
 ---
@@ -25,7 +25,7 @@ description: Official Agent Skills for the Venice API — load Venice knowledge 
 
 ## Why skills?
 
-Without skills, your agent has to discover Venice's quirks the hard way — `venice_parameters`, model-type enums, 402 payment-required flows, video queue/retrieve lifecycle, character slugs, and so on. Skills bundle that knowledge into focused, on-demand files so the agent only loads what it needs for the current task.
+Without skills, your agent has to discover Venice's quirks the hard way: `venice_parameters`, model-type enums, 402 payment-required flows, video queue/retrieve lifecycle, character slugs, and so on. Skills bundle that knowledge into focused, on-demand files so the agent only loads what it needs for the current task.
 
 Each `SKILL.md` includes:
 
@@ -40,21 +40,21 @@ Each `SKILL.md` includes:
 |---|---|
 | `venice-api-overview` | Base URL, auth modes, response headers, pricing model, versioning |
 | `venice-auth` | Bearer API keys + SIWE / x402 wallet authentication |
-| `venice-chat` | `/chat/completions` — `venice_parameters`, multimodal, tools, reasoning, streaming |
-| `venice-responses` | `/responses` — OpenAI-compatible Responses API (Alpha) |
-| `venice-embeddings` | `/embeddings` — models, encoding formats, dimensions |
+| `venice-chat` | `/chat/completions` with `venice_parameters`, multimodal, tools, reasoning, streaming |
+| `venice-responses` | `/responses`, the OpenAI-compatible Responses API (Alpha) |
+| `venice-embeddings` | `/embeddings` models, encoding formats, dimensions |
 | `venice-image-generate` | `/image/generate`, `/images/generations`, `/image/styles` |
 | `venice-image-edit` | `/image/edit`, `/image/multi-edit`, `/image/upscale`, `/image/background-remove` |
-| `venice-audio-speech` | `/audio/speech` — TTS models, voices, formats, streaming |
+| `venice-audio-speech` | `/audio/speech` TTS models, voices, formats, streaming |
 | `venice-audio-music` | `/audio/quote`, `/audio/queue`, `/audio/retrieve`, `/audio/complete` |
-| `venice-audio-transcription` | `/audio/transcriptions` — Whisper, Parakeet, Scribe, Wizper, xAI STT |
+| `venice-audio-transcription` | `/audio/transcriptions` with Whisper, Parakeet, Scribe, Wizper, xAI STT |
 | `venice-video` | `/video/*` generation + transcription |
 | `venice-models` | `/models`, `/models/traits`, `/models/compatibility_mapping` |
 | `venice-characters` | `/characters*` + `venice_parameters.character_slug` |
 | `venice-api-keys` | CRUD `/api_keys`, rate limits, Web3 key generation |
 | `venice-billing` | `/billing/balance`, `/billing/usage`, `/billing/usage-analytics` |
-| `venice-x402` | `/x402/*` — wallet credits, USDC on Base |
-| `venice-crypto-rpc` | `/crypto/rpc/*` — JSON-RPC proxy with 1×/2×/4× pricing |
+| `venice-x402` | `/x402/*` wallet credits, USDC on Base |
+| `venice-crypto-rpc` | `/crypto/rpc/*` JSON-RPC proxy with 1×/2×/4× pricing |
 | `venice-augment` | `/augment/text-parser`, `/augment/scrape`, `/augment/search` |
 | `venice-errors` | Error shapes, 402 payment required, 422 content policy, 429 rate limits, retry strategy |
 
@@ -149,9 +149,9 @@ Drop the `skills/` folder (or any subset) into whichever path your runtime watch
 | Claude Code | `.claude/skills/` | `~/.claude/skills/` |
 | Codex | `.codex/skills/` | `~/.codex/skills/` (or `$CODEX_HOME/skills/`) |
 | OpenCode | `.opencode/skills/` (also `.claude/skills/`, `.agents/skills/`) | `~/.config/opencode/skills/` |
-| Hermes Agent | — | `~/.hermes/skills/` (or `$HERMES_OPTIONAL_SKILLS_DIR`) |
+| Hermes Agent | n/a | `~/.hermes/skills/` (or `$HERMES_OPTIONAL_SKILLS_DIR`) |
 | Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
-| Cline | `.clinerules/skills/` | — |
+| Cline | `.clinerules/skills/` | n/a |
 | Other runtimes | `.agents/skills/` (convention) | `~/.agents/skills/` |
 
 <Tip>
@@ -170,7 +170,7 @@ Then symlink or copy the subsets you want into your agent's skill path.
 
 ## How agents load them
 
-The agent discovers each `SKILL.md` by its frontmatter `name` and `description`. When the user asks something that matches a skill's purpose, the agent loads that one file into context — not the whole catalog — so the prompt stays small and the answer stays accurate.
+The agent discovers each `SKILL.md` by its frontmatter `name` and `description`. When the user asks something that matches a skill's purpose, the agent loads that one file into context (not the whole catalog), so the prompt stays small and the answer stays accurate.
 
 For example, an agent that needs to generate music will load `venice-audio-music` and immediately know:
 
@@ -184,7 +184,7 @@ Without the skill, the agent might try to call `/audio/speech` for music and get
 ## Authoring a new skill
 
 1. Copy `template/` to `skills/<your-skill>/`.
-2. Fill in the frontmatter and body. Keep `description` concrete — it's what an agent uses to decide when to load the skill.
+2. Fill in the frontmatter and body. Keep `description` concrete, since it's what an agent uses to decide when to load the skill.
 3. Link related skills at the bottom for cross-navigation.
 4. Open a PR against [`veniceai/skills`](https://github.com/veniceai/skills).
 

--- a/guides/integrations/venice-video-harness.mdx
+++ b/guides/integrations/venice-video-harness.mdx
@@ -1,0 +1,306 @@
+---
+title: Venice Video Harness
+description: Agent-first, Venice-optimized harness for consistency-first AI video creation
+"og:title": "Venice Video Harness | Venice API Docs"
+"og:description": "Drive Venice from Claude Code or Cursor with a reusable production system for character-consistent videos, storyboards, trailers, and long-form narrative content."
+---
+
+The [Venice Video Harness](https://github.com/jordanurbs/venice-video-harness) by [Jordan Urbs](https://github.com/jordanurbs) is an agent-first, Venice-optimized toolkit for **consistency-first video creation at any length**. It turns an IDE agent (Claude Code, Cursor, Codex, etc.) into an operator of a reusable Venice production system covering 50+ Venice video, image, audio, and music models.
+
+<Card title="GitHub: jordanurbs/venice-video-harness" icon="github" href="https://github.com/jordanurbs/venice-video-harness">
+  MIT licensed. Community-maintained.
+</Card>
+
+<CardGroup cols={3}>
+  <Card title="Character-consistent video" icon="users">
+    Lock characters, voices, and aesthetics across an entire series
+  </Card>
+  <Card title="Storyboard-to-video" icon="film">
+    Two-pass panel generation with Venice multi-edit refinement
+  </Card>
+  <Card title="Text-first editing" icon="scissors">
+    Transcribe locally with whisper.cpp, cut from a 12KB pack, self-eval at every boundary
+  </Card>
+</CardGroup>
+
+## What this is
+
+Most Venice integrations are thin wrappers around API calls. The Venice Video Harness is the **higher-level layer** that sits between your agent and the Venice API:
+
+- **Orchestration rules** in `CLAUDE.md`
+- **Reusable playbooks** in `.claude/commands/` (19 workflow commands)
+- **Specialized agents** in `.claude/agents/` (art-director, prompt-engineer, cut-qa, and more)
+- **Venice production skills** in `.claude/skills/` (compatible with the [Agent Skills](/guides/integrations/venice-skills) format)
+- **TypeScript execution layer** in `src/`
+- **Comprehensive model registry** covering 50+ Venice video, image, audio, and music models
+
+Built for creators producing:
+
+- Character-consistent video projects (any genre, any length)
+- Visual-style-locked series or campaigns
+- Storyboard-to-video workflows
+- Short-form and long-form narrative content
+- Branded cinematic sequences, trailers, and teasers
+- Recurring-character social series
+
+## Getting started
+
+### Requirements
+
+<CardGroup cols={3}>
+  <Card title="Node.js 20+" icon="node-js" href="https://nodejs.org/">
+    Latest LTS recommended
+  </Card>
+  <Card title="ffmpeg + ffprobe" icon="terminal" href="https://ffmpeg.org/">
+    On your PATH
+  </Card>
+  <Card title="Venice API key" icon="key" href="/guides/getting-started/generating-api-key">
+    From [venice.ai/settings/api](https://venice.ai/settings/api)
+  </Card>
+</CardGroup>
+
+Optional, for the editing pipeline: install `whisper-cpp` for local transcription.
+
+```bash
+brew install whisper-cpp
+mkdir -p ~/.cache/whisper.cpp
+curl -L -o ~/.cache/whisper.cpp/ggml-base.en.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
+```
+
+### Setup
+
+<Steps>
+  <Step title="Clone the harness">
+    ```bash
+    git clone https://github.com/jordanurbs/venice-video-harness.git
+    cd venice-video-harness
+    ```
+  </Step>
+
+  <Step title="Configure your API key">
+    ```bash
+    cp .env.example .env
+    # Add VENICE_API_KEY to .env
+    ```
+  </Step>
+
+  <Step title="Install and build">
+    ```bash
+    npm install
+    npm run build
+    ```
+  </Step>
+
+  <Step title="Open in your agent">
+    Open the project in Cursor, Claude Code, or any IDE with agentic chat. The agent reads `CLAUDE.md` and the playbooks automatically.
+
+    Try one of these first messages:
+
+    - "Set up this Venice video harness for first use"
+    - "Create a new character-consistent video series"
+    - "Generate a 30-second branded video sequence"
+    - "Build a multi-episode narrative with locked characters"
+    - "Create a product launch trailer with consistent visual style"
+  </Step>
+</Steps>
+
+## What's Venice-optimized about it
+
+- **Image prompts tuned for Venice image models** — `seedream-v5-lite`, `nano-banana-pro`, `flux-2-pro/max`, and more
+- **Two-pass panel generation** with Venice multi-edit refinement for character correction
+- **Model-routing logic** for action, atmosphere, and character-consistency tiers
+- **Reference-aware video generation** — uses `elements`, `reference_image_urls`, and `scene_image_urls` correctly per model
+- **Environment-aware prompt adaptation** — daytime vs night scene handling
+- **Venice-native audio paths** for TTS (Kokoro, Qwen3, ElevenLabs), SFX, and music
+- **Cost estimation** before generation via `/video/quote` and `/audio/quote`
+- **Model-aware parameter building** — auto-skips parameters the target model doesn't support
+
+## Model routing defaults
+
+The harness defaults are opinionated because consistency is the point. The current routing (April 2026):
+
+**Seedance 2.0 R2V by default. Kling O3 R2V fallback for 3+ character scenes. Seedance 2.0 i2v for establishing shots.**
+
+| Role | Default model | When used |
+|---|---|---|
+| Character shots (1–2 characters) | `seedance-2-0-reference-to-video` | Default R2V — flat `reference_image_urls` with `@Image` tags, up to 15s, native stereo audio |
+| Character shots (3+ characters) | `kling-o3-standard-reference-to-video` | Auto-fallback — structured `elements` for multi-character identity |
+| Establishing / mood / action | `seedance-2-0-image-to-video` | No characters — epic cinematic quality, up to 15s |
+
+These are overridable per-project via `series.json → videoDefaults`. To target a non-Seedance family (e.g. accounts that lack Seedance access), set `videoDefaults` to `kling-o3-standard-reference-to-video` and `veo3.1-fast-image-to-video`.
+
+<Note>
+**Seedance face rule:** Seedance 2.0 blocks face-bearing input images that weren't produced by `seedream-v5-lite` or `seedream-v5-lite-edit`. The harness handles this automatically — it routes character-bearing image work through Seedream and runs a pre-flight gate before every Seedance call.
+</Note>
+
+## Supported Venice models
+
+### Video (April 2026)
+
+| Family | i2v | t2v | Max duration | Audio | Notes |
+|---|---|---|---|---|---|
+| **Seedance 2.0** | i2v, R2V | t2v | 15s | Yes (stereo, lip-sync 8+ langs) | #1 ranked. R2V: flat `reference_image_urls`, `@Image` tags. |
+| **Kling V3** | Pro, Standard | Pro, Standard | 15s | Yes | `end_image_url` for frame targeting |
+| **Kling O3** | Pro, Std, Pro R2V, Std R2V | Pro, Standard | 15s | Yes | R2V: `elements`, `reference_image_urls`, `scene_image_urls` |
+| **Kling 2.6 / 2.5 Turbo** | Pro | Pro | 10s | 2.6: Yes / 2.5: No | `end_image_url` |
+| **Veo 3.1** | Fast, Full | Fast, Full | 8s | Yes | Up to 4K resolution |
+| **Sora 2** | Standard, Pro | Standard, Pro | 12s | Yes | Up to 1080p |
+| **Wan 2.6 / 2.5** | Std, Flash / Yes | Std / Yes | 15s / 10s | Yes | `audio_url` input |
+| **LTX Video 2.0** | Fast, Full, v2.3, 19B | Fast, Full, v2.3, 19B | 20s | Yes | Up to 4K, longest synced |
+| **Longcat** | Std, Distilled | Std, Distilled | **30s** | No | Longest single-shot |
+| **Vidu Q3** | Yes | Yes | 16s | Yes | `reference_image_urls` |
+| **PixVerse v5.6** | Std, Transition | Standard | 8s | Yes | Transition: `end_image_url` |
+| **Grok Imagine** | Yes | Yes | 15s | Yes | Wide aspect ratio support |
+
+### Image, audio, and music
+
+- **Image (22+ models)** — `nano-banana-pro/2`, `gpt-image-2`, `flux-2-pro/max`, `grok-imagine`, `qwen-image-2-pro`, `recraft-v4-pro`, `seedream-v4` / `v5-lite`, `lustify-sdxl/v7`, `wai-Illustrious`, and more
+- **Multi-edit** — `qwen-edit`, `flux-2-max-edit`, `nano-banana-pro-edit`, `seedream-v5-lite-edit`, `gpt-image-2-edit`, and more
+- **TTS** — `tts-kokoro` (50+ voices), `tts-qwen3-0-6b/1-7b`, `elevenlabs-tts-v3`, `elevenlabs-tts-multilingual-v2`
+- **Music** — `elevenlabs-music`, `minimax-music-v2`, `ace-step-15`, `stable-audio-25`
+- **SFX** — `elevenlabs-sound-effects-v2`, `mmaudio-v2-text-to-audio`
+
+## Production pipelines
+
+### Generation pipeline
+
+End-to-end narrative video — script → storyboard → video → audio → assembly:
+
+```bash
+npm run dev -- produce-episode -p output/my-series -e 1
+```
+
+Reference implementation in `src/mini-drama/` covers:
+
+- Series / character / episode management
+- LLM-powered script workshopping
+- Two-pass storyboard generation (generate + multi-edit refine)
+- Vision-based panel QA
+- Video generation with frame chaining
+- Layered audio post-production
+- Subtitle burn-in and final assembly
+
+### Editing pipeline
+
+Cut already-existing media (Venice-generated shots or real raw footage). **Text-first**: the LLM reads a compact `takes_packed.md` (~12KB per 40 min of audio) rather than frame-dumping video.
+
+The five steps:
+
+<Steps>
+  <Step title="Transcribe">
+    Local whisper.cpp produces per-source `*.words.json` + `takes_packed.md`.
+  </Step>
+  <Step title="Read the pack">
+    The LLM forms a cut strategy from text alone.
+  </Step>
+  <Step title="Confirm">
+    Proposes the strategy and waits for "yes / revise / cancel".
+  </Step>
+  <Step title="Render the EDL">
+    JSON cut list → ffmpeg concat with 30ms audio fades. Archive-first — originals are never overwritten.
+  </Step>
+  <Step title="Self-eval">
+    The `cut-qa` agent runs 6 programmatic checks at every cut boundary; max 3 fix iterations.
+  </Step>
+</Steps>
+
+The `cut-qa` checks catch aspect-ratio regressions, frame-hash jumps inside a word, VO truncation, lighting discontinuity, audio peaks above -6 dBFS, and caption overlap with in-frame text.
+
+<Tip>
+The editing pipeline is inspired by [browser-use/video-use](https://github.com/browser-use/video-use). Their core insight — *"the LLM never watches the video, it reads it"* — is what makes agent-driven editing work without drowning in frame-dump tokens.
+</Tip>
+
+## Commands, agents, and skills
+
+The harness exposes 19 workflow commands, 10 specialized agents, and 7 production skills. Highlights:
+
+| Workflow command | Purpose |
+|---|---|
+| `new-series` | Create a new series with locked aesthetics |
+| `add-character` / `lock-character` | Character + voice locking |
+| `workshop-episode` | Collaborative episode scripting |
+| `storyboard-episode` | Storyboard one episode |
+| `produce-episode` | Full pipeline in one command |
+| `generate-trailer` | Full trailer pipeline |
+| `edit-footage` | Text-first editing pipeline for existing media |
+| `ingest-screenplay` | Ingest a Fountain or PDF screenplay |
+
+| Specialized agent | Role |
+|---|---|
+| `art-director` | Aesthetic, palette, lighting, composition decisions |
+| `prompt-engineer` | Venice image prompts, character consistency |
+| `storyboard-qa` | Panel QA for continuity and character checks |
+| `cut-qa` | Post-render quality gate (6 checks per cut, max 3 iterations) |
+| `overlay-designer` | Branded motion graphics, parallel sub-agents |
+| `trailer-curator` | Trailer shot selection and anti-spoiler rules |
+
+| Production skill | Purpose |
+|---|---|
+| `venice-api` | Venice REST API usage and defaults |
+| `venice-video-model-routing` | R2V-first routing, decision trees |
+| `character-consistency` | Multi-shot character consistency guidance |
+| `shot-composition` | Shot composition and camera guidance |
+| `screenplay-parsing` | Screenplay parsing workflows |
+| `video-editing` | Text-first editing philosophy, EDL format, cut-qa loop |
+
+## NLE round-trip
+
+After rendering, export the assembled timeline as XML for fine-tuning in your editor of choice. Every video segment, dialogue clip, SFX clip, and music cue lands on its own track.
+
+```bash
+mini-drama export-timeline -p output/<project> -e 1 --format fcpxml      # Final Cut Pro X
+mini-drama export-timeline -p output/<project> -e 1 --format premiere    # Premiere Pro
+mini-drama export-timeline -p output/<project> -e 1 --format davinci     # DaVinci Resolve
+```
+
+## Programmatic usage
+
+You can also call into the harness's modules directly from your own TypeScript:
+
+```typescript
+import { VeniceClient } from './src/venice/client.js';
+import { generateVideo, quoteVideo } from './src/venice/video.js';
+import { listVideoModels } from './src/venice/models.js';
+
+const client = new VeniceClient();
+
+const quote = await quoteVideo(client, {
+  model: 'kling-v3-pro-image-to-video',
+  duration: '8s',
+  audio: true,
+});
+console.log(`Estimated cost: $${quote.quote}`);
+
+const result = await generateVideo(client, {
+  model: 'kling-v3-pro-image-to-video',
+  prompt: 'A slow dolly shot pushes forward...',
+  duration: '8s',
+  imageUrl: 'data:image/png;base64,...',
+  audio: true,
+  outputPath: 'output/shot-001.mp4',
+});
+
+const longModels = listVideoModels({ minDurationSec: 20 });
+```
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="GitHub" icon="github" href="https://github.com/jordanurbs/venice-video-harness">
+    Source code, issues, and releases
+  </Card>
+  <Card title="Venice Video Generation" icon="film" href="/guides/media/video-generation">
+    The underlying API the harness drives
+  </Card>
+  <Card title="Reference-to-Video" icon="image" href="/guides/media/reference-to-video">
+    R2V guide for character consistency
+  </Card>
+  <Card title="Seedance 2.0" icon="bolt" href="/guides/media/seedance-2-0">
+    The harness's default video family
+  </Card>
+</CardGroup>
+
+<Note>
+Community-maintained. Provided as-is by [Jordan Urbs](https://github.com/jordanurbs). For harness-specific issues, file them on the [project's GitHub repo](https://github.com/jordanurbs/venice-video-harness/issues).
+</Note>

--- a/guides/integrations/venice-video-harness.mdx
+++ b/guides/integrations/venice-video-harness.mdx
@@ -5,9 +5,9 @@ description: Agent-first, Venice-optimized harness for consistency-first AI vide
 "og:description": "Drive Venice from Claude Code or Cursor with a reusable production system for character-consistent videos, storyboards, trailers, and long-form narrative content."
 ---
 
-The [Venice Video Harness](https://github.com/jordanurbs/venice-video-harness) by [Jordan Urbs](https://github.com/jordanurbs) is an agent-first, Venice-optimized toolkit for **consistency-first video creation at any length**. It turns an IDE agent (Claude Code, Cursor, Codex, etc.) into an operator of a reusable Venice production system covering 50+ Venice video, image, audio, and music models.
+The [Venice Video Harness](https://github.com/jordanurbs/venice-video-harness) is a community, agent-first, Venice-optimized toolkit for **consistency-first video creation at any length**. It turns an IDE agent (Claude Code, Cursor, Codex, etc.) into an operator of a reusable Venice production system covering 50+ Venice video, image, audio, and music models.
 
-<Card title="GitHub: jordanurbs/venice-video-harness" icon="github" href="https://github.com/jordanurbs/venice-video-harness">
+<Card title="GitHub: venice-video-harness" icon="github" href="https://github.com/jordanurbs/venice-video-harness">
   MIT licensed. Community-maintained.
 </Card>
 
@@ -107,14 +107,14 @@ curl -L -o ~/.cache/whisper.cpp/ggml-base.en.bin \
 
 ## What's Venice-optimized about it
 
-- **Image prompts tuned for Venice image models** — `seedream-v5-lite`, `nano-banana-pro`, `flux-2-pro/max`, and more
+- **Image prompts tuned for Venice image models** like `seedream-v5-lite`, `nano-banana-pro`, `flux-2-pro/max`, and more
 - **Two-pass panel generation** with Venice multi-edit refinement for character correction
 - **Model-routing logic** for action, atmosphere, and character-consistency tiers
-- **Reference-aware video generation** — uses `elements`, `reference_image_urls`, and `scene_image_urls` correctly per model
-- **Environment-aware prompt adaptation** — daytime vs night scene handling
+- **Reference-aware video generation** that uses `elements`, `reference_image_urls`, and `scene_image_urls` correctly per model
+- **Environment-aware prompt adaptation** for daytime vs night scene handling
 - **Venice-native audio paths** for TTS (Kokoro, Qwen3, ElevenLabs), SFX, and music
 - **Cost estimation** before generation via `/video/quote` and `/audio/quote`
-- **Model-aware parameter building** — auto-skips parameters the target model doesn't support
+- **Model-aware parameter building** that auto-skips parameters the target model doesn't support
 
 ## Model routing defaults
 
@@ -124,14 +124,14 @@ The harness defaults are opinionated because consistency is the point. The curre
 
 | Role | Default model | When used |
 |---|---|---|
-| Character shots (1–2 characters) | `seedance-2-0-reference-to-video` | Default R2V — flat `reference_image_urls` with `@Image` tags, up to 15s, native stereo audio |
-| Character shots (3+ characters) | `kling-o3-standard-reference-to-video` | Auto-fallback — structured `elements` for multi-character identity |
-| Establishing / mood / action | `seedance-2-0-image-to-video` | No characters — epic cinematic quality, up to 15s |
+| Character shots (1-2 characters) | `seedance-2-0-reference-to-video` | Default R2V with flat `reference_image_urls`, `@Image` tags, up to 15s, native stereo audio |
+| Character shots (3+ characters) | `kling-o3-standard-reference-to-video` | Auto-fallback with structured `elements` for multi-character identity |
+| Establishing / mood / action | `seedance-2-0-image-to-video` | No characters; epic cinematic quality, up to 15s |
 
 These are overridable per-project via `series.json → videoDefaults`. To target a non-Seedance family (e.g. accounts that lack Seedance access), set `videoDefaults` to `kling-o3-standard-reference-to-video` and `veo3.1-fast-image-to-video`.
 
 <Note>
-**Seedance face rule:** Seedance 2.0 blocks face-bearing input images that weren't produced by `seedream-v5-lite` or `seedream-v5-lite-edit`. The harness handles this automatically — it routes character-bearing image work through Seedream and runs a pre-flight gate before every Seedance call.
+**Seedance face rule:** Seedance 2.0 blocks face-bearing input images that weren't produced by `seedream-v5-lite` or `seedream-v5-lite-edit`. The harness handles this automatically by routing character-bearing image work through Seedream and running a pre-flight gate before every Seedance call.
 </Note>
 
 ## Supported Venice models
@@ -155,17 +155,17 @@ These are overridable per-project via `series.json → videoDefaults`. To target
 
 ### Image, audio, and music
 
-- **Image (22+ models)** — `nano-banana-pro/2`, `gpt-image-2`, `flux-2-pro/max`, `grok-imagine`, `qwen-image-2-pro`, `recraft-v4-pro`, `seedream-v4` / `v5-lite`, `lustify-sdxl/v7`, `wai-Illustrious`, and more
-- **Multi-edit** — `qwen-edit`, `flux-2-max-edit`, `nano-banana-pro-edit`, `seedream-v5-lite-edit`, `gpt-image-2-edit`, and more
-- **TTS** — `tts-kokoro` (50+ voices), `tts-qwen3-0-6b/1-7b`, `elevenlabs-tts-v3`, `elevenlabs-tts-multilingual-v2`
-- **Music** — `elevenlabs-music`, `minimax-music-v2`, `ace-step-15`, `stable-audio-25`
-- **SFX** — `elevenlabs-sound-effects-v2`, `mmaudio-v2-text-to-audio`
+- **Image (22+ models):** `nano-banana-pro/2`, `gpt-image-2`, `flux-2-pro/max`, `grok-imagine`, `qwen-image-2-pro`, `recraft-v4-pro`, `seedream-v4` / `v5-lite`, `lustify-sdxl/v7`, `wai-Illustrious`, and more
+- **Multi-edit:** `qwen-edit`, `flux-2-max-edit`, `nano-banana-pro-edit`, `seedream-v5-lite-edit`, `gpt-image-2-edit`, and more
+- **TTS:** `tts-kokoro` (50+ voices), `tts-qwen3-0-6b/1-7b`, `elevenlabs-tts-v3`, `elevenlabs-tts-multilingual-v2`
+- **Music:** `elevenlabs-music`, `minimax-music-v2`, `ace-step-15`, `stable-audio-25`
+- **SFX:** `elevenlabs-sound-effects-v2`, `mmaudio-v2-text-to-audio`
 
 ## Production pipelines
 
 ### Generation pipeline
 
-End-to-end narrative video — script → storyboard → video → audio → assembly:
+End-to-end narrative video (script → storyboard → video → audio → assembly):
 
 ```bash
 npm run dev -- produce-episode -p output/my-series -e 1
@@ -198,7 +198,7 @@ The five steps:
     Proposes the strategy and waits for "yes / revise / cancel".
   </Step>
   <Step title="Render the EDL">
-    JSON cut list → ffmpeg concat with 30ms audio fades. Archive-first — originals are never overwritten.
+    JSON cut list → ffmpeg concat with 30ms audio fades. Archive-first, so originals are never overwritten.
   </Step>
   <Step title="Self-eval">
     The `cut-qa` agent runs 6 programmatic checks at every cut boundary; max 3 fix iterations.
@@ -208,7 +208,7 @@ The five steps:
 The `cut-qa` checks catch aspect-ratio regressions, frame-hash jumps inside a word, VO truncation, lighting discontinuity, audio peaks above -6 dBFS, and caption overlap with in-frame text.
 
 <Tip>
-The editing pipeline is inspired by [browser-use/video-use](https://github.com/browser-use/video-use). Their core insight — *"the LLM never watches the video, it reads it"* — is what makes agent-driven editing work without drowning in frame-dump tokens.
+The editing pipeline is inspired by [browser-use/video-use](https://github.com/browser-use/video-use). Their core insight, *"the LLM never watches the video, it reads it"*, is what makes agent-driven editing work without drowning in frame-dump tokens.
 </Tip>
 
 ## Commands, agents, and skills
@@ -302,5 +302,5 @@ const longModels = listVideoModels({ minDurationSec: 20 });
 </CardGroup>
 
 <Note>
-Community-maintained. Provided as-is by [Jordan Urbs](https://github.com/jordanurbs). For harness-specific issues, file them on the [project's GitHub repo](https://github.com/jordanurbs/venice-video-harness/issues).
+Community-maintained and provided as-is. For harness-specific issues, file them on the [project's GitHub repo](https://github.com/jordanurbs/venice-video-harness/issues).
 </Note>


### PR DESCRIPTION
## Summary

Adds three new guides under a new **Agent Tooling** navigation group in the **Guides** tab:

- **Venice MCP Server** (`guides/integrations/venice-mcp`) — official MCP server [`@veniceai/mcp-server`](https://github.com/veniceai/venice-mcp-server) exposing 31 Venice tools (chat, image, video, audio, music, embeddings, augment, characters, x402) to Claude Desktop, Cursor, ChatGPT, LM Studio, Continue, and any other MCP host.
- **Venice Skills** (`guides/integrations/venice-skills`) — 19 official Agent Skills from [`veniceai/skills`](https://github.com/veniceai/skills) covering the full Venice API for Claude Code, Cursor, Codex, OpenCode, Hermes, and Cline.
- **Venice Video Harness** (`guides/integrations/venice-video-harness`) — community agent-first harness by Jordan Urbs ([`jordanurbs/venice-video-harness`](https://github.com/jordanurbs/venice-video-harness)) for consistency-first video creation, covering 50+ Venice video/image/audio/music models, an end-to-end production pipeline, and a text-first editing pipeline.

Context: kicked off from the Slack thread where TomB announced the official Venice MCP launch and Sabrina/Jordan confirmed we should add MCP + Skills + the video harness as docs pages.

## Files changed

- `guides/integrations/venice-mcp.mdx` *(new)*
- `guides/integrations/venice-skills.mdx` *(new)*
- `guides/integrations/venice-video-harness.mdx` *(new)*
- `docs.json` — adds new **Agent Tooling** group (`icon: screwdriver-wrench`) under the **Guides** tab

## Test plan

- [ ] Mintlify preview builds without errors
- [ ] All three new pages render and appear in the **Agent Tooling** group in the sidebar
- [ ] Internal links to `/guides/getting-started/generating-api-key`, `/guides/integrations/x402-venice-api`, `/guides/media/*`, `/api-reference/api-spec`, etc. resolve
- [ ] External GitHub / npm links open correctly
- [ ] Code blocks (JSON, bash, TypeScript) render with the right syntax highlighting
