### PR TITLE
docs: update x402 Solana payment docs

### DIFF
--- a/api-reference/endpoint/crypto/rpc.mdx
+++ b/api-reference/endpoint/crypto/rpc.mdx
@@ -12,7 +12,7 @@ Forward a JSON-RPC 2.0 request (single or batch) to a supported blockchain node.
 This endpoint supports two authentication methods:
 
 - **API Key**: Standard Bearer token authentication via the `Authorization: Bearer <key>` header.
-- **x402 Wallet**: Pay-as-you-go with USDC credits from your Ethereum wallet — no Venice account required. See the [x402 guide](/guides/integrations/x402-venice-api) for setup.
+- **x402 Wallet**: Pay-as-you-go with USDC credits from a wallet on a supported chain such as Base or Solana. No Venice account required. See the [x402 guide](/guides/integrations/x402-venice-api) for setup.
 
 Both methods share the same rate limits and billing (Venice credits).
 

--- a/api-reference/endpoint/crypto/rpc.mdx
+++ b/api-reference/endpoint/crypto/rpc.mdx
@@ -12,7 +12,7 @@ Forward a JSON-RPC 2.0 request (single or batch) to a supported blockchain node.
 This endpoint supports two authentication methods:
 
 - **API Key**: Standard Bearer token authentication via the `Authorization: Bearer <key>` header.
-- **x402 Wallet**: Pay-as-you-go with USDC credits from a wallet on a supported chain such as Base or Solana. No Venice account required. See the [x402 guide](/guides/integrations/x402-venice-api) for setup.
+- **x402 Wallet**: Pay-as-you-go with USDC credits from your Ethereum wallet — no Venice account required. See the [x402 guide](/guides/integrations/x402-venice-api) for setup.
 
 Both methods share the same rate limits and billing (Venice credits).
 

--- a/api-reference/endpoint/crypto/rpc.mdx
+++ b/api-reference/endpoint/crypto/rpc.mdx
@@ -12,7 +12,7 @@ Forward a JSON-RPC 2.0 request (single or batch) to a supported blockchain node.
 This endpoint supports two authentication methods:
 
 - **API Key**: Standard Bearer token authentication via the `Authorization: Bearer <key>` header.
-- **x402 Wallet**: Pay-as-you-go with USDC credits from your Ethereum wallet — no Venice account required. See the [x402 guide](/guides/integrations/x402-venice-api) for setup.
+- **x402 Wallet**: Pay-as-you-go with USDC credits from a wallet on Base or Solana. No Venice account required. See the [x402 guide](/guides/integrations/x402-venice-api) for setup.
 
 Both methods share the same rate limits and billing (Venice credits).
 

--- a/guides/getting-started/generating-api-key-agent.mdx
+++ b/guides/getting-started/generating-api-key-agent.mdx
@@ -145,7 +145,7 @@ The minted key can spend from the user account in this priority order: DIEM, the
 If the agent needs a fully crypto-native, headless funding path, the cleanest options are:
 
 1. **Stake more VVV** so the daily DIEM allocation covers the agent's spend. The minted key picks this up automatically.
-2. **Use the [x402 wallet flow](/guides/integrations/x402-venice-api) instead of the API key.** With x402 the agent signs a SIWE message per request, tops up directly with USDC on Base via `POST /api/v1/x402/top-up`, and pays per request. The x402 USDC balance is wallet-bound, not user-bound, so it does not show up as balance for the minted Bearer key, but it does let the same wallet pay for inference programmatically.
+2. **Use the [x402 wallet flow](/guides/integrations/x402-venice-api) instead of the API key.** With x402 the agent signs a Sign-In-With-X message per request, tops up directly with USDC on Base or Solana via `POST /api/v1/x402/top-up`, and pays per request. The x402 USDC balance is wallet-bound, not user-bound, so it does not show up as balance for the minted Bearer key, but it does let the same wallet pay for inference programmatically.
 
 ## Related resources
 
@@ -155,7 +155,7 @@ If the agent needs a fully crypto-native, headless funding path, the cleanest op
   </Card>
 
   <Card title="x402 Wallet Authentication" icon="wallet" href="/guides/integrations/x402-venice-api">
-    Pay per request with USDC on Base, no API key required.
+    Pay per request with USDC on Base or Solana, no API key required.
   </Card>
 
   <Card title="Generate Web3 API Key Endpoint" icon="code" href="/api-reference/endpoint/api_keys/generate_web3_key/post">

--- a/guides/getting-started/generating-api-key-agent.mdx
+++ b/guides/getting-started/generating-api-key-agent.mdx
@@ -145,7 +145,7 @@ The minted key can spend from the user account in this priority order: DIEM, the
 If the agent needs a fully crypto-native, headless funding path, the cleanest options are:
 
 1. **Stake more VVV** so the daily DIEM allocation covers the agent's spend. The minted key picks this up automatically.
-2. **Use the [x402 wallet flow](/guides/integrations/x402-venice-api) instead of the API key.** With x402 the agent signs a Sign-In-With-X message per request, tops up directly with USDC on a supported chain such as Base or Solana via `POST /api/v1/x402/top-up`, and pays per request. The x402 USDC balance is wallet-bound, not user-bound, so it does not show up as balance for the minted Bearer key, but it does let the same wallet pay for inference programmatically.
+2. **Use the [x402 wallet flow](/guides/integrations/x402-venice-api) instead of the API key.** With x402 the agent signs a SIWE message per request, tops up directly with USDC on Base via `POST /api/v1/x402/top-up`, and pays per request. The x402 USDC balance is wallet-bound, not user-bound, so it does not show up as balance for the minted Bearer key, but it does let the same wallet pay for inference programmatically.
 
 ## Related resources
 
@@ -155,7 +155,7 @@ If the agent needs a fully crypto-native, headless funding path, the cleanest op
   </Card>
 
   <Card title="x402 Wallet Authentication" icon="wallet" href="/guides/integrations/x402-venice-api">
-    Pay per request with USDC on Base or Solana, no API key required.
+    Pay per request with USDC on Base, no API key required.
   </Card>
 
   <Card title="Generate Web3 API Key Endpoint" icon="code" href="/api-reference/endpoint/api_keys/generate_web3_key/post">

--- a/guides/getting-started/generating-api-key-agent.mdx
+++ b/guides/getting-started/generating-api-key-agent.mdx
@@ -145,7 +145,7 @@ The minted key can spend from the user account in this priority order: DIEM, the
 If the agent needs a fully crypto-native, headless funding path, the cleanest options are:
 
 1. **Stake more VVV** so the daily DIEM allocation covers the agent's spend. The minted key picks this up automatically.
-2. **Use the [x402 wallet flow](/guides/integrations/x402-venice-api) instead of the API key.** With x402 the agent signs a SIWE message per request, tops up directly with USDC on Base via `POST /api/v1/x402/top-up`, and pays per request. The x402 USDC balance is wallet-bound, not user-bound, so it does not show up as balance for the minted Bearer key, but it does let the same wallet pay for inference programmatically.
+2. **Use the [x402 wallet flow](/guides/integrations/x402-venice-api) instead of the API key.** With x402 the agent signs a Sign-In-With-X message per request, tops up directly with USDC on a supported chain such as Base or Solana via `POST /api/v1/x402/top-up`, and pays per request. The x402 USDC balance is wallet-bound, not user-bound, so it does not show up as balance for the minted Bearer key, but it does let the same wallet pay for inference programmatically.
 
 ## Related resources
 
