### PR TITLE
feat: surface model_spec.legacy badge + reflect qwen-image FAL migration

### DIFF
--- a/api-reference/endpoint/image/generate.mdx
+++ b/api-reference/endpoint/image/generate.mdx
@@ -9,8 +9,8 @@ openapi: 'POST /image/generate'
 
 Image models use model-specific sizing parameters:
 
-- Pixel-based models accept `width` and `height`, for example `venice-sd35` and `qwen-image`.
-- Aspect-ratio models accept `aspect_ratio`, for example `qwen-image-2`.
+- Pixel-based models accept `width` and `height`, for example `venice-sd35`.
+- Aspect-ratio models accept `aspect_ratio`, for example `qwen-image` and `qwen-image-2`.
 - Resolution-tier models accept both `aspect_ratio` and `resolution`.
 
 For example, `gpt-image-2`, `nano-banana-2`, and `nano-banana-pro` support `resolution` values of `1K`, `2K`, and `4K`:

--- a/guides/getting-started/openai-migration.mdx
+++ b/guides/getting-started/openai-migration.mdx
@@ -77,7 +77,7 @@ Many libraries and tools read `OPENAI_API_KEY` and `OPENAI_BASE_URL` automatical
 | o1 / o3 | `grok-41-fast` (Anonymized) | Reasoning | $0.50 / $1.25 |
 | gpt-4-vision | `mistral-31-24b` or `qwen3-vl-235b-a22b` | Vision | $0.50 / $2.00 |
 | text-embedding-3-small | `text-embedding-bge-m3` | Embeddings | $0.15 / $0.60 |
-| dall-e-3 | `qwen-image` (Private, $0.01) or `flux-2-pro` | Image | From $0.01 |
+| dall-e-3 | `qwen-image` (Anonymized, $0.03) or `flux-2-pro` | Image | From $0.03 |
 | whisper | `nvidia/parakeet-tdt-0.6b-v3` | STT | $0.0001/sec |
 | tts-1 | `tts-kokoro` | TTS | $3.50/1M chars |
 

--- a/guides/integrations/vercel-ai-sdk.mdx
+++ b/guides/integrations/vercel-ai-sdk.mdx
@@ -184,8 +184,7 @@ export async function POST(req: Request) {
     body: JSON.stringify({
       model: 'qwen-image',
       prompt,
-      width: 1024,
-      height: 1024,
+      aspect_ratio: '1:1',
     }),
   });
 

--- a/guides/media/image-generation.mdx
+++ b/guides/media/image-generation.mdx
@@ -219,8 +219,8 @@ Use the styles endpoint when you want exact preset names instead of guessing the
 | `model` | string | Yes | - | Model ID to use for generation |
 | `prompt` | string | Yes | - | What to generate |
 | `negative_prompt` | string | No | - | What to avoid in the image |
-| `width` | integer | No | `1024` | Output width in pixels for pixel-based models such as `venice-sd35` and `qwen-image` |
-| `height` | integer | No | `1024` | Output height in pixels for pixel-based models such as `venice-sd35` and `qwen-image` |
+| `width` | integer | No | `1024` | Output width in pixels for pixel-based models such as `venice-sd35` |
+| `height` | integer | No | `1024` | Output height in pixels for pixel-based models such as `venice-sd35` |
 | `format` | string | No | `webp` | Output format: `jpeg`, `png`, or `webp` |
 | `variants` | integer | No | `1` | Number of images to generate (`1`-`4`), only when `return_binary` is `false` |
 | `return_binary` | boolean | No | `false` | Return raw image bytes instead of base64 JSON |
@@ -228,7 +228,7 @@ Use the styles endpoint when you want exact preset names instead of guessing the
 | `seed` | integer | No | random | Reuse the same seed for more consistent iterations |
 | `cfg_scale` | number | No | model-dependent | Higher values push the model to follow the prompt more closely |
 | `style_preset` | string | No | - | Apply a preset style from [Image Styles](/api-reference/endpoint/image/styles) |
-| `aspect_ratio` | string | Conditional | - | Used by models that support ratio-based sizing, such as `qwen-image-2`, `gpt-image-2`, `nano-banana-2`, and `nano-banana-pro` |
+| `aspect_ratio` | string | Conditional | - | Used by models that support ratio-based sizing, such as `qwen-image`, `qwen-image-2`, `gpt-image-2`, `nano-banana-2`, and `nano-banana-pro` |
 | `resolution` | string | Conditional | - | Used by models that support resolution tiers such as `1K`, `2K`, or `4K` |
 | `enable_web_search` | boolean | Conditional | `false` | Allows supported models to use current web information; adds extra cost |
 

--- a/model-search.js
+++ b/model-search.js
@@ -246,6 +246,7 @@
     anonymized: 'The model provider may retain prompt data, though it is anonymized by Venice. For sensitive content, use a Private, TEE, or E2EE model.',
     beta: 'Experimental model that may change or be removed without notice. Not recommended for production.',
     deprecated: 'This model is scheduled for removal. See the deprecations page for timeline and migration guide.',
+    legacy: 'Legacy model retained for API/B2B compatibility. No longer surfaced in the Venice app; pricing and rate limits remain supported.',
     uncensored: 'Responds to all prompts without content-based refusals or filtering.',
     upgraded: 'A newer version of this model is available with improved performance.',
     content_moderation: 'This model applies upstream content moderation. Requests blocked by the provider\u2019s filters are still billed at the full rate.'
@@ -731,6 +732,10 @@
     return model.model_spec?.betaModel === true;
   }
 
+  function isLegacyModel(model) {
+    return model.model_spec?.legacy === true;
+  }
+
   function isDeprecatedModel(model) {
     const dep = model.model_spec?.deprecation;
     return dep != null && (dep.date != null || dep.removesAt != null);
@@ -926,6 +931,10 @@
   function renderPricingImageTable(models) {
     const imageModels = models.filter(m => m.type === 'image').filter(m => !isDeprecatedModel(m))
       .sort((a, b) => {
+        // Push legacy (API-only) models to the very bottom, then beta below regulars.
+        const aLegacy = isLegacyModel(a) ? 1 : 0;
+        const bLegacy = isLegacyModel(b) ? 1 : 0;
+        if (aLegacy !== bLegacy) return aLegacy - bLegacy;
         const aBeta = isBetaModel(a) ? 1 : 0;
         const bBeta = isBetaModel(b) ? 1 : 0;
         if (aBeta !== bBeta) return aBeta - bBeta;
@@ -940,6 +949,7 @@
       const modelId = escapeHtml(model.id);
       const name = escapeHtml(spec.name || model.id);
       const betaTag = isBetaModel(model) ? '<span class="vpt-badge vpt-beta vpt-tooltip" data-tooltip="Experimental model that may change or be removed without notice.">Beta</span>' : '';
+      const legacyTag = isLegacyModel(model) ? `<span class="vpt-badge vpt-legacy vpt-tooltip" data-tooltip="${TOOLTIPS.legacy}">Legacy</span>` : '';
       const moderationTag = hasContentModeration(model.id) ? `<span class="vpt-badge vpt-moderation vpt-tooltip" data-tooltip="${TOOLTIPS.content_moderation}">Moderated</span>` : '';
       const privacyTag = getPrivacyTag(model, 'vpt');
       const resPricing = spec.pricing?.resolutions;
@@ -956,10 +966,10 @@
         priceItems = `<span class="vpt-price-item"><span class="vpt-price-label">Per Image</span><span class="vpt-price-value">${formatPrice(spec.pricing?.generation?.usd)}</span></span>`;
       }
 
-      return `<div class="vpt-row${isBetaModel(model) ? ' vpt-beta-row' : ''}">
+      return `<div class="vpt-row${isBetaModel(model) ? ' vpt-beta-row' : ''}${isLegacyModel(model) ? ' vpt-legacy-row' : ''}">
         <div class="vpt-row-top">
           <div class="vpt-row-left">
-            <span class="vpt-model-name">${name}</span>${betaTag}
+            <span class="vpt-model-name">${name}</span>${betaTag}${legacyTag}
             <code class="vpt-model-id">${modelId}</code>${pricingCopyBtn(modelId)}
           </div>
           <div class="vpt-row-right">${moderationTag}${privacyTag}</div>
@@ -2377,6 +2387,10 @@
       const deprecatedBadge = isDeprecatedModel(model)
         ? `<span class="vmb-deprecated-badge vmb-tooltip" data-tooltip="Scheduled for removal on ${formatDeprecationDate(getModelRemovalDate(model))}. See the deprecations page for details.">Deprecated</span>` 
         : '';
+
+      const legacyBadge = isLegacyModel(model)
+        ? `<span class="vmb-legacy-badge vmb-tooltip" data-tooltip="${TOOLTIPS.legacy}">Legacy</span>`
+        : '';
       
       const uncensoredBadge = isUncensoredModel(model)
         ? `<span class="vmb-uncensored-badge vmb-tooltip" data-tooltip="${TOOLTIPS.uncensored}">Uncensored</span>` 
@@ -2455,7 +2469,7 @@
               </div>
               <div class="vmb-model-right">
                 ${contextStr ? `<span class="vmb-context vmb-context-desktop">${contextStr}</span>` : ''}
-                ${typeBadge}${videoTypeBadge}${privacyBadge}${betaBadge}${deprecatedBadge}${upgradedBadge}${uncensoredBadge}${moderationBadge}${rateLimitBadge}
+                ${typeBadge}${videoTypeBadge}${privacyBadge}${betaBadge}${legacyBadge}${deprecatedBadge}${upgradedBadge}${uncensoredBadge}${moderationBadge}${rateLimitBadge}
               </div>
             </div>
             <div class="vmb-model-info">

--- a/models/image.mdx
+++ b/models/image.mdx
@@ -19,5 +19,5 @@ See the [Image Generate API](/api-reference/endpoint/image/generate) for text-to
 </Note>
 
 <Tip>
-Image generation sizing is model-specific. Pixel-based models such as `venice-sd35` and `qwen-image` use `width` and `height`; aspect-ratio models such as `qwen-image-2` use `aspect_ratio`; models that list resolution options such as `1K`, `2K`, or `4K` use both `resolution` and `aspect_ratio`.
+Image generation sizing is model-specific. Pixel-based models such as `venice-sd35` use `width` and `height`; aspect-ratio models such as `qwen-image` and `qwen-image-2` use `aspect_ratio`; models that list resolution options such as `1K`, `2K`, or `4K` use both `resolution` and `aspect_ratio`.
 </Tip>

--- a/overview/getting-started.mdx
+++ b/overview/getting-started.mdx
@@ -411,7 +411,7 @@ Create images from text prompts using diffusion models:
 **Note:** The response returns base64-encoded images in the `images` array. Decode the base64 string to save or display the image.
 
 **Popular Image Models:**
-- `qwen-image` - Highest quality image generation
+- `qwen-image` - Highest quality image generation (legacy, API-only — requires `aspect_ratio`)
 - `venice-sd35` - Default choice, works with all features
 - `hidream` - Fast generation for production use
 

--- a/scripts/update-static-models.js
+++ b/scripts/update-static-models.js
@@ -47,6 +47,7 @@ function cleanModel(m) {
   if (m.created) clean.created = m.created;
   const spec = m.model_spec || {};
   if (spec.betaModel) clean.model_spec.betaModel = true;
+  if (spec.legacy) clean.model_spec.legacy = true;
   if (spec.privacy) clean.model_spec.privacy = spec.privacy;
   if (spec.availableContextTokens) clean.model_spec.availableContextTokens = spec.availableContextTokens;
   if (spec.pricing) clean.model_spec.pricing = spec.pricing;

--- a/style.css
+++ b/style.css
@@ -708,6 +708,24 @@
   color: #80a8d0;
 }
 
+.vmb-legacy-badge {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: #64748b;
+}
+
+.dark .vmb-legacy-badge {
+  background: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: #94a3b8;
+}
+
 .vmb-uncensored-badge {
   font-size: 10px;
   padding: 2px 8px;
@@ -925,6 +943,23 @@
 
 .vpt-beta-row {
   opacity: 0.85;
+}
+
+.vpt-legacy {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  margin-left: 6px;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: #64748b;
+}
+
+.vpt-legacy-row {
+  opacity: 0.8;
 }
 
 .vpt-upgraded {
@@ -1448,7 +1483,8 @@
   /* Smaller badges */
   .vmb-privacy-badge,
   .vmb-uncensored-badge,
-  .vmb-beta-badge {
+  .vmb-beta-badge,
+  .vmb-legacy-badge {
     font-size: 9px;
     padding: 2px 6px;
   }


### PR DESCRIPTION
Adds first-class support for the new `model_spec.legacy` flag emitted by outerface for API-only/B2B models:

- `model-search.js`: `isLegacyModel()` helper, Legacy badge in both the pricing table and the model browser, sort legacy models to the bottom of the image pricing list, tooltip text matching the API schema.
- `style.css`: light + dark mode styling for `.vmb-legacy-badge`, `.vpt-legacy`, and `.vpt-legacy-row` (opacity 0.8 to visually de-emphasize).
- `scripts/update-static-models.js`: persist `legacy: true` into the static fallback so the badge survives offline/cold renders.

Reflects qwen-image's migration from Venice-Operated Comfy to FAL (see outerface feat/migrate-qwen-image-to-fal):

- `models/image.mdx`, `api-reference/endpoint/image/generate.mdx`, `guides/media/image-generation.mdx`: move qwen-image from the pixel-based (width/height) list to the aspect-ratio list. The FAL backend uses `customSizeMapping` keyed by aspect_ratio, so passing raw width/height no longer affects output dimensions.
- `guides/integrations/vercel-ai-sdk.mdx`: update the qwen-image request example to use `aspect_ratio: '1:1'` instead of width/height.
- `guides/getting-started/openai-migration.mdx`: correct the dall-e-3 migration row — qwen-image is now Anonymized (FAL-routed, not Venice-Operated) and priced at $0.03/image, not $0.01.
- `overview/getting-started.mdx`: tag the qwen-image recommendation as legacy/API-only so new integrators know it won't appear in the Venice app picker.