@@ -155,7 +155,7 @@ If the agent needs a fully crypto-native, headless funding path, the cleanest op
   </Card>
 
   <Card title="x402 Wallet Authentication" icon="wallet" href="/guides/integrations/x402-venice-api">
-    Pay per request with USDC on Base, no API key required.
+    Pay per request with USDC on Base or Solana, no API key required.
   </Card>
 
   <Card title="Generate Web3 API Key Endpoint" icon="code" href="/api-reference/endpoint/api_keys/generate_web3_key/post">

--- a/guides/integrations/crypto-rpc-agents.mdx
+++ b/guides/integrations/crypto-rpc-agents.mdx
@@ -18,7 +18,7 @@ Venice gives your agent both inference (230+ models) and blockchain access (10 E
     Stake VVV on Base to earn daily DIEM, the only fully headless funding path for a minted API key. USD and crypto top-ups are also available through the dashboard.
   </Card>
   <Card title="Keyless auth via x402" icon="wallet">
-    Agents can authenticate with a wallet signature and pay in USDC on Base.
+    Agents can authenticate with a wallet signature and pay in USDC on supported chains such as Base or Solana.
   </Card>
 </CardGroup>
 
@@ -40,7 +40,7 @@ Pick the auth method that matches how your agent runs.
 | Method | Best for | How it works |
 |---|---|---|
 | **API key** | Server-side agents, fixed deployments | `Authorization: Bearer <key>` header. Get a key at [venice.ai/settings/api](https://venice.ai/settings/api). |
-| **x402 wallet** | Autonomous, crypto-native, or short-lived agents | Wallet signs a SIWE message, pays per request in USDC on Base. No Venice account needed. See the [x402 guide](/guides/integrations/x402-venice-api). |
+| **x402 wallet** | Autonomous, crypto-native, or short-lived agents | Wallet signs a Sign-In-With-X message, pays per request with USDC on a supported chain such as Base or Solana. No Venice account needed. See the [x402 guide](/guides/integrations/x402-venice-api). |
 
 Both methods share the same rate limits and billing in Venice credits.
 

--- a/guides/integrations/crypto-rpc-agents.mdx
+++ b/guides/integrations/crypto-rpc-agents.mdx
@@ -18,7 +18,7 @@ Venice gives your agent both inference (230+ models) and blockchain access (10 E
     Stake VVV on Base to earn daily DIEM, the only fully headless funding path for a minted API key. USD and crypto top-ups are also available through the dashboard.
   </Card>
   <Card title="Keyless auth via x402" icon="wallet">
-    Agents can authenticate with a wallet signature and pay in USDC on supported chains such as Base or Solana.
+    Agents can authenticate with a wallet signature and pay in USDC on Base.
   </Card>
 </CardGroup>
 
@@ -40,7 +40,7 @@ Pick the auth method that matches how your agent runs.
 | Method | Best for | How it works |
 |---|---|---|
 | **API key** | Server-side agents, fixed deployments | `Authorization: Bearer <key>` header. Get a key at [venice.ai/settings/api](https://venice.ai/settings/api). |
-| **x402 wallet** | Autonomous, crypto-native, or short-lived agents | Wallet signs a Sign-In-With-X message, pays per request with USDC on a supported chain such as Base or Solana. No Venice account needed. See the [x402 guide](/guides/integrations/x402-venice-api). |
+| **x402 wallet** | Autonomous, crypto-native, or short-lived agents | Wallet signs a SIWE message, pays per request in USDC on Base. Balance and transaction lookups also accept Solana wallet addresses. No Venice account needed. See the [x402 guide](/guides/integrations/x402-venice-api). |
 
 Both methods share the same rate limits and billing in Venice credits.
 

--- a/guides/integrations/crypto-rpc-agents.mdx
+++ b/guides/integrations/crypto-rpc-agents.mdx
@@ -293,7 +293,7 @@ See [Autonomous Agent API Key Creation](/guides/getting-started/generating-api-k
 
 ## x402 wallet auth in 30 seconds
 
-If your agent already has a Base wallet, skip the API key entirely. The [`venice-x402-client`](https://github.com/veniceai/x402-client) SDK handles SIWE signing, top-ups, and balance tracking.
+If your agent already has a Base or Solana wallet, skip the API key entirely. The [`venice-x402-client`](https://github.com/veniceai/x402-client) SDK handles Sign-In-With-X signing, top-ups, and balance tracking.
 
 ```bash
 npm install venice-x402-client
@@ -380,7 +380,7 @@ These categories of methods are intentionally rejected:
     Live list of supported network slugs
   </Card>
   <Card title="x402 Wallet Auth" icon="wallet" href="/guides/integrations/x402-venice-api">
-    Authenticate and pay with a Base wallet
+    Authenticate and pay with a Base or Solana wallet
   </Card>
   <Card title="Autonomous Agent API Key" icon="robot" href="/guides/getting-started/generating-api-key-agent">
     Mint your own key by staking VVV

--- a/guides/integrations/crypto-rpc-agents.mdx
+++ b/guides/integrations/crypto-rpc-agents.mdx
@@ -18,7 +18,7 @@ Venice gives your agent both inference (230+ models) and blockchain access (10 E
     Stake VVV on Base to earn daily DIEM, the only fully headless funding path for a minted API key. USD and crypto top-ups are also available through the dashboard.
   </Card>
   <Card title="Keyless auth via x402" icon="wallet">
-    Agents can authenticate with a wallet signature and pay in USDC on Base.
+    Agents can authenticate with a wallet signature and pay in USDC on Base or Solana.
   </Card>
 </CardGroup>
 
@@ -40,7 +40,7 @@ Pick the auth method that matches how your agent runs.
 | Method | Best for | How it works |
 |---|---|---|
 | **API key** | Server-side agents, fixed deployments | `Authorization: Bearer <key>` header. Get a key at [venice.ai/settings/api](https://venice.ai/settings/api). |
-| **x402 wallet** | Autonomous, crypto-native, or short-lived agents | Wallet signs a SIWE message, pays per request in USDC on Base. Balance and transaction lookups also accept Solana wallet addresses. No Venice account needed. See the [x402 guide](/guides/integrations/x402-venice-api). |
+| **x402 wallet** | Autonomous, crypto-native, or short-lived agents | Wallet signs a Sign-In-With-X message, pays per request in USDC on Base or Solana. No Venice account needed. See the [x402 guide](/guides/integrations/x402-venice-api). |
 
 Both methods share the same rate limits and billing in Venice credits.
 

--- a/guides/integrations/venice-mcp.mdx
+++ b/guides/integrations/venice-mcp.mdx
@@ -132,9 +132,9 @@ Only relevant if you authenticate with a wallet via [x402](/guides/integrations/
 
 | Tool | Description |
 |---|---|
-| `venice_x402_balance` | Check prepaid x402 credit balance for a wallet. |
+| `venice_x402_balance` | Check prepaid x402 credit balance for an EVM or Solana wallet address. |
 | `venice_x402_top_up_info` | Fetch top-up requirements (network, USDC token, receiver, min amount). |
-| `venice_x402_transactions` | List recent x402 top-up and debit transactions. |
+| `venice_x402_transactions` | List recent x402 top-up and debit transactions for an EVM or Solana wallet address. |
 
 ## Configuration
 
@@ -155,7 +155,7 @@ If both `VENICE_API_KEY` and `VENICE_SIWX_TOKEN` are set, the API key wins.
 
 ## x402 wallet mode
 
-Venice supports authenticating with a [Sign-In-With-X wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on supported chains such as Base and Solana, in addition to the normal API key flow. No email, phone, or KYC required: your wallet is the only identity.
+Venice supports authenticating with a [SIWE-signed wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on Base mainnet, in addition to the normal API key flow. No email, phone, or KYC required: your wallet is the only identity. Balance and transaction helper tools also accept Solana wallet addresses.
 
 ```json
 {
@@ -173,8 +173,8 @@ The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on 
 
 | Flow | What happens |
 |---|---|
-| **One-time setup** | Sign a Sign-In-With-X message in your wallet → produces a SIWX token (base64 JSON). |
-| **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC payment for one of the returned Base or Solana options, resubmit, and Venice credits your balance. |
+| **One-time setup** | Sign a SIWE message in your wallet → produces a SIWX token (base64 JSON). |
+| **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC EIP-3009 transfer in your wallet, resubmit, and Venice credits your balance. |
 | **Every inference call** | MCP server sends `X-Sign-In-With-X: <SIWX>`; Venice debits your prepaid balance. |
 
 Minimum top-up is **\$5 USD**. Minimum balance to call inference is **\$0.10**. Once topped up, calls are sub-100ms because settlement happens off-chain on a fast credit account.

--- a/guides/integrations/venice-mcp.mdx
+++ b/guides/integrations/venice-mcp.mdx
@@ -155,7 +155,7 @@ If both `VENICE_API_KEY` and `VENICE_SIWX_TOKEN` are set, the API key wins.
 
 ## x402 wallet mode
 
-Venice supports authenticating with a [SIWE-signed wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on Base mainnet, in addition to the normal API key flow. No email, phone, or KYC required: your wallet is the only identity.
+Venice supports authenticating with a [Sign-In-With-X wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on supported chains such as Base and Solana, in addition to the normal API key flow. No email, phone, or KYC required: your wallet is the only identity.
 
 ```json
 {
@@ -173,8 +173,8 @@ The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on 
 
 | Flow | What happens |
 |---|---|
-| **One-time setup** | Sign a SIWE message in your wallet → produces a SIWX token (base64 JSON). |
-| **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC EIP-3009 transfer in your wallet, resubmit, and Venice credits your balance. |
+| **One-time setup** | Sign a Sign-In-With-X message in your wallet → produces a SIWX token (base64 JSON). |
+| **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC payment for one of the returned Base or Solana options, resubmit, and Venice credits your balance. |
 | **Every inference call** | MCP server sends `X-Sign-In-With-X: <SIWX>`; Venice debits your prepaid balance. |
 
 Minimum top-up is **\$5 USD**. Minimum balance to call inference is **\$0.10**. Once topped up, calls are sub-100ms because settlement happens off-chain on a fast credit account.

--- a/guides/integrations/venice-mcp.mdx
+++ b/guides/integrations/venice-mcp.mdx
@@ -155,7 +155,7 @@ If both `VENICE_API_KEY` and `VENICE_SIWX_TOKEN` are set, the API key wins.
 
 ## x402 wallet mode
 
-Venice supports authenticating with a [SIWE-signed wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on Base mainnet, in addition to the normal API key flow. No email, phone, or KYC required: your wallet is the only identity. Balance and transaction helper tools also accept Solana wallet addresses.
+Venice supports authenticating with a [Sign-In-With-X wallet token](/guides/integrations/x402-venice-api) backed by prepaid USDC credit on Base or Solana, in addition to the normal API key flow. No email, phone, or KYC required: your wallet is the only identity.
 
 ```json
 {
@@ -163,18 +163,18 @@ Venice supports authenticating with a [SIWE-signed wallet token](/guides/integra
     "venice": {
       "command": "npx",
       "args": ["-y", "@veniceai/mcp-server@0.2.0"],
-      "env": { "VENICE_SIWX_TOKEN": "<base64 SIWE payload>" }
+      "env": { "VENICE_SIWX_TOKEN": "<base64 Sign-In-With-X payload>" }
     }
   }
 }
 ```
 
-The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on every Venice API call. The server never sees your private key. SIWE signing and USDC top-up authorizations happen in your own wallet.
+The MCP server forwards `VENICE_SIWX_TOKEN` as the `X-Sign-In-With-X` header on every Venice API call. The server never sees your private key. Wallet signing and USDC top-up authorizations happen in your own wallet.
 
 | Flow | What happens |
 |---|---|
-| **One-time setup** | Sign a SIWE message in your wallet → produces a SIWX token (base64 JSON). |
-| **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC EIP-3009 transfer in your wallet, resubmit, and Venice credits your balance. |
+| **One-time setup** | Sign a Sign-In-With-X message in your wallet → produces a SIWX token (base64 JSON). |
+| **Top up** | `POST /api/v1/x402/top-up` returns 402 + payment requirements. Sign a USDC payment for one of the returned Base or Solana options, resubmit, and Venice credits your balance. |
 | **Every inference call** | MCP server sends `X-Sign-In-With-X: <SIWX>`; Venice debits your prepaid balance. |
 
 Minimum top-up is **\$5 USD**. Minimum balance to call inference is **\$0.10**. Once topped up, calls are sub-100ms because settlement happens off-chain on a fast credit account.

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -53,7 +53,7 @@ Each `SKILL.md` includes:
 | `venice-characters` | `/characters*` + `venice_parameters.character_slug` |
 | `venice-api-keys` | CRUD `/api_keys`, rate limits, Web3 key generation |
 | `venice-billing` | `/billing/balance`, `/billing/usage`, `/billing/usage-analytics` |
-| `venice-x402` | `/x402/*` wallet credits, USDC on Base, EVM and Solana address lookups |
+| `venice-x402` | `/x402/*` wallet credits, USDC on Base or Solana |
 | `venice-crypto-rpc` | `/crypto/rpc/*` JSON-RPC proxy with 1×/2×/4× pricing |
 | `venice-augment` | `/augment/text-parser`, `/augment/scrape`, `/augment/search` |
 | `venice-errors` | Error shapes, 402 payment required, 422 content policy, 429 rate limits, retry strategy |

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -53,7 +53,7 @@ Each `SKILL.md` includes:
 | `venice-characters` | `/characters*` + `venice_parameters.character_slug` |
 | `venice-api-keys` | CRUD `/api_keys`, rate limits, Web3 key generation |
 | `venice-billing` | `/billing/balance`, `/billing/usage`, `/billing/usage-analytics` |
-| `venice-x402` | `/x402/*` wallet credits, USDC on Base |
+| `venice-x402` | `/x402/*` wallet credits, USDC on Base or Solana |
 | `venice-crypto-rpc` | `/crypto/rpc/*` JSON-RPC proxy with 1×/2×/4× pricing |
 | `venice-augment` | `/augment/text-parser`, `/augment/scrape`, `/augment/search` |
 | `venice-errors` | Error shapes, 402 payment required, 422 content policy, 429 rate limits, retry strategy |

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -53,7 +53,7 @@ Each `SKILL.md` includes:
 | `venice-characters` | `/characters*` + `venice_parameters.character_slug` |
 | `venice-api-keys` | CRUD `/api_keys`, rate limits, Web3 key generation |
 | `venice-billing` | `/billing/balance`, `/billing/usage`, `/billing/usage-analytics` |
-| `venice-x402` | `/x402/*` wallet credits, USDC on Base or Solana |
+| `venice-x402` | `/x402/*` wallet credits, USDC on Base, EVM and Solana address lookups |
 | `venice-crypto-rpc` | `/crypto/rpc/*` JSON-RPC proxy with 1×/2×/4× pricing |
 | `venice-augment` | `/augment/text-parser`, `/augment/scrape`, `/augment/search` |
 | `venice-errors` | Error shapes, 402 payment required, 422 content policy, 429 rate limits, retry strategy |

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -39,7 +39,7 @@ Each `SKILL.md` includes:
 | Skill | Covers |
 |---|---|
 | `venice-api-overview` | Base URL, auth modes, response headers, pricing model, versioning |
-| `venice-auth` | Bearer API keys + SIWE / x402 wallet authentication |
+| `venice-auth` | Bearer API keys + Sign-In-With-X / x402 wallet authentication |
 | `venice-chat` | `/chat/completions` with `venice_parameters`, multimodal, tools, reasoning, streaming |
 | `venice-responses` | `/responses`, the OpenAI-compatible Responses API (Alpha) |
 | `venice-embeddings` | `/embeddings` models, encoding formats, dimensions |

--- a/guides/integrations/x402-venice-api.mdx
+++ b/guides/integrations/x402-venice-api.mdx
@@ -5,15 +5,15 @@ description: Access Venice without an API key using wallet authentication.
 "og:description": Access Venice without an API key using wallet authentication.
 ---
 
-X402 lets you use Venice's paid API routes by authenticating with an EVM wallet on Base. No API key or account required. Sign a message, maintain a balance, and call any supported route. Balance and transaction lookups also accept Solana wallet addresses.
+X402 lets you use Venice's paid API routes by authenticating with a wallet and maintaining a prepaid USDC balance. No API key or account required. Sign a message, top up on Base or Solana, and call any supported route.
 
 <CardGroup cols={3}>
   <Card title="Wallet Auth" icon="wallet">
-    Authenticate with a signed SIWE payload in the `X-Sign-In-With-X` header.
+    Authenticate with a signed Sign-In-With-X payload in the `X-Sign-In-With-X` header.
   </Card>
 
   <Card title="Pay with USDC" icon="coins">
-    Maintain spendable balance with USDC on Base.
+    Maintain spendable balance with USDC on Base or Solana.
   </Card>
 
   <Card title="DIEM First" icon="sparkles">
@@ -23,13 +23,13 @@ X402 lets you use Venice's paid API routes by authenticating with an EVM wallet 
 
 ## What is X402?
 
-[X402](https://www.x402.org/) is an open payment standard that lets applications and agents pay for services programmatically using cryptocurrency. Venice implements X402 on Base so that wallets can authenticate and pay for inference directly.
+[X402](https://www.x402.org/) is an open payment standard that lets applications and agents pay for services programmatically using cryptocurrency. Venice implements X402 so that wallets can authenticate and pay for inference directly with USDC on Base or Solana.
 
 ## Prerequisites
 
-- An EVM wallet on Base
-- A small amount of ETH on Base for gas
-- USDC on Base (or existing DIEM-backed balance from a linked Venice account)
+- A wallet on Base or Solana
+- Native token for gas on the selected chain, such as ETH on Base or SOL on Solana
+- USDC on the selected chain (or existing DIEM-backed balance from a linked Venice account)
 
 <Tip>
   Consider using a dedicated wallet for automation rather than your main treasury wallet.
@@ -37,7 +37,7 @@ X402 lets you use Venice's paid API routes by authenticating with an EVM wallet 
 
 ## Quick start
 
-The [`venice-x402-client`](https://github.com/veniceai/x402-client) SDK provides helpers for SIWE auth, top-ups, and balance tracking.
+The [`venice-x402-client`](https://github.com/veniceai/x402-client) SDK provides helpers for wallet auth, top-ups, and balance tracking.
 
 ```bash
 npm install venice-x402-client
@@ -91,7 +91,9 @@ If you're not using the SDK or need to understand the underlying protocol, here'
 
 ### Step 1: Create the X-Sign-In-With-X header
 
-Venice expects a Base64-encoded JSON payload containing a signed SIWE message. Generate a fresh nonce and timestamp for each request flow.
+Venice expects a Base64-encoded JSON payload containing a signed Sign-In-With-X message. EVM wallets sign an EIP-4361 SIWE message on Base. Solana wallets sign the Solana SIWX message with Ed25519. Generate a fresh nonce and timestamp for each request flow.
+
+For Solana, set `chainId` to `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`, include `type: "ed25519"` in the encoded JSON payload, and provide the Ed25519 signature as base58 or base64. The signed message starts with `<domain> wants you to sign in with your Solana account:`, followed by the wallet address and the standard `URI`, `Version`, `Chain ID`, `Nonce`, `Issued At`, and optional `Expiration Time` fields.
 
 ```typescript
 import { Wallet } from 'ethers'
@@ -135,7 +137,7 @@ console.log(xSignInWithX)
 Before making a paid request, verify the wallet has spendable balance:
 
 ```bash
-export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS
+export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS_OR_SOLANA_ADDRESS
 export X402_AUTH=YOUR_BASE64_SIWX_HEADER
 
 curl --request GET \
@@ -154,18 +156,18 @@ The `walletAddress` path parameter accepts either an EVM address (`0x...`) or a 
 
 ### Step 3: Top up
 
-Top up with USDC on Base:
+Top up with USDC on Base or Solana:
 
 ```bash
 curl --request POST \
   --url https://api.venice.ai/api/v1/x402/top-up
 ```
 
-The first call returns `402 Payment Required` with a `PAYMENT-REQUIRED` header containing an `accepts` array. Use those payment details to build an `X-402-Payment` header and retry the same route.
+The first call returns `402 Payment Required` with a `PAYMENT-REQUIRED` header containing an `accepts` array. Each entry describes one accepted payment option, including `network`, `asset`, `payTo`, and `amount`. Choose the Base or Solana option you want to pay with, use those exact details to build an `X-402-Payment` header, and retry the same route.
 
-#### Building the X-402-Payment header
+#### Building the X-402-Payment header for Base
 
-The following script creates a signed x402 payment and sends the top-up request. Requires the `x402` and `viem` npm packages.
+The following script creates a signed x402 payment on Base and sends the top-up request. Requires the `x402` and `viem` npm packages.
 
 ```bash
 export EVM_PRIVATE_KEY=0xYOUR_PRIVATE_KEY
@@ -203,7 +205,7 @@ curl -X POST "https://api.venice.ai/api/v1/x402/top-up" \
 ```
 
 <Note>
-  Use the latest `PAYMENT-REQUIRED` / `accepts` response as the source of truth in production instead of hardcoding these values.
+  Use the latest `PAYMENT-REQUIRED` / `accepts` response as the source of truth in production instead of hardcoding these values. For Solana top-ups, build the payment from the Solana entry returned in `accepts`. Solana entries use `network: "solana"`, the USDC mint as `asset`, and may include network-specific metadata such as `extra.feePayer`.
 </Note>
 
 ### Step 4: Make a request
@@ -235,7 +237,7 @@ Successful responses may include an `X-Balance-Remaining` header.
 Review the wallet's transaction history:
 
 ```bash
-export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS
+export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS_OR_SOLANA_ADDRESS
 export X402_AUTH=YOUR_BASE64_SIWX_HEADER
 
 curl --request GET \
@@ -267,7 +269,7 @@ The following public paid Venice routes currently support x402 wallet authentica
 
 | Endpoint | Auth | Purpose |
 | --- | --- | --- |
-| `POST /api/v1/x402/top-up` | Initial request: none. Retry: `X-402-Payment` | Add USDC credits to the wallet's spendable balance |
+| `POST /api/v1/x402/top-up` | Initial request: none. Retry: `X-402-Payment` | Add USDC credits to the wallet's spendable balance using an accepted Base or Solana payment option |
 
 ### Wallet-only routes
 
@@ -284,7 +286,7 @@ These routes use `X-Sign-In-With-X` for identity but do not charge balance.
 
 | Status | Likely cause | What to do |
 | --- | --- | --- |
-| `401` | Malformed or expired SIWE payload | Rebuild `X-Sign-In-With-X` with a fresh nonce and timestamp |
+| `401` | Malformed or expired Sign-In-With-X payload | Rebuild `X-Sign-In-With-X` with a fresh nonce and timestamp |
 | `402` on a paid route | Not enough spendable balance | Top up and retry |
 | `402` on `/x402/top-up` | Expected. This is the payment initiation flow. | Use the returned payment details to build `X-402-Payment` and retry |
 | `403` on balance or transactions | Wallet mismatch | Ensure the authenticated wallet matches the `walletAddress` path parameter |

--- a/guides/integrations/x402-venice-api.mdx
+++ b/guides/integrations/x402-venice-api.mdx
@@ -5,15 +5,15 @@ description: Access Venice without an API key using wallet authentication.
 "og:description": Access Venice without an API key using wallet authentication.
 ---
 
-X402 lets you use Venice's paid API routes by authenticating with an Ethereum wallet on Base. No API key or account required. Sign a message, maintain a balance, and call any supported route.
+X402 lets you use Venice's paid API routes by authenticating with a wallet and maintaining a prepaid USDC balance. No API key or account required. Sign a message, top up on a supported chain such as Base or Solana, and call any supported route.
 
 <CardGroup cols={3}>
   <Card title="Wallet Auth" icon="wallet">
-    Authenticate with a signed SIWE payload in the `X-Sign-In-With-X` header.
+    Authenticate with a signed Sign-In-With-X payload in the `X-Sign-In-With-X` header.
   </Card>
 
   <Card title="Pay with USDC" icon="coins">
-    Maintain spendable balance with USDC on Base.
+    Maintain spendable balance with USDC on supported chains, including Base and Solana.
   </Card>
 
   <Card title="DIEM First" icon="sparkles">
@@ -23,13 +23,13 @@ X402 lets you use Venice's paid API routes by authenticating with an Ethereum wa
 
 ## What is X402?
 
-[X402](https://www.x402.org/) is an open payment standard that lets applications and agents pay for services programmatically using cryptocurrency. Venice implements X402 on Base so that wallets can authenticate and pay for inference directly.
+[X402](https://www.x402.org/) is an open payment standard that lets applications and agents pay for services programmatically using cryptocurrency. Venice implements X402 so that wallets can authenticate and pay for inference directly with USDC on supported chains, including Base and Solana.
 
 ## Prerequisites
 
-- An EVM wallet on Base
-- A small amount of ETH on Base for gas
-- USDC on Base (or existing DIEM-backed balance from a linked Venice account)
+- A wallet on a supported chain, such as an EVM wallet on Base or a Solana wallet
+- Native token for gas on the selected chain, such as ETH on Base or SOL on Solana
+- USDC on the selected chain (or existing DIEM-backed balance from a linked Venice account)
 
 <Tip>
   Consider using a dedicated wallet for automation rather than your main treasury wallet.
@@ -91,7 +91,7 @@ If you're not using the SDK or need to understand the underlying protocol, here'
 
 ### Step 1: Create the X-Sign-In-With-X header
 
-Venice expects a Base64-encoded JSON payload containing a signed SIWE message. Generate a fresh nonce and timestamp for each request flow.
+Venice expects a Base64-encoded JSON payload containing a signed Sign-In-With-X message. The example below uses an EVM wallet and SIWE on Base; Solana wallets should use the Sign-In-With-X flow supported by your wallet tooling. Generate a fresh nonce and timestamp for each request flow.
 
 ```typescript
 import { Wallet } from 'ethers'
@@ -135,7 +135,7 @@ console.log(xSignInWithX)
 Before making a paid request, verify the wallet has spendable balance:
 
 ```bash
-export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS
+export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS_OR_SOLANA_ADDRESS
 export X402_AUTH=YOUR_BASE64_SIWX_HEADER
 
 curl --request GET \
@@ -152,18 +152,18 @@ The response includes:
 
 ### Step 3: Top up
 
-Top up with USDC on Base:
+Top up with USDC on a supported payment chain, such as Base or Solana:
 
 ```bash
 curl --request POST \
   --url https://api.venice.ai/api/v1/x402/top-up
 ```
 
-The first call returns `402 Payment Required` with a `PAYMENT-REQUIRED` header containing an `accepts` array. Use those payment details to build an `X-402-Payment` header and retry the same route.
+The first call returns `402 Payment Required` with a `PAYMENT-REQUIRED` header containing an `accepts` array. Each entry describes one accepted payment option, including `network`, `asset`, `payTo`, and `amount`. Choose the Base or Solana option you want to pay with, use those exact details to build an `X-402-Payment` header, and retry the same route.
 
-#### Building the X-402-Payment header
+#### Building the X-402-Payment header for Base
 
-The following script creates a signed x402 payment and sends the top-up request. Requires the `x402` and `viem` npm packages.
+The following script creates a signed x402 payment on Base and sends the top-up request. Requires the `x402` and `viem` npm packages.
 
 ```bash
 export EVM_PRIVATE_KEY=0xYOUR_PRIVATE_KEY
@@ -201,7 +201,7 @@ curl -X POST "https://api.venice.ai/api/v1/x402/top-up" \
 ```
 
 <Note>
-  Use the latest `PAYMENT-REQUIRED` / `accepts` response as the source of truth in production instead of hardcoding these values.
+  Use the latest `PAYMENT-REQUIRED` / `accepts` response as the source of truth in production instead of hardcoding these values. For Solana top-ups, build the payment from the Solana entry returned in `accepts`.
 </Note>
 
 ### Step 4: Make a request
@@ -233,7 +233,7 @@ Successful responses may include an `X-Balance-Remaining` header.
 Review the wallet's transaction history:
 
 ```bash
-export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS
+export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS_OR_SOLANA_ADDRESS
 export X402_AUTH=YOUR_BASE64_SIWX_HEADER
 
 curl --request GET \
@@ -263,7 +263,7 @@ The following public paid Venice routes currently support x402 wallet authentica
 
 | Endpoint | Auth | Purpose |
 | --- | --- | --- |
-| `POST /api/v1/x402/top-up` | Initial request: none. Retry: `X-402-Payment` | Add USDC credits to the wallet's spendable balance |
+| `POST /api/v1/x402/top-up` | Initial request: none. Retry: `X-402-Payment` | Add USDC credits to the wallet's spendable balance using an accepted Base or Solana payment option |
 
 ### Wallet-only routes
 
@@ -280,7 +280,7 @@ These routes use `X-Sign-In-With-X` for identity but do not charge balance.
 
 | Status | Likely cause | What to do |
 | --- | --- | --- |
-| `401` | Malformed or expired SIWE payload | Rebuild `X-Sign-In-With-X` with a fresh nonce and timestamp |
+| `401` | Malformed or expired Sign-In-With-X payload | Rebuild `X-Sign-In-With-X` with a fresh nonce and timestamp |
 | `402` on a paid route | Not enough spendable balance | Top up and retry |
 | `402` on `/x402/top-up` | Expected. This is the payment initiation flow. | Use the returned payment details to build `X-402-Payment` and retry |
 | `403` on balance or transactions | Wallet mismatch | Ensure the authenticated wallet matches the `walletAddress` path parameter |

--- a/guides/integrations/x402-venice-api.mdx
+++ b/guides/integrations/x402-venice-api.mdx
@@ -5,15 +5,15 @@ description: Access Venice without an API key using wallet authentication.
 "og:description": Access Venice without an API key using wallet authentication.
 ---
 
-X402 lets you use Venice's paid API routes by authenticating with a wallet and maintaining a prepaid USDC balance. No API key or account required. Sign a message, top up on a supported chain such as Base or Solana, and call any supported route.
+X402 lets you use Venice's paid API routes by authenticating with an EVM wallet on Base. No API key or account required. Sign a message, maintain a balance, and call any supported route. Balance and transaction lookups also accept Solana wallet addresses.
 
 <CardGroup cols={3}>
   <Card title="Wallet Auth" icon="wallet">
-    Authenticate with a signed Sign-In-With-X payload in the `X-Sign-In-With-X` header.
+    Authenticate with a signed SIWE payload in the `X-Sign-In-With-X` header.
   </Card>
 
   <Card title="Pay with USDC" icon="coins">
-    Maintain spendable balance with USDC on supported chains, including Base and Solana.
+    Maintain spendable balance with USDC on Base.
   </Card>
 
   <Card title="DIEM First" icon="sparkles">
@@ -23,13 +23,13 @@ X402 lets you use Venice's paid API routes by authenticating with a wallet and m
 
 ## What is X402?
 
-[X402](https://www.x402.org/) is an open payment standard that lets applications and agents pay for services programmatically using cryptocurrency. Venice implements X402 so that wallets can authenticate and pay for inference directly with USDC on supported chains, including Base and Solana.
+[X402](https://www.x402.org/) is an open payment standard that lets applications and agents pay for services programmatically using cryptocurrency. Venice implements X402 on Base so that wallets can authenticate and pay for inference directly.
 
 ## Prerequisites
 
-- A wallet on a supported chain, such as an EVM wallet on Base or a Solana wallet
-- Native token for gas on the selected chain, such as ETH on Base or SOL on Solana
-- USDC on the selected chain (or existing DIEM-backed balance from a linked Venice account)
+- An EVM wallet on Base
+- A small amount of ETH on Base for gas
+- USDC on Base (or existing DIEM-backed balance from a linked Venice account)
 
 <Tip>
   Consider using a dedicated wallet for automation rather than your main treasury wallet.
@@ -91,7 +91,7 @@ If you're not using the SDK or need to understand the underlying protocol, here'
 
 ### Step 1: Create the X-Sign-In-With-X header
 
-Venice expects a Base64-encoded JSON payload containing a signed Sign-In-With-X message. The example below uses an EVM wallet and SIWE on Base; Solana wallets should use the Sign-In-With-X flow supported by your wallet tooling. Generate a fresh nonce and timestamp for each request flow.
+Venice expects a Base64-encoded JSON payload containing a signed SIWE message. Generate a fresh nonce and timestamp for each request flow.
 
 ```typescript
 import { Wallet } from 'ethers'
@@ -135,7 +135,7 @@ console.log(xSignInWithX)
 Before making a paid request, verify the wallet has spendable balance:
 
 ```bash
-export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS_OR_SOLANA_ADDRESS
+export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS
 export X402_AUTH=YOUR_BASE64_SIWX_HEADER
 
 curl --request GET \
@@ -150,20 +150,22 @@ The response includes:
 - `minimumTopUpUsd` and `suggestedTopUpUsd`: guidance for top-ups
 - `diemBalanceUsd`: DIEM-backed balance, if any
 
+The `walletAddress` path parameter accepts either an EVM address (`0x...`) or a Solana base58 address.
+
 ### Step 3: Top up
 
-Top up with USDC on a supported payment chain, such as Base or Solana:
+Top up with USDC on Base:
 
 ```bash
 curl --request POST \
   --url https://api.venice.ai/api/v1/x402/top-up
 ```
 
-The first call returns `402 Payment Required` with a `PAYMENT-REQUIRED` header containing an `accepts` array. Each entry describes one accepted payment option, including `network`, `asset`, `payTo`, and `amount`. Choose the Base or Solana option you want to pay with, use those exact details to build an `X-402-Payment` header, and retry the same route.
+The first call returns `402 Payment Required` with a `PAYMENT-REQUIRED` header containing an `accepts` array. Use those payment details to build an `X-402-Payment` header and retry the same route.
 
-#### Building the X-402-Payment header for Base
+#### Building the X-402-Payment header
 
-The following script creates a signed x402 payment on Base and sends the top-up request. Requires the `x402` and `viem` npm packages.
+The following script creates a signed x402 payment and sends the top-up request. Requires the `x402` and `viem` npm packages.
 
 ```bash
 export EVM_PRIVATE_KEY=0xYOUR_PRIVATE_KEY
@@ -201,7 +203,7 @@ curl -X POST "https://api.venice.ai/api/v1/x402/top-up" \
 ```
 
 <Note>
-  Use the latest `PAYMENT-REQUIRED` / `accepts` response as the source of truth in production instead of hardcoding these values. For Solana top-ups, build the payment from the Solana entry returned in `accepts`.
+  Use the latest `PAYMENT-REQUIRED` / `accepts` response as the source of truth in production instead of hardcoding these values.
 </Note>
 
 ### Step 4: Make a request
@@ -233,7 +235,7 @@ Successful responses may include an `X-Balance-Remaining` header.
 Review the wallet's transaction history:
 
 ```bash
-export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS_OR_SOLANA_ADDRESS
+export WALLET_ADDRESS=0xYOUR_WALLET_ADDRESS
 export X402_AUTH=YOUR_BASE64_SIWX_HEADER
 
 curl --request GET \
@@ -242,6 +244,8 @@ curl --request GET \
 ```
 
 The ledger includes entries such as `TOP_UP`, `CHARGE`, and `REFUND`.
+
+The `walletAddress` path parameter accepts either an EVM address (`0x...`) or a Solana base58 address.
 
 ---
 
@@ -263,7 +267,7 @@ The following public paid Venice routes currently support x402 wallet authentica
 
 | Endpoint | Auth | Purpose |
 | --- | --- | --- |
-| `POST /api/v1/x402/top-up` | Initial request: none. Retry: `X-402-Payment` | Add USDC credits to the wallet's spendable balance using an accepted Base or Solana payment option |
+| `POST /api/v1/x402/top-up` | Initial request: none. Retry: `X-402-Payment` | Add USDC credits to the wallet's spendable balance |
 
 ### Wallet-only routes
 
@@ -271,8 +275,8 @@ These routes use `X-Sign-In-With-X` for identity but do not charge balance.
 
 | Endpoint | Purpose |
 | --- | --- |
-| `GET /api/v1/x402/balance/{walletAddress}` | Check spendable balance |
-| `GET /api/v1/x402/transactions/{walletAddress}` | View transaction history |
+| `GET /api/v1/x402/balance/{walletAddress}` | Check spendable balance for an EVM or Solana wallet address |
+| `GET /api/v1/x402/transactions/{walletAddress}` | View transaction history for an EVM or Solana wallet address |
 
 ---
 
@@ -280,7 +284,7 @@ These routes use `X-Sign-In-With-X` for identity but do not charge balance.
 
 | Status | Likely cause | What to do |
 | --- | --- | --- |
-| `401` | Malformed or expired Sign-In-With-X payload | Rebuild `X-Sign-In-With-X` with a fresh nonce and timestamp |
+| `401` | Malformed or expired SIWE payload | Rebuild `X-Sign-In-With-X` with a fresh nonce and timestamp |
 | `402` on a paid route | Not enough spendable balance | Top up and retry |
 | `402` on `/x402/top-up` | Expected. This is the payment initiation flow. | Use the returned payment details to build `X-402-Payment` and retry |
 | `403` on balance or transactions | Wallet mismatch | Ensure the authenticated wallet matches the `walletAddress` path parameter |

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -15,16 +15,14 @@ info:
 
     - API Key: Use Bearer token in Authorization header
 
-    - x402 Wallet: Use USDC credits via wallet authentication (no account
-      required)
+    - x402 Wallet: Use USDC credits via Ethereum wallet (no account required)
 
 
     **For x402 wallet access:**
 
     1. POST /x402/top-up without headers to get payment requirements
 
-    2. Sign a USDC payment for one of the returned Base or Solana payment
-    options using x402 tooling
+    2. Sign a USDC payment using the x402 SDK
 
     3. POST /x402/top-up with X-402-Payment header to add credits
 
@@ -62,19 +60,18 @@ tags:
     name: Crypto RPC
   - description: >-
       Wallet-based API access using the x402 protocol. No API key required —
-      authenticate with a wallet.
+      authenticate with an Ethereum wallet.
 
 
       **How it works:**
 
       1. **Authenticate** — Send an `X-Sign-In-With-X` header (base64-encoded
-      signed wallet message) with any request. See the `siwx` security scheme
-      for the exact format.
+      signed SIWE message) with any request. See the `siwx` security scheme for
+      the exact format.
 
       2. **Top up** — `POST /x402/top-up` without a payment header returns
-      payment requirements. Sign a USDC transfer for one of the returned Base or
-      Solana payment options using x402 tooling and re-submit with the
-      `X-402-Payment` header.
+      payment requirements. Sign a USDC transfer on Base using the x402 SDK
+      (`npm install x402`) and re-submit with the `X-402-Payment` header.
 
       3. **Use any endpoint** — All inference endpoints (chat, image, audio,
       video, embeddings) accept `siwx` as an alternative to `BearerAuth`.
@@ -93,7 +90,7 @@ tags:
 
       const venice = new VeniceClient(process.env.WALLET_KEY)
 
-      await venice.topUp(10) // $10 USDC on a supported payment chain
+      await venice.topUp(10) // $10 USDC on Base
 
       const res = await venice.chat({ model: 'zai-org-glm-5-1', messages: [{
       role: 'user', content: 'Hello!' }] })
@@ -101,8 +98,7 @@ tags:
       ```
 
 
-      **Payment:** USDC on supported payment chains, including Base and Solana.
-      Minimum top-up: $5.
+      **Payment:** USDC on Base (chain ID 8453). Minimum top-up: $5.
       Alternatively, stake DIEM tokens for daily credits (1 DIEM = $1/day).
     name: x402
 components:
@@ -113,14 +109,13 @@ components:
       type: http
     siwx:
       description: >-
-        Wallet-based authentication using the x402 protocol (Sign-In-With-X; EVM
-        examples use EIP-4361 SIWE).
+        Wallet-based authentication using the x402 protocol (Sign-In-With-X /
+        EIP-4361 SIWE).
 
 
         **Header format:** Base64-encoded JSON object with the following fields:
 
-        - `address` — Wallet address. EVM addresses should be checksummed; x402
-        balance and transaction lookups also accept Solana addresses.
+        - `address` — Ethereum wallet address (checksummed)
 
         - `message` — EIP-4361 SIWE message string (created with
         `SiweMessage.prepareMessage()`)
@@ -130,7 +125,7 @@ components:
 
         - `timestamp` — Unix timestamp in milliseconds
 
-        - `chainId` — Chain ID for EVM SIWE flows (use `8453` for Base)
+        - `chainId` — Chain ID (use `8453` for Base)
 
 
         **SIWE message fields:**
@@ -185,9 +180,8 @@ components:
 
 
         **Billing:** x402 users pay from a prepaid USDC credit balance. Top up
-        via `POST /x402/top-up` with an accepted Base or Solana payment option.
-        When balance is insufficient, endpoints return `402` with structured
-        top-up instructions.
+        via `POST /x402/top-up`. When balance is insufficient, endpoints return
+        `402` with structured top-up instructions.
       in: header
       name: X-Sign-In-With-X
       type: apiKey
@@ -286,7 +280,6 @@ components:
           description: List of supported blockchain networks.
           example:
             - base
-            - solana
         topUpInstructions:
           type: object
           properties:
@@ -306,12 +299,11 @@ components:
               example: POST /api/v1/x402/top-up with the signed X-402-Payment header
             receiverWallet:
               type: string
-              description: Venice receiver wallet address for the selected network.
+              description: Venice receiver wallet address.
               example: <RECEIVER_WALLET_ADDRESS>
             tokenAddress:
               type: string
-              description: USDC token contract address or asset identifier for the selected
-                network.
+              description: USDC token contract address.
               example: <USDC_TOKEN_ADDRESS>
             tokenDecimals:
               type: number
@@ -319,7 +311,7 @@ components:
               example: 6
             network:
               type: string
-              description: Target blockchain network in CAIP-2 format.
+              description: Target blockchain network.
               example: eip155:8453
             minimumAmountUsd:
               type: number
@@ -13190,10 +13182,10 @@ paths:
   /x402/balance/{walletAddress}:
     get:
       description: Get the x402 credit balance for a wallet address. Requires
-        Sign-In-With-X authentication for the same EVM or Solana wallet.
+        Sign-in-with-x authentication (via SIWE) for the same wallet.
       operationId: getX402Balance
       parameters:
-        - description: base64-encoded JSON Sign-In-With-X payload proving wallet ownership
+        - description: base64-encoded JSON SIWE payload message proving wallet ownership
           in: header
           name: X-Sign-In-With-X
           required: true
@@ -13427,13 +13419,11 @@ paths:
                           example: 2
                         network:
                           type: string
-                          description: CAIP-2 network identifier for the accepted payment
-                            option. Base and Solana options may be returned.
+                          description: Network in EIP-155 CAIP-2 format.
                           example: eip155:8453
                         asset:
                           type: string
-                          description: Token contract address or asset identifier for
-                            the selected network.
+                          description: Token contract address.
                           example: <USDC_TOKEN_ADDRESS>
                         amount:
                           type: string
@@ -13441,7 +13431,7 @@ paths:
                           example: "5000000"
                         payTo:
                           type: string
-                          description: Receiver wallet address for the selected network.
+                          description: Receiver wallet address.
                           example: <RECEIVER_WALLET_ADDRESS>
                       required:
                         - protocol
@@ -13490,10 +13480,10 @@ paths:
   /x402/transactions/{walletAddress}:
     get:
       description: Get paginated x402 transaction history for a wallet address.
-        Requires Sign-In-With-X authentication for the same EVM or Solana wallet.
+        Requires Sign-in-with-x authentication for the same wallet.
       operationId: getX402Transactions
       parameters:
-        - description: base64-encoded JSON Sign-In-With-X payload proving wallet ownership
+        - description: base64-encoded JSON SIWE payload message proving wallet ownership
           in: header
           name: X-Sign-In-With-X
           required: true

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -15,14 +15,16 @@ info:
 
     - API Key: Use Bearer token in Authorization header
 
-    - x402 Wallet: Use USDC credits via Ethereum wallet (no account required)
+    - x402 Wallet: Use USDC credits via wallet authentication (no account
+      required)
 
 
     **For x402 wallet access:**
 
     1. POST /x402/top-up without headers to get payment requirements
 
-    2. Sign a USDC payment using the x402 SDK
+    2. Sign a USDC payment for one of the returned Base or Solana payment
+    options using x402 tooling
 
     3. POST /x402/top-up with X-402-Payment header to add credits
 
@@ -60,18 +62,19 @@ tags:
     name: Crypto RPC
   - description: >-
       Wallet-based API access using the x402 protocol. No API key required —
-      authenticate with an Ethereum wallet.
+      authenticate with a wallet.
 
 
       **How it works:**
 
       1. **Authenticate** — Send an `X-Sign-In-With-X` header (base64-encoded
-      signed SIWE message) with any request. See the `siwx` security scheme for
-      the exact format.
+      signed wallet message) with any request. See the `siwx` security scheme
+      for the exact format.
 
       2. **Top up** — `POST /x402/top-up` without a payment header returns
-      payment requirements. Sign a USDC transfer on Base using the x402 SDK
-      (`npm install x402`) and re-submit with the `X-402-Payment` header.
+      payment requirements. Sign a USDC transfer for one of the returned Base or
+      Solana payment options using x402 tooling and re-submit with the
+      `X-402-Payment` header.
 
       3. **Use any endpoint** — All inference endpoints (chat, image, audio,
       video, embeddings) accept `siwx` as an alternative to `BearerAuth`.
@@ -90,7 +93,7 @@ tags:
 
       const venice = new VeniceClient(process.env.WALLET_KEY)
 
-      await venice.topUp(10) // $10 USDC on Base
+      await venice.topUp(10) // $10 USDC on a supported payment chain
 
       const res = await venice.chat({ model: 'zai-org-glm-5-1', messages: [{
       role: 'user', content: 'Hello!' }] })
@@ -98,7 +101,8 @@ tags:
       ```
 
 
-      **Payment:** USDC on Base (chain ID 8453). Minimum top-up: $5.
+      **Payment:** USDC on supported payment chains, including Base and Solana.
+      Minimum top-up: $5.
       Alternatively, stake DIEM tokens for daily credits (1 DIEM = $1/day).
     name: x402
 components:
@@ -109,13 +113,14 @@ components:
       type: http
     siwx:
       description: >-
-        Wallet-based authentication using the x402 protocol (Sign-In-With-X /
-        EIP-4361 SIWE).
+        Wallet-based authentication using the x402 protocol (Sign-In-With-X; EVM
+        examples use EIP-4361 SIWE).
 
 
         **Header format:** Base64-encoded JSON object with the following fields:
 
-        - `address` — Ethereum wallet address (checksummed)
+        - `address` — Wallet address. EVM addresses should be checksummed; x402
+        balance and transaction lookups also accept Solana addresses.
 
         - `message` — EIP-4361 SIWE message string (created with
         `SiweMessage.prepareMessage()`)
@@ -125,7 +130,7 @@ components:
 
         - `timestamp` — Unix timestamp in milliseconds
 
-        - `chainId` — Chain ID (use `8453` for Base)
+        - `chainId` — Chain ID for EVM SIWE flows (use `8453` for Base)
 
 
         **SIWE message fields:**
@@ -180,8 +185,9 @@ components:
 
 
         **Billing:** x402 users pay from a prepaid USDC credit balance. Top up
-        via `POST /x402/top-up`. When balance is insufficient, endpoints return
-        `402` with structured top-up instructions.
+        via `POST /x402/top-up` with an accepted Base or Solana payment option.
+        When balance is insufficient, endpoints return `402` with structured
+        top-up instructions.
       in: header
       name: X-Sign-In-With-X
       type: apiKey
@@ -280,6 +286,7 @@ components:
           description: List of supported blockchain networks.
           example:
             - base
+            - solana
         topUpInstructions:
           type: object
           properties:
@@ -299,11 +306,12 @@ components:
               example: POST /api/v1/x402/top-up with the signed X-402-Payment header
             receiverWallet:
               type: string
-              description: Venice receiver wallet address.
+              description: Venice receiver wallet address for the selected network.
               example: <RECEIVER_WALLET_ADDRESS>
             tokenAddress:
               type: string
-              description: USDC token contract address.
+              description: USDC token contract address or asset identifier for the selected
+                network.
               example: <USDC_TOKEN_ADDRESS>
             tokenDecimals:
               type: number
@@ -311,7 +319,7 @@ components:
               example: 6
             network:
               type: string
-              description: Target blockchain network.
+              description: Target blockchain network in CAIP-2 format.
               example: eip155:8453
             minimumAmountUsd:
               type: number
@@ -13182,10 +13190,10 @@ paths:
   /x402/balance/{walletAddress}:
     get:
       description: Get the x402 credit balance for a wallet address. Requires
-        Sign-in-with-x authentication (via SIWE) for the same wallet.
+        Sign-In-With-X authentication for the same EVM or Solana wallet.
       operationId: getX402Balance
       parameters:
-        - description: base64-encoded JSON SIWE payload message proving wallet ownership
+        - description: base64-encoded JSON Sign-In-With-X payload proving wallet ownership
           in: header
           name: X-Sign-In-With-X
           required: true
@@ -13419,11 +13427,13 @@ paths:
                           example: 2
                         network:
                           type: string
-                          description: Network in EIP-155 CAIP-2 format.
+                          description: CAIP-2 network identifier for the accepted payment
+                            option. Base and Solana options may be returned.
                           example: eip155:8453
                         asset:
                           type: string
-                          description: Token contract address.
+                          description: Token contract address or asset identifier for
+                            the selected network.
                           example: <USDC_TOKEN_ADDRESS>
                         amount:
                           type: string
@@ -13431,7 +13441,7 @@ paths:
                           example: "5000000"
                         payTo:
                           type: string
-                          description: Receiver wallet address.
+                          description: Receiver wallet address for the selected network.
                           example: <RECEIVER_WALLET_ADDRESS>
                       required:
                         - protocol
@@ -13480,10 +13490,10 @@ paths:
   /x402/transactions/{walletAddress}:
     get:
       description: Get paginated x402 transaction history for a wallet address.
-        Requires Sign-in-with-x authentication for the same wallet.
+        Requires Sign-In-With-X authentication for the same EVM or Solana wallet.
       operationId: getX402Transactions
       parameters:
-        - description: base64-encoded JSON SIWE payload message proving wallet ownership
+        - description: base64-encoded JSON Sign-In-With-X payload proving wallet ownership
           in: header
           name: X-Sign-In-With-X
           required: true


### PR DESCRIPTION
## Summary
- Document x402 wallet inference and top-ups as supported with USDC on Base or Solana.
- Update the x402 guide with Solana SIWX details from the regenerated Swagger, including `chainId: solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`, `type: ed25519`, and Solana `accepts` metadata like `extra.feePayer`.
- Update MCP, skills, agent, and crypto RPC cross-references to match the Base-or-Solana x402 flow.

## Test plan
- [x] Merged latest `origin/main` with regenerated Swagger `20260526.005904`.
- [x] Checked edited files with IDE diagnostics.
- [x] Ran Git whitespace checks with CRLF-aware settings.
