### PR TITLE
docs: add agent CTAs to API overview

### DIFF
--- a/guides/integrations/ai-agents.mdx
+++ b/guides/integrations/ai-agents.mdx
@@ -1,51 +1,102 @@
 ---
-title: "AI Agents"
-description: "Venice is supported with the following AI Agent communities."
+title: AI Agents
+description: Build private agents with Venice across apps, coding tools, MCP hosts, skills, frameworks, and crypto workflows.
 "og:title": "AI Agents | Venice API Docs"
-"og:description": "Venice is supported with the following AI Agent communities"
+"og:description": "Use Venice as the private model, tools, media, and wallet layer for AI agents."
 ---
 
-* [Coinbase Agentkit](https://www.coinbase.com/developer-platform/discover/launches/introducing-agentkit)
+Build agents on Venice with private, OpenAI-compatible models, media endpoints, tool access, and wallet-based payments.
 
-* [Eliza](https://github.com/ai16z/eliza) - Venice support introduced via this [PR](https://github.com/ai16z/eliza/pull/1008).
+<CardGroup cols={2}>
+  <Card title="Agent apps" icon="robot" href="#agent-apps">
+    OpenClaw, Hermes Agent, and NanoClaw.
+  </Card>
 
-* [OpenClaw](https://docs.openclaw.ai/providers/venice) - Open source AI assistant with Venice API integration for easy AI-powered conversations. See the [OpenClaw Venice Provider Guide](https://docs.openclaw.ai/providers/venice) for setup instructions.
+  <Card title="Coding agents" icon="terminal" href="#coding-agents">
+    Claude Code, Cursor, and Codex CLI.
+  </Card>
 
-## Eliza Instructions
+  <Card title="MCP + Skills" icon="plug" href="#tools-and-skills">
+    Runtime tools, endpoint guidance, and production playbooks.
+  </Card>
 
-To setup Eliza with Venice, follow these instructions. A full blog post with more detail can be found [here](https://venice.ai/blog/how-to-build-a-social-media-ai-agent-with-elizaos-venice-api).
+  <Card title="Autonomous agents" icon="link" href="#autonomous-and-framework-agents">
+    x402 wallet auth, Crypto RPC, autonomous keys, and agent frameworks.
+  </Card>
+</CardGroup>
 
-* Clone the Eliza repository:
+## Agent apps
 
-```bash
-# Clone the repository
-git clone https://github.com/ai16z/eliza.git
-```
+<CardGroup cols={3}>
+  <Card title="OpenClaw" icon="message" href="/guides/integrations/openclaw-bot">
+    Connect Venice to WhatsApp, Telegram, Discord, iMessage, Slack, and more.
+  </Card>
 
-* Copy `.env.example` to `.env`
+  <Card title="Hermes Agent" icon="brain" href="/guides/integrations/hermes-agent">
+    Self-hosted agents with memory, skills, and Venice models.
+  </Card>
 
-* Update `.env` specifying your `VENICE_API_KEY`, and model selections for  `SMALL_VENICE_MODEL`, `MEDIUM_VENICE_MODEL`, `LARGE_VENICE_MODEL`, `IMAGE_VENICE_MODEL`, instructions on generating your key can be found [here](/guides/getting-started/generating-api-key).
+  <Card title="NanoClaw" icon="mobile-screen" href="/guides/integrations/nanoclaw-venice">
+    Lightweight WhatsApp and Telegram assistant powered by Venice.
+  </Card>
+</CardGroup>
 
-* Create a new character in the `/characters/` folder with a filename similar to  `your_character.character.json`to specify the character profile, tools/functions, and Venice.ai as the model provider:
+## Coding agents
 
-```typescript
-   modelProvider: "venice"
-```
+<CardGroup cols={3}>
+  <Card title="Claude Code" icon="terminal" href="/guides/integrations/claude-code">
+    Use Claude Code with Venice-hosted Claude models.
+  </Card>
 
-* Build the repo:
+  <Card title="Cursor" icon="code" href="/guides/integrations/cursor">
+    Add Venice models to Cursor with the `venice-` model prefix.
+  </Card>
 
-```bash
-pnpm i
-pnpm build
-pnpm start
-```
+  <Card title="Codex CLI" icon="square-terminal" href="/guides/integrations/codex-cli">
+    Point Codex CLI at Venice's OpenAI-compatible endpoint.
+  </Card>
+</CardGroup>
 
-* Start your character
+## Tools and skills
 
-```bash
-pnpm start --characters="characters/<your_character>.character.json"
-```
+<CardGroup cols={3}>
+  <Card title="Venice MCP Server" icon="plug" href="/guides/integrations/venice-mcp">
+    Expose chat, image, video, audio, music, embeddings, and more as MCP tools.
+  </Card>
 
-* Start the local UI to chat with the agent
+  <Card title="Venice Skills" icon="screwdriver-wrench" href="/guides/integrations/venice-skills">
+    Give agents endpoint-specific instructions synced to the API spec.
+  </Card>
 
-![](/images/eliza-config.png)
+  <Card title="Video Harness" icon="video" href="/guides/integrations/venice-video-harness">
+    Use agent playbooks for repeatable Venice video production.
+  </Card>
+</CardGroup>
+
+## Autonomous and framework agents
+
+<CardGroup cols={3}>
+  <Card title="Crypto RPC for Agents" icon="link" href="/guides/integrations/crypto-rpc-agents">
+    Give agents inference and on-chain access through one credential.
+  </Card>
+
+  <Card title="x402 Wallet Auth" icon="wallet" href="/guides/integrations/x402-venice-api">
+    Let agents pay for Venice with Base or Solana USDC.
+  </Card>
+
+  <Card title="Autonomous API Keys" icon="key" href="/guides/getting-started/generating-api-key-agent">
+    Mint API keys from a staked VVV wallet.
+  </Card>
+
+  <Card title="LangChain" icon="link" href="/guides/integrations/langchain">
+    Build chains and agents on Venice models.
+  </Card>
+
+  <Card title="Vercel AI SDK" icon="triangle" href="/guides/integrations/vercel-ai-sdk">
+    Stream Venice models through the AI SDK.
+  </Card>
+
+  <Card title="CrewAI" icon="users" href="/guides/integrations/crewai">
+    Run multi-agent crews with Venice as the model provider.
+  </Card>
+</CardGroup>

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -19,23 +19,19 @@ Build AI with no data retention, permissionless access, and compute you permanen
 
 ## Build AI Agents With Venice
 
-Venice is more than a chat endpoint. Use one private, OpenAI-compatible API for agent frameworks, MCP tool hosts, messaging bots, media generation, and wallet-funded autonomy.
+Private models, tools, and payments for agents.
 
-<CardGroup cols={2}>
-  <Card title="Messaging agents with OpenClaw" href="/guides/integrations/openclaw-bot" icon="robot">
-    Run Venice-powered agents across WhatsApp, Telegram, Discord, iMessage, Slack, and more.
+<CardGroup cols={3}>
+  <Card title="OpenClaw + Hermes" icon="robot">
+    [OpenClaw](/guides/integrations/openclaw-bot) for messaging. [Hermes](/guides/integrations/hermes-agent) for persistent agents.
   </Card>
 
-  <Card title="Persistent agents with Hermes" href="/guides/integrations/hermes-agent" icon="brain">
-    Give self-hosted agents private inference, long-running memory, and access to Venice tools.
+  <Card title="MCP + Agent Skills" icon="plug">
+    [MCP](/guides/integrations/venice-mcp) for tools. [Skills](/guides/integrations/venice-skills) for API guidance.
   </Card>
 
-  <Card title="Tool access through MCP" href="/guides/integrations/venice-mcp" icon="plug">
-    Add 31 Venice tools to Claude Desktop, Cursor, LM Studio, and other MCP-compatible hosts.
-  </Card>
-
-  <Card title="Autonomous crypto agents" href="/guides/integrations/crypto-rpc-agents" icon="link">
-    Combine LLM inference, x402 wallet auth, and multi-chain RPC under one Venice credential.
+  <Card title="Autonomous Crypto Agents" href="/guides/integrations/crypto-rpc-agents" icon="link">
+    Inference, wallet auth, and multi-chain RPC in one API.
   </Card>
 </CardGroup>
 

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -56,8 +56,8 @@ res = client.chat.completions.create(
 
 <div className="venice-section-header">
   <p className="venice-section-eyebrow">Endpoints</p>
-  <h2 className="venice-section-title">Everything an agent needs</h2>
-  <p className="venice-section-subtitle">Generation, tools, and payments behind one API key.</p>
+  <h2 className="venice-section-title">One API for every modality</h2>
+  <p className="venice-section-subtitle">Chat, image, audio, video, and embeddings behind one API key.</p>
 </div>
 
 <div className="venice-apis-grid">

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -3,351 +3,184 @@ title: Venice API
 "og:title": "Venice API Docs" 
 ---
 
-Build AI with no data retention, permissionless access, and compute you permanently own.
+The API for private, unrestricted access to intelligence.
 
-<CardGroup cols={3}>
-  <Card title="Start Building" href="/overview/getting-started" target="_blank" icon="rocket">
-    Make your first request in minutes.
-  </Card>
-  <Card title="View Models" href="/overview/models" target="_blank" icon="database">
-    Compare capabilities, context, and base models.
-  </Card>
-  <Card title="API Reference" href="/api-reference" target="_blank" icon="rectangle-code">
-    Endpoints, payloads, and examples.
-  </Card>
-</CardGroup>
+<div className="venice-hero-grid">
+  <a className="venice-api-card" href="/overview/getting-started">
+    <span className="venice-api-card-name">Quickstart</span>
+    <p className="venice-api-card-desc">Make your first API call in minutes.</p>
+    <span className="venice-api-card-action">Get started →</span>
+  </a>
+  <a className="venice-api-card" href="/overview/models">
+    <span className="venice-api-card-name">Browse Models</span>
+    <p className="venice-api-card-desc">Compare 250+ models by context, price, and modality.</p>
+    <span className="venice-api-card-action">View catalog →</span>
+  </a>
+  <a className="venice-api-card" href="/api-reference">
+    <span className="venice-api-card-name">API Reference</span>
+    <p className="venice-api-card-desc">Endpoints, payloads, and language examples.</p>
+    <span className="venice-api-card-action">Read reference →</span>
+  </a>
+</div>
 
-## Build AI Agents With Venice
+<div className="venice-section-header">
+  <p className="venice-section-eyebrow">APIs</p>
+  <h2 className="venice-section-title">Build with Venice APIs</h2>
+  <p className="venice-section-subtitle">Chat, image, audio, and video behind one API key. OpenAI-compatible where it applies.</p>
+</div>
 
-Private models, tools, and payments for agents.
+<div className="venice-apis-grid">
+  <a className="venice-api-card" href="/api-reference/endpoint/chat/completions">
+    <span className="venice-api-card-name">Chat Completions</span>
+    <p className="venice-api-card-desc">OpenAI-compatible chat with reasoning, tool use, and streaming across 100+ text models.</p>
+    <div className="venice-api-card-chips">
+      <span className="venice-api-card-chip">Streaming</span>
+      <span className="venice-api-card-chip">Tools</span>
+      <span className="venice-api-card-chip">Vision</span>
+    </div>
+    <span className="venice-api-card-action">See reference →</span>
+  </a>
 
-<CardGroup cols={3}>
-  <Card title="OpenClaw + Hermes" icon="robot">
-    [OpenClaw](/guides/integrations/openclaw-bot) for messaging. [Hermes](/guides/integrations/hermes-agent) for persistent agents.
-  </Card>
+  <a className="venice-api-card" href="/api-reference/endpoint/image/generations">
+    <span className="venice-api-card-name">Image Generation</span>
+    <p className="venice-api-card-desc">Text-to-image, edits, and upscaling across photorealistic, stylized, and uncensored models.</p>
+    <div className="venice-api-card-chips">
+      <span className="venice-api-card-chip">Generate</span>
+      <span className="venice-api-card-chip">Upscale</span>
+      <span className="venice-api-card-chip">Edit</span>
+    </div>
+    <span className="venice-api-card-action">See reference →</span>
+  </a>
 
-  <Card title="MCP + Agent Skills" icon="plug">
-    [MCP](/guides/integrations/venice-mcp) for tools. [Skills](/guides/integrations/venice-skills) for API guidance.
-  </Card>
+  <a className="venice-api-card" href="/api-reference/endpoint/audio/speech">
+    <span className="venice-api-card-name">Audio Synthesis</span>
+    <p className="venice-api-card-desc">Text-to-speech with 50+ multilingual voices and low-latency streaming for real-time agents.</p>
+    <div className="venice-api-card-chips">
+      <span className="venice-api-card-chip">TTS</span>
+      <span className="venice-api-card-chip">50+ voices</span>
+      <span className="venice-api-card-chip">Streaming</span>
+    </div>
+    <span className="venice-api-card-action">See reference →</span>
+  </a>
 
-  <Card title="Autonomous Crypto Agents" href="/guides/integrations/crypto-rpc-agents" icon="link">
-    Inference, wallet auth, and multi-chain RPC in one API.
-  </Card>
-</CardGroup>
-
-## OpenAI Compatibility
-
-Use your existing OpenAI code with just a base URL change.
-
-<CodeGroup>
-```python Python
-import openai
-
-client = openai.OpenAI(
-    api_key="your-api-key",
-    base_url="https://api.venice.ai/api/v1"
-)
-
-response = client.chat.completions.create(
-    model="venice-uncensored-1-2",
-    messages=[{"role": "user", "content": "Hello World!"}]
-)
-
-print(response.choices[0].message.content)
-```
-
-```ts TypeScript
-import OpenAI from "openai";
-
-const openai = new OpenAI({
-  apiKey: process.env.VENICE_API_KEY!,
-  baseURL: "https://api.venice.ai/api/v1",
-});
-
-const completion = await openai.chat.completions.create({
-  model: "venice-uncensored-1-2",
-  messages: [{ role: "user", content: "Hello World!" }],
-});
-
-console.log(completion.choices[0].message.content);
-```
-
-```bash Curl
-curl https://api.venice.ai/api/v1/chat/completions \
-  -H "Authorization: Bearer $VENICE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "venice-uncensored-1-2",
-    "messages": [{"role": "user", "content": "Hello World!"}]
-  }'
-```
-
-```go Go
-package main
-
-import (
-    "context"
-    "fmt"
-    "os"
-    "github.com/openai/openai-go"
-)
-
-func main() {
-    client, err := openai.NewClient(os.Getenv("VENICE_API_KEY"))
-    if err != nil {
-        fmt.Printf("Error creating client: %v\n", err)
-        return
-    }
-    
-    client.BaseURL = "https://api.venice.ai/api/v1"
-    
-    resp, err := client.CreateChatCompletion(
-        context.Background(),
-        openai.ChatCompletionRequest{
-            Model: "venice-uncensored-1-2",
-            Messages: []openai.ChatCompletionMessage{
-                {
-                    Role:    openai.ChatMessageRoleUser,
-                    Content: "Hello World!",
-                },
-            },
-        },
-    )
-    
-    if err != nil {
-        fmt.Printf("Error: %v\n", err)
-        return
-    }
-    
-    fmt.Println(resp.Choices[0].Message.Content)
-}
-```
-
-```php PHP
-<?php
-
-require_once 'vendor/autoload.php';
-
-use OpenAI\Client;
-
-$client = OpenAI::client('your-api-key');
-$client->setBaseUrl('https://api.venice.ai/api/v1');
-
-$response = $client->chat()->create([
-    'model' => 'venice-uncensored',
-    'messages' => [
-        [
-            'role' => 'user',
-            'content' => 'Hello World!'
-        ]
-    ]
-]);
-
-echo $response->choices[0]->message->content;
-```
-
-```csharp C#
-using OpenAI;
-
-var client = new OpenAIClient("your-api-key");
-client.BaseUrl = "https://api.venice.ai/api/v1";
-
-var chatCompletion = await client.GetChatCompletionsAsync(new ChatCompletionOptions
-{
-    Model = "venice-uncensored-1-2",
-    Messages = { new ChatMessage(ChatRole.User, "Hello World!") }
-});
-
-Console.WriteLine(chatCompletion.Value.Choices[0].Message.Content);
-```
-
-```java Java
-import com.openai.OpenAI;
-import com.openai.OpenAIHttpException;
-import com.openai.core.ApiError;
-import com.openai.types.chat.ChatCompletionRequest;
-import com.openai.types.chat.ChatCompletionResponse;
-import com.openai.types.chat.ChatMessage;
-
-public class Main {
-    public static void main(String[] args) {
-        OpenAI client = OpenAI.builder()
-            .apiKey(System.getenv("VENICE_API_KEY"))
-            .baseUrl("https://api.venice.ai/api/v1")
-            .build();
-
-        try {
-            ChatCompletionResponse response = client.chatCompletions().create(
-                ChatCompletionRequest.builder()
-                    .model("venice-uncensored-1-2")
-                    .messages(ChatMessage.of("Hello World!"))
-                    .build()
-            );
-            
-            System.out.println(response.choices().get(0).message().content());
-        } catch (OpenAIHttpException e) {
-            System.err.println("Error: " + e.getMessage());
-        }
-    }
-}
-```
-
-```swift Swift
-import OpenAI
-
-let client = OpenAI(apiToken: "your-api-key")
-client.baseURL = "https://api.venice.ai/api/v1"
-
-Task {
-    do {
-        let response = try await client.chats.create(
-            model: "venice-uncensored-1-2",
-            messages: [.init(role: .user, content: "Hello World!")]
-        )
-        
-        print(response.choices[0].message.content ?? "")
-    } catch {
-        print("Error: \(error)")
-    }
-}
-```
-</CodeGroup>
-
-
-## Build with Venice APIs
-
-Access chat, image generation (generate/upscale/edit), audio (TTS), and characters.
-
-<CardGroup cols={2}>
-  <Card title="Chat Completions" href="/api-reference/endpoint/chat/completions" icon="message">
-    **Text + reasoning**
-    
-    Vision, tool use, streaming
-  </Card>
-  
-  <Card title="Image Generation" href="/api-reference/endpoint/image/generations" icon="image">
-    **Generate, upscale, and edit**
-    
-    Models for styles, quality, and uncensored
-  </Card>
-  
-  <Card title="Audio Synthesis" href="/api-reference/endpoint/audio/speech" icon="headphones">
-    **Text → speech**
-    
-    50+ multilingual voices
-  </Card>
-  
-  <Card title="AI Characters" href="/api-reference/endpoint/characters/list" icon="user">
-    **Characters API**
-    
-    Create, list, and chat with personas
-  </Card>
-</CardGroup>
+  <a className="venice-api-card" href="/api-reference/endpoint/video/queue">
+    <span className="venice-api-card-name">Video</span>
+    <p className="venice-api-card-desc">Text-to-video, reference-to-video, and audio transcription through an async job queue.</p>
+    <div className="venice-api-card-chips">
+      <span className="venice-api-card-chip">Text-to-video</span>
+      <span className="venice-api-card-chip">Reference-to-video</span>
+      <span className="venice-api-card-chip">Transcription</span>
+    </div>
+    <span className="venice-api-card-action">See reference →</span>
+  </a>
+</div>
 
 [View all API endpoints →](/api-reference)
 
-## Popular Models
+<div className="venice-agents-panel">
+  <div className="venice-agents-copy">
+    <p className="venice-agents-eyebrow">For agent builders</p>
+    <h2>Build AI agents on Venice</h2>
+    <p>Private inference, MCP tools, and wallet-funded workflows for messaging, coding, and on-chain agents.</p>
+    <a className="venice-agents-button" href="/guides/integrations/ai-agents">Explore the AI Agents hub →</a>
+  </div>
 
-Copy a Model ID and use it as `model` in your requests.
+  <div className="venice-agents-cards">
+    <a className="venice-agents-card" href="/guides/integrations/ai-agents#agent-apps">
+      <span className="venice-agents-card-title">Agent apps</span>
+      <span className="venice-agents-card-desc">OpenClaw, Hermes, NanoClaw</span>
+    </a>
+    <a className="venice-agents-card" href="/guides/integrations/ai-agents#coding-agents">
+      <span className="venice-agents-card-title">Coding agents</span>
+      <span className="venice-agents-card-desc">Claude Code, Cursor, Codex CLI</span>
+    </a>
+    <a className="venice-agents-card" href="/guides/integrations/ai-agents#tools-and-skills">
+      <span className="venice-agents-card-title">MCP + Skills</span>
+      <span className="venice-agents-card-desc">31 tools for any agent runtime</span>
+    </a>
+  </div>
+</div>
 
-<Card title="GLM 5.1" icon="brain">
-  Flagship model for deep reasoning and production agents.
+<div className="venice-section-header">
+  <p className="venice-section-eyebrow">Models</p>
+  <h2 className="venice-section-title">Pick a model, copy the ID, ship it</h2>
+  <p className="venice-section-subtitle">A few of the most popular models on Venice. Drop the ID straight into your `model` field.</p>
+</div>
 
-  Model ID: `zai-org-glm-5.1`
-  Base: GLM 5.1
-  Context: 200k • Modalities: Text → Text
+<div className="venice-models-grid">
+  <a className="venice-model-card" href="/overview/models">
+    <div className="venice-model-card-head">
+      <span className="venice-model-card-name">Kimi K2.6</span>
+      <span className="venice-model-card-maker">Moonshot AI</span>
+    </div>
+    <p className="venice-model-card-desc">Open-weights frontier reasoning. Strong long-context and tool use at a fraction of frontier prices.</p>
+    <div className="venice-model-card-stats">
+      <span>256K context</span>
+      <span>\$0.85 / \$4.66 per 1M</span>
+      <span className="venice-model-card-privacy">Private</span>
+    </div>
+    <code className="venice-model-card-id">kimi-k2-6</code>
+  </a>
 
-  **Use cases**
-  - Agent planning and tool use
-  - Complex code & system design
-  - Long‑context reasoning
+  <a className="venice-model-card" href="/overview/models">
+    <div className="venice-model-card-head">
+      <span className="venice-model-card-name">Claude Opus 4.7</span>
+      <span className="venice-model-card-maker">Anthropic</span>
+    </div>
+    <p className="venice-model-card-desc">Best-in-class for coding, planning, and long-horizon agents that need to stay coherent.</p>
+    <div className="venice-model-card-stats">
+      <span>1M context</span>
+      <span>\$6.00 / \$30.00 per 1M</span>
+      <span className="venice-model-card-privacy">Anonymized</span>
+    </div>
+    <code className="venice-model-card-id">claude-opus-4-7</code>
+  </a>
 
-  ```json
-  {"model":"zai-org-glm-5.1","messages":[{"role":"user","content":"Plan a zero‑downtime DB migration in 3 steps"}]}
-  ```
-</Card>
+  <a className="venice-model-card" href="/overview/models">
+    <div className="venice-model-card-head">
+      <span className="venice-model-card-name">GPT-5.5</span>
+      <span className="venice-model-card-maker">OpenAI</span>
+    </div>
+    <p className="venice-model-card-desc">Frontier general intelligence with 1M context. Strong default for chat, RAG, and multi-step reasoning.</p>
+    <div className="venice-model-card-stats">
+      <span>1M context</span>
+      <span>\$6.25 / \$37.50 per 1M</span>
+      <span className="venice-model-card-privacy">Anonymized</span>
+    </div>
+    <code className="venice-model-card-id">openai-gpt-55</code>
+  </a>
+</div>
 
-<CardGroup cols={2}>
-  <Card title="Venice Uncensored 1.2" icon="shield">
-    **Unfiltered generation**
-    
-    Model ID: `venice-uncensored-1-2`
-    
-    Base model: Venice Uncensored 1.2
-    
-    Context: 128k • Best for: uncensored creative, red‑team testing
-    
-    ```json
-    {"model":"venice-uncensored-1-2","messages":[{"role":"user","content":"Write an unfiltered analysis of content moderation policies"}]}
-    ```
-  </Card>
-  
-  <Card title="Mistral 3.1 24B" icon="eye">
-    **Vision + tools**
-    
-    Model ID: `mistral-31-24b`
-    
-    Base model: Mistral 3.1 24B
-    
-    Context: 131k • Supports: Vision, Function calling, image analysis
-    
-    ```json
-    {"model":"mistral-31-24b","messages":[{"role":"user","content":"Describe this image"}]}
-    ```
-  </Card>
-  
-  <Card title="Qwen 3.5 9B" icon="bolt">
-    **Fast and cost‑efficient**
-    
-    Model ID: `qwen3-5-9b`
-    
-    Base model: Qwen 3.5 9B
-    
-    Context: 256k • Best for: chatbots, classification, light reasoning
-    
-    ```json
-    {"model":"qwen3-5-9b","messages":[{"role":"user","content":"Summarize:"}]}
-    ```
-  </Card>
-  
-<Card title="Nano Banana Pro" icon="image">
-    **Image generation**
-    
-    Model ID: `nano-banana-pro`
-    
-    Base model: Nano Banana Pro
+<a className="venice-models-cta" href="/overview/models">
+  <span className="venice-models-cta-left">
+    <span className="venice-models-cta-count">250+ models</span>
+    <span className="venice-models-cta-sub">Text, image, audio, and video</span>
+  </span>
+  <span className="venice-models-cta-action">Browse the catalog →</span>
+</a>
 
-    
-    Best for: Text‑to‑image, photorealism, product shots, light upscaling
-    
-    ```json
-    {"model":"nano-banana-pro","prompt":"a serene canal in venice at sunset"}
-    ```
-  </Card>
-</CardGroup>
-
-[View all models →](/overview/models)
-
-## Extend models with built‑in tools
-
-Toggle on compatible models using `venice_parameters` or model suffixes
+<div className="venice-section-header">
+  <p className="venice-section-eyebrow">Tools</p>
+  <h2 className="venice-section-title">Built‑in tools for chat models</h2>
+  <p className="venice-section-subtitle">Turn on web search, attach files, or query a blockchain with `venice_parameters` or a Venice-native endpoint.</p>
+</div>
 
 <CardGroup cols={4}>
   <Card title="Web Search" icon="globe">
   </Card>
-  
-  <Card title="Reasoning" icon="brain">
+
+  <Card title="Web Scraping" icon="browser">
   </Card>
-  
-  <Card title="Vision" icon="eye">
+
+  <Card title="File Inputs" icon="file">
   </Card>
-  
-  <Card title="Tool Calling" icon="link">
+
+  <Card title="Crypto RPC" icon="link">
   </Card>
 </CardGroup>
 
 <Accordion title="Web Search Code Samples">
-Enable real-time web search with citations on **all text models**. Get up-to-date information from the internet and include source citations in responses. Works with any Venice text model.
+Add real-time web search with citations to any text model via `enable_web_search`.
 
 <CodeGroup>
 ```bash Curl
@@ -355,7 +188,7 @@ curl https://api.venice.ai/api/v1/chat/completions \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "zai-org-glm-5.1",
+    "model": "zai-org-glm-5-1",
     "messages": [{"role": "user", "content": "What are the latest developments in AI?"}],
     "venice_parameters": {
       "enable_web_search": "auto"
@@ -366,158 +199,47 @@ curl https://api.venice.ai/api/v1/chat/completions \
 ```ts TypeScript
 import OpenAI from "openai";
 
-const openai = new OpenAI({
+const client = new OpenAI({
   apiKey: process.env.VENICE_API_KEY!,
   baseURL: "https://api.venice.ai/api/v1",
 });
 
-const completion = await openai.chat.completions.create({
-  model: "zai-org-glm-5.1",
+const completion = await client.chat.completions.create({
+  model: "zai-org-glm-5-1",
   messages: [{ role: "user", content: "What are the latest developments in AI?" }],
-  // @ts-ignore - Venice-specific parameter
+  // @ts-expect-error - Venice-specific parameter
   venice_parameters: {
-    enable_web_search: "auto"
-  }
+    enable_web_search: "auto",
+  },
 });
 
 console.log(completion.choices[0].message.content);
 ```
 
 ```python Python
-import openai
+import os
+from openai import OpenAI
 
-client = openai.OpenAI(
-    api_key="your-api-key",
-    base_url="https://api.venice.ai/api/v1"
+client = OpenAI(
+    api_key=os.environ["VENICE_API_KEY"],
+    base_url="https://api.venice.ai/api/v1",
 )
 
 response = client.chat.completions.create(
     model="zai-org-glm-5-1",
     messages=[{"role": "user", "content": "What are the latest developments in AI?"}],
-        extra_body={
+    extra_body={
         "venice_parameters": {
-            "enable_web_search": "auto"
+            "enable_web_search": "auto",
         }
-    }
+    },
 )
 
 print(response.choices[0].message.content)
 ```
 
-```go Go
-package main
-
-import (
-    "context"
-    "fmt"
-    "os"
-    "github.com/openai/openai-go"
-)
-
-func main() {
-    client, err := openai.NewClient(os.Getenv("VENICE_API_KEY"))
-    if err != nil {
-        fmt.Printf("Error creating client: %v\n", err)
-        return
-    }
-    
-    client.BaseURL = "https://api.venice.ai/api/v1"
-    
-    // Note: Go client doesn't support venice_parameters directly
-    // Use model suffix approach instead
-    resp, err := client.CreateChatCompletion(
-        context.Background(),
-        openai.ChatCompletionRequest{
-            Model: "zai-org-glm-5-1:enable_web_search=on&enable_web_citations=true",
-            Messages: []openai.ChatCompletionMessage{
-                {
-                    Role:    openai.ChatMessageRoleUser,
-                    Content: "What are the latest developments in AI?",
-                },
-            },
-        },
-    )
-    
-    if err != nil {
-        fmt.Printf("Error: %v\n", err)
-        return
-    }
-    
-    fmt.Println(resp.Choices[0].Message.Content)
-}
-```
-
-```php PHP
-<?php
-
-require_once 'vendor/autoload.php';
-
-use OpenAI\Client;
-
-$client = OpenAI::client('your-api-key');
-$client->setBaseUrl('https://api.venice.ai/api/v1');
-
-$response = $client->chat()->create([
-    'model' => 'zai-org-glm-5-1:enable_web_search=on&enable_web_citations=true',
-    'messages' => [
-        [
-            'role' => 'user',
-            'content' => 'What are the latest developments in AI?'
-        ]
-    ]
-]);
-
-echo $response->choices[0]->message->content;
-```
-
-```csharp C#
-using OpenAI;
-
-var client = new OpenAIClient("your-api-key");
-client.BaseUrl = "https://api.venice.ai/api/v1";
-
-var chatCompletion = await client.GetChatCompletionsAsync(new ChatCompletionOptions
-{
-    Model = "zai-org-glm-5-1:enable_web_search=on&enable_web_citations=true",
-    Messages = { new ChatMessage(ChatRole.User, "What are the latest developments in AI?") }
-});
-
-Console.WriteLine(chatCompletion.Value.Choices[0].Message.Content);
-```
-
-```java Java
-import com.openai.OpenAI;
-import com.openai.OpenAIHttpException;
-import com.openai.core.ApiError;
-import com.openai.types.chat.ChatCompletionRequest;
-import com.openai.types.chat.ChatCompletionResponse;
-import com.openai.types.chat.ChatMessage;
-
-public class Main {
-    public static void main(String[] args) {
-        OpenAI client = OpenAI.builder()
-            .apiKey(System.getenv("VENICE_API_KEY"))
-            .baseUrl("https://api.venice.ai/api/v1")
-            .build();
-
-        try {
-            ChatCompletionResponse response = client.chatCompletions().create(
-                ChatCompletionRequest.builder()
-                    .model("zai-org-glm-5-1:enable_web_search=on&enable_web_citations=true")
-                    .messages(ChatMessage.of("What are the latest developments in AI?"))
-                    .build()
-            );
-            
-            System.out.println(response.choices().get(0).message().content());
-        } catch (OpenAIHttpException e) {
-            System.err.println("Error: " + e.getMessage());
-        }
-    }
-}
-```
-
 ```bash Model Suffix
-# Alternative approach: append parameters directly to model ID
+# Alternative: append parameters directly to the model ID
 curl https://api.venice.ai/api/v1/chat/completions \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -H "Content-Type: application/json" \
@@ -529,8 +251,8 @@ curl https://api.venice.ai/api/v1/chat/completions \
 </CodeGroup>
 </Accordion>
 
-<Accordion title="Reasoning Mode Code Samples">
-Advanced step-by-step reasoning with visible thinking process. Available on **reasoning models**: `qwen3-4b`, `deepseek-ai-DeepSeek-R1`. Shows detailed problem-solving steps in `<think>` tags.
+<Accordion title="Web Scraping Code Samples">
+Set `enable_web_scraping: true` and the model will fetch and read any URLs in the user message before answering.
 
 <CodeGroup>
 ```bash Curl
@@ -538,10 +260,12 @@ curl https://api.venice.ai/api/v1/chat/completions \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "qwen3-4b",
-    "messages": [{"role": "user", "content": "Solve: If x + 2y = 10 and 3x - y = 5, what are x and y?"}],
+    "model": "openai-gpt-55",
+    "messages": [
+      {"role": "user", "content": "Summarize this post in five bullets: https://venice.ai/blog/how-to-use-venice-api"}
+    ],
     "venice_parameters": {
-      "strip_thinking_response": false
+      "enable_web_scraping": true
     }
   }'
 ```
@@ -549,747 +273,238 @@ curl https://api.venice.ai/api/v1/chat/completions \
 ```ts TypeScript
 import OpenAI from "openai";
 
-const openai = new OpenAI({
+const client = new OpenAI({
   apiKey: process.env.VENICE_API_KEY!,
   baseURL: "https://api.venice.ai/api/v1",
 });
 
-const completion = await openai.chat.completions.create({
-  model: "qwen3-4b",
-  messages: [{ role: "user", content: "Solve: If x + 2y = 10 and 3x - y = 5, what are x and y?" }],
-  // @ts-ignore - Venice-specific parameter
+const response = await client.chat.completions.create({
+  model: "openai-gpt-55",
+  messages: [
+    {
+      role: "user",
+      content:
+        "Summarize this post in five bullets: https://venice.ai/blog/how-to-use-venice-api",
+    },
+  ],
+  // @ts-expect-error - Venice-specific parameter
   venice_parameters: {
-    strip_thinking_response: false
-  }
+    enable_web_scraping: true,
+  },
 });
 
-console.log(completion.choices[0].message.content);
+console.log(response.choices[0].message.content);
 ```
 
 ```python Python
-import openai
+import os
+from openai import OpenAI
 
-client = openai.OpenAI(
-    api_key="your-api-key",
-    base_url="https://api.venice.ai/api/v1"
+client = OpenAI(
+    api_key=os.environ["VENICE_API_KEY"],
+    base_url="https://api.venice.ai/api/v1",
 )
 
 response = client.chat.completions.create(
-    model="qwen3-4b",
-    messages=[{"role": "user", "content": "Solve: If x + 2y = 10 and 3x - y = 5, what are x and y?"}],
+    model="openai-gpt-55",
+    messages=[
+        {
+            "role": "user",
+            "content": "Summarize this post in five bullets: https://venice.ai/blog/how-to-use-venice-api",
+        }
+    ],
     extra_body={
         "venice_parameters": {
-            "strip_thinking_response": False
+            "enable_web_scraping": True,
         }
-    }
+    },
 )
 
 print(response.choices[0].message.content)
 ```
-
-```go Go
-package main
-
-import (
-    "context"
-    "fmt"
-    "os"
-    "github.com/openai/openai-go"
-)
-
-func main() {
-    client, err := openai.NewClient(os.Getenv("VENICE_API_KEY"))
-    if err != nil {
-        fmt.Printf("Error creating client: %v\n", err)
-        return
-    }
-    
-    client.BaseURL = "https://api.venice.ai/api/v1"
-    
-    resp, err := client.CreateChatCompletion(
-        context.Background(),
-        openai.ChatCompletionRequest{
-            Model: "qwen3-4b",
-            Messages: []openai.ChatCompletionMessage{
-                {
-                    Role:    openai.ChatMessageRoleUser,
-                    Content: "Solve: If x + 2y = 10 and 3x - y = 5, what are x and y?",
-                },
-            },
-        },
-    )
-    
-    if err != nil {
-        fmt.Printf("Error: %v\n", err)
-        return
-    }
-    
-    fmt.Println(resp.Choices[0].Message.Content)
-}
-```
-
-```php PHP
-<?php
-
-require_once 'vendor/autoload.php';
-
-use OpenAI\Client;
-
-$client = OpenAI::client('your-api-key');
-$client->setBaseUrl('https://api.venice.ai/api/v1');
-
-$response = $client->chat()->create([
-    'model' => 'qwen3-4b',
-    'messages' => [
-        [
-            'role' => 'user',
-            'content' => 'Solve: If x + 2y = 10 and 3x - y = 5, what are x and y?'
-        ]
-    ]
-]);
-
-echo $response->choices[0]->message->content;
-```
-
-```csharp C#
-using OpenAI;
-
-var client = new OpenAIClient("your-api-key");
-client.BaseUrl = "https://api.venice.ai/api/v1";
-
-var chatCompletion = await client.GetChatCompletionsAsync(new ChatCompletionOptions
-{
-    Model = "qwen3-4b",
-    Messages = { new ChatMessage(ChatRole.User, "Solve: If x + 2y = 10 and 3x - y = 5, what are x and y?") }
-});
-
-Console.WriteLine(chatCompletion.Value.Choices[0].Message.Content);
-```
-
-```java Java
-import com.openai.OpenAI;
-import com.openai.OpenAIHttpException;
-import com.openai.core.ApiError;
-import com.openai.types.chat.ChatCompletionRequest;
-import com.openai.types.chat.ChatCompletionResponse;
-import com.openai.types.chat.ChatMessage;
-
-public class Main {
-    public static void main(String[] args) {
-        OpenAI client = OpenAI.builder()
-            .apiKey(System.getenv("VENICE_API_KEY"))
-            .baseUrl("https://api.venice.ai/api/v1")
-            .build();
-
-        try {
-            ChatCompletionResponse response = client.chatCompletions().create(
-                ChatCompletionRequest.builder()
-                    .model("qwen3-4b")
-                    .messages(ChatMessage.of("Solve: If x + 2y = 10 and 3x - y = 5, what are x and y?"))
-                    .build()
-            );
-            
-            System.out.println(response.choices().get(0).message().content());
-        } catch (OpenAIHttpException e) {
-            System.err.println("Error: " + e.getMessage());
-        }
-    }
-}
-```
-
-```bash Model Suffix
-# Alternative approach: append parameters directly to model ID
-curl https://api.venice.ai/api/v1/chat/completions \
-  -H "Authorization: Bearer $VENICE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "qwen3-4b:strip_thinking_response=true",
-    "messages": [{"role": "user", "content": "Solve this math problem"}]
-  }'
-```
 </CodeGroup>
 </Accordion>
 
-<Accordion title="Vision Processing Code Samples">
-Image understanding and multimodal analysis. Available on **vision models**: `qwen3-vl-235b-a22b`. Upload images via base64 data URIs or URLs for analysis, description, and reasoning.
+<Accordion title="File Inputs Code Samples">
+Attach PDFs, Office docs, code, and text files (up to 25MB) directly to a chat request. See the [File Inputs guide](/guides/features/file-inputs) for the full format list.
 
 <CodeGroup>
 ```bash Curl
+# Encode a local file as a base64 data URL, then send it inline
+FILE_B64=$(base64 q3-report.pdf | tr -d '\n')
+
 curl https://api.venice.ai/api/v1/chat/completions \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "model": "qwen3-vl-235b-a22b",
-    "messages": [
+  -d "{
+    \"model\": \"openai-gpt-55\",
+    \"messages\": [
       {
-        "role": "user",
-        "content": [
-          {"type": "text", "text": "What do you see in this image?"},
-          {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
+        \"role\": \"user\",
+        \"content\": [
+          {\"type\": \"text\", \"text\": \"Summarize this report in five bullets and list the main risks.\"},
+          {\"type\": \"file\", \"file\": {\"filename\": \"q3-report.pdf\", \"file_data\": \"data:application/pdf;base64,${FILE_B64}\"}}
         ]
       }
     ]
-  }'
+  }"
 ```
 
 ```ts TypeScript
 import OpenAI from "openai";
+import { readFile } from "node:fs/promises";
 
-const openai = new OpenAI({
+const client = new OpenAI({
   apiKey: process.env.VENICE_API_KEY!,
   baseURL: "https://api.venice.ai/api/v1",
 });
 
-const completion = await openai.chat.completions.create({
-  model: "qwen3-vl-235b-a22b",
+const pdf = await readFile("q3-report.pdf");
+const fileData = `data:application/pdf;base64,${pdf.toString("base64")}`;
+
+const response = await client.chat.completions.create({
+  model: "openai-gpt-55",
   messages: [
     {
       role: "user",
       content: [
-        { type: "text", text: "What do you see in this image?" },
-        { type: "image_url", image_url: { url: "data:image/jpeg;base64,..." } }
-      ]
-    }
-  ]
+        { type: "text", text: "Summarize this report in five bullets and list the main risks." },
+        // @ts-expect-error - Venice file input block
+        { type: "file", file: { filename: "q3-report.pdf", file_data: fileData } },
+      ],
+    },
+  ],
 });
 
-console.log(completion.choices[0].message.content);
+console.log(response.choices[0].message.content);
 ```
 
 ```python Python
-import openai
+import base64
+import os
+from pathlib import Path
+from openai import OpenAI
 
-client = openai.OpenAI(
-    api_key="your-api-key",
-    base_url="https://api.venice.ai/api/v1"
+client = OpenAI(
+    api_key=os.environ["VENICE_API_KEY"],
+    base_url="https://api.venice.ai/api/v1",
 )
 
+path = Path("q3-report.pdf")
+file_data = "data:application/pdf;base64," + base64.b64encode(path.read_bytes()).decode("utf-8")
+
 response = client.chat.completions.create(
-    model="qwen3-vl-235b-a22b",
+    model="openai-gpt-55",
     messages=[
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "What do you see in this image?"},
-                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
-            ]
+                {"type": "text", "text": "Summarize this report in five bullets and list the main risks."},
+                {"type": "file", "file": {"filename": "q3-report.pdf", "file_data": file_data}},
+            ],
         }
-    ]
+    ],
 )
 
 print(response.choices[0].message.content)
 ```
-
-```go Go
-package main
-
-import (
-    "context"
-    "fmt"
-    "os"
-    "github.com/openai/openai-go"
-)
-
-func main() {
-    client, err := openai.NewClient(os.Getenv("VENICE_API_KEY"))
-    if err != nil {
-        fmt.Printf("Error creating client: %v\n", err)
-        return
-    }
-    
-    client.BaseURL = "https://api.venice.ai/api/v1"
-    
-    resp, err := client.CreateChatCompletion(
-        context.Background(),
-        openai.ChatCompletionRequest{
-            Model: "qwen3-vl-235b-a22b",
-            Messages: []openai.ChatCompletionMessage{
-                {
-                    Role: openai.ChatMessageRoleUser,
-                    Content: []openai.ChatCompletionContentPart{
-                        {Type: "text", Text: "What do you see in this image?"},
-                        {Type: "image_url", ImageURL: &openai.ChatCompletionContentPartImageURL{URL: "data:image/jpeg;base64,..."}},
-                    },
-                },
-            },
-        },
-    )
-    
-    if err != nil {
-        fmt.Printf("Error: %v\n", err)
-        return
-    }
-    
-    fmt.Println(resp.Choices[0].Message.Content)
-}
-```
-
-```php PHP
-<?php
-
-require_once 'vendor/autoload.php';
-
-use OpenAI\Client;
-
-$client = OpenAI::client('your-api-key');
-$client->setBaseUrl('https://api.venice.ai/api/v1');
-
-$response = $client->chat()->create([
-    'model' => 'qwen3-vl-235b-a22b',
-    'messages' => [
-        [
-            'role' => 'user',
-            'content' => [
-                ['type' => 'text', 'text' => 'What do you see in this image?'],
-                ['type' => 'image_url', 'image_url' => ['url' => 'data:image/jpeg;base64,...']]
-            ]
-        ]
-    ]
-]);
-
-echo $response->choices[0]->message->content;
-```
-
-```csharp C#
-using OpenAI;
-
-var client = new OpenAIClient("your-api-key");
-client.BaseUrl = "https://api.venice.ai/api/v1";
-
-var chatCompletion = await client.GetChatCompletionsAsync(new ChatCompletionOptions
-{
-    Model = "qwen3-vl-235b-a22b",
-    Messages = { 
-        new ChatMessage(ChatRole.User, [
-            ChatMessageContentPart.CreateTextPart("What do you see in this image?"),
-            ChatMessageContentPart.CreateImagePart(new Uri("data:image/jpeg;base64,..."))
-        ])
-    }
-});
-
-Console.WriteLine(chatCompletion.Value.Choices[0].Message.Content);
-```
-
-```java Java
-import com.openai.OpenAI;
-import com.openai.OpenAIHttpException;
-import com.openai.core.ApiError;
-import com.openai.types.chat.*;
-
-public class Main {
-    public static void main(String[] args) {
-        OpenAI client = OpenAI.builder()
-            .apiKey(System.getenv("VENICE_API_KEY"))
-            .baseUrl("https://api.venice.ai/api/v1")
-            .build();
-
-        try {
-            ChatCompletionResponse response = client.chatCompletions().create(
-                ChatCompletionRequest.builder()
-                    .model("qwen3-vl-235b-a22b")
-                    .messages(ChatMessage.builder()
-                        .role(ChatMessage.Role.USER)
-                        .content(ChatMessage.Content.ofMultiple(
-                            ChatMessage.ContentPart.text("What do you see in this image?"),
-                            ChatMessage.ContentPart.imageUrl("data:image/jpeg;base64,...")
-                        ))
-                        .build())
-                    .build()
-            );
-            
-            System.out.println(response.choices().get(0).message().content());
-        } catch (OpenAIHttpException e) {
-            System.err.println("Error: " + e.getMessage());
-        }
-    }
-}
-```
-
-```bash Model Suffix
-# Alternative approach: append parameters directly to model ID
-curl https://api.venice.ai/api/v1/chat/completions \
-  -H "Authorization: Bearer $VENICE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "mistral-31-24b:enable_web_search=auto",
-    "messages": [
-      {
-        "role": "user",
-        "content": [
-          {"type": "text", "text": "What do you see in this image and find similar examples online?"},
-          {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
-        ]
-      }
-    ]
-  }'
-```
 </CodeGroup>
 </Accordion>
 
-<Accordion title="Tool Calling Code Samples">
-Tool use and external API integration. Available on **function calling models**: `zai-org-glm-5-1`, `qwen3-4b`, `mistral-31-24b`, `llama-3.2-3b`, `zai-org-glm-5-1`. Define tools for the model to call external APIs, databases, or custom functions.
+<Accordion title="Crypto RPC Code Samples">
+Proxy JSON-RPC 2.0 calls across 11 supported chains with your Venice key or an x402 wallet. See the [Crypto RPC reference](/api-reference/endpoint/crypto/rpc) for chains, methods, and credit tiers.
 
 <CodeGroup>
 ```bash Curl
-curl https://api.venice.ai/api/v1/chat/completions \
+curl https://api.venice.ai/api/v1/crypto/rpc/ethereum-mainnet \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "zai-org-glm-5-1",
-    "messages": [{"role": "user", "content": "What is the weather like in New York?"}],
-    "tools": [
-      {
-        "type": "function",
-        "function": {
-          "name": "get_weather",
-          "description": "Get current weather for a location",
-          "parameters": {
-            "type": "object",
-            "properties": {
-              "location": {"type": "string", "description": "City name"}
-            },
-            "required": ["location"]
-          }
-        }
-      }
-    ]
+    "jsonrpc": "2.0",
+    "method": "eth_blockNumber",
+    "params": [],
+    "id": 1
   }'
 ```
 
 ```ts TypeScript
-import OpenAI from "openai";
+const response = await fetch(
+  "https://api.venice.ai/api/v1/crypto/rpc/base-mainnet",
+  {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.VENICE_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify([
+      { jsonrpc: "2.0", method: "eth_chainId", params: [], id: 1 },
+      { jsonrpc: "2.0", method: "eth_blockNumber", params: [], id: 2 },
+    ]),
+  }
+);
 
-const openai = new OpenAI({
-  apiKey: process.env.VENICE_API_KEY!,
-  baseURL: "https://api.venice.ai/api/v1",
-});
-
-const completion = await openai.chat.completions.create({
-  model: "zai-org-glm-5-1",
-  messages: [{ role: "user", content: "What is the weather like in New York?" }],
-  tools: [
-    {
-      type: "function",
-      function: {
-        name: "get_weather",
-        description: "Get current weather for a location",
-        parameters: {
-          type: "object",
-          properties: {
-            location: { type: "string", description: "City name" }
-          },
-          required: ["location"]
-        }
-      }
-    }
-  ]
-});
-
-console.log(completion.choices[0].message.content);
+const results = await response.json();
+console.log(results);
 ```
 
 ```python Python
-import openai
+import os
+import requests
 
-client = openai.OpenAI(
-    api_key="your-api-key",
-    base_url="https://api.venice.ai/api/v1"
+response = requests.post(
+    "https://api.venice.ai/api/v1/crypto/rpc/ethereum-mainnet",
+    headers={
+        "Authorization": f"Bearer {os.environ['VENICE_API_KEY']}",
+        "Content-Type": "application/json",
+    },
+    json={
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"],
+        "id": 1,
+    },
 )
 
-response = client.chat.completions.create(
-    model="zai-org-glm-5-1",
-    messages=[{"role": "user", "content": "What is the weather like in New York?"}],
-    tools=[
-        {
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "description": "Get current weather for a location",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "location": {"type": "string", "description": "City name"}
-                    },
-                    "required": ["location"]
-                }
-            }
-        }
-    ]
-)
-
-print(response.choices[0].message.content)
-```
-
-```go Go
-package main
-
-import (
-    "context"
-    "fmt"
-    "os"
-    "github.com/openai/openai-go"
-)
-
-func main() {
-    client, err := openai.NewClient(os.Getenv("VENICE_API_KEY"))
-    if err != nil {
-        fmt.Printf("Error creating client: %v\n", err)
-        return
-    }
-    
-    client.BaseURL = "https://api.venice.ai/api/v1"
-    
-    resp, err := client.CreateChatCompletion(
-        context.Background(),
-        openai.ChatCompletionRequest{
-            Model: "zai-org-glm-5-1",
-            Messages: []openai.ChatCompletionMessage{
-                {
-                    Role:    openai.ChatMessageRoleUser,
-                    Content: "What is the weather like in New York?",
-                },
-            },
-            Tools: []openai.ChatCompletionTool{
-                {
-                    Type: openai.ChatCompletionToolTypeFunction,
-                    Function: &openai.FunctionDefinition{
-                        Name:        "get_weather",
-                        Description: "Get current weather for a location",
-                        Parameters: map[string]interface{}{
-                            "type": "object",
-                            "properties": map[string]interface{}{
-                                "location": map[string]interface{}{
-                                    "type":        "string",
-                                    "description": "City name",
-                                },
-                            },
-                            "required": []string{"location"},
-                        },
-                    },
-                },
-            },
-        },
-    )
-    
-    if err != nil {
-        fmt.Printf("Error: %v\n", err)
-        return
-    }
-    
-    fmt.Println(resp.Choices[0].Message.Content)
-}
-```
-
-```php PHP
-<?php
-
-require_once 'vendor/autoload.php';
-
-use OpenAI\Client;
-
-$client = OpenAI::client('your-api-key');
-$client->setBaseUrl('https://api.venice.ai/api/v1');
-
-$response = $client->chat()->create([
-    'model' => 'zai-org-glm-5-1',
-    'messages' => [
-        [
-            'role' => 'user',
-            'content' => 'What is the weather like in New York?'
-        ]
-    ],
-    'tools' => [
-        [
-            'type' => 'function',
-            'function' => [
-                'name' => 'get_weather',
-                'description' => 'Get current weather for a location',
-                'parameters' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'location' => [
-                            'type' => 'string',
-                            'description' => 'City name'
-                        ]
-                    ],
-                    'required' => ['location']
-                ]
-            ]
-        ]
-    ]
-]);
-
-echo $response->choices[0]->message->content;
-```
-
-```csharp C#
-using OpenAI;
-
-var client = new OpenAIClient("your-api-key");
-client.BaseUrl = "https://api.venice.ai/api/v1";
-
-var chatCompletion = await client.GetChatCompletionsAsync(new ChatCompletionOptions
-{
-    Model = "zai-org-glm-5-1",
-    Messages = { new ChatMessage(ChatRole.User, "What is the weather like in New York?") },
-    Tools = {
-        ChatTool.CreateFunctionTool(
-            functionName: "get_weather",
-            functionDescription: "Get current weather for a location",
-            functionParameters: BinaryData.FromString("""
-            {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "City name"
-                    }
-                },
-                "required": ["location"]
-            }
-            """)
-        )
-    }
-});
-
-Console.WriteLine(chatCompletion.Value.Choices[0].Message.Content);
-```
-
-```java Java
-import com.openai.OpenAI;
-import com.openai.OpenAIHttpException;
-import com.openai.core.ApiError;
-import com.openai.types.chat.*;
-
-public class Main {
-    public static void main(String[] args) {
-        OpenAI client = OpenAI.builder()
-            .apiKey(System.getenv("VENICE_API_KEY"))
-            .baseUrl("https://api.venice.ai/api/v1")
-            .build();
-
-        try {
-            ChatCompletionResponse response = client.chatCompletions().create(
-                ChatCompletionRequest.builder()
-                    .model("zai-org-glm-5-1")
-                    .messages(ChatMessage.of("What is the weather like in New York?"))
-                    .tools(ChatCompletionTool.builder()
-                        .type(ChatCompletionToolType.FUNCTION)
-                        .function(FunctionDefinition.builder()
-                            .name("get_weather")
-                            .description("Get current weather for a location")
-                            .parameters(FunctionParameters.builder()
-                                .putProperty("location", FunctionParameters.Property.builder()
-                                    .type("string")
-                                    .description("City name")
-                                    .build())
-                                .required("location")
-                                .build())
-                            .build())
-                        .build())
-                    .build()
-            );
-            
-            System.out.println(response.choices().get(0).message().content());
-        } catch (OpenAIHttpException e) {
-            System.err.println("Error: " + e.getMessage());
-        }
-    }
-}
-```
-
-```bash Model Suffix
-# Alternative approach: append parameters directly to model ID
-curl https://api.venice.ai/api/v1/chat/completions \
-  -H "Authorization: Bearer $VENICE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "zai-org-glm-5-1:enable_web_search=auto",
-    "messages": [{"role": "user", "content": "What is the weather like in New York?"}],
-    "tools": [
-      {
-        "type": "function",
-        "function": {
-          "name": "get_weather",
-          "description": "Get current weather for a location",
-          "parameters": {
-            "type": "object",
-            "properties": {
-              "location": {"type": "string", "description": "City name"}
-            },
-            "required": ["location"]
-          }
-        }
-      }
-    ]
-  }'
+print(response.json())
 ```
 </CodeGroup>
 </Accordion>
 
-### Available Parameters
+<div className="venice-pricing">
+  <div className="venice-section-header">
+    <p className="venice-section-eyebrow">Pricing</p>
+    <h2 className="venice-section-title">Top up, stake, or pay per request</h2>
+    <p className="venice-section-subtitle">Fund an account with credits, stake DIEM for a daily allowance, or skip the account entirely with USDC on Base.</p>
+  </div>
 
-| Parameter | Options | Description |
-|-----------|---------|-------------|
-| `enable_web_search` | `off`, `on`, `auto` | Enable real-time web search |
-| `enable_web_scraping` | `true`, `false` | Scrape URLs detected in user message |
-| `enable_web_citations` | `true`, `false` | Include citations in web search results |
-| `strip_thinking_response` | `true`, `false` | Hide reasoning steps from response |
-| `disable_thinking` | `true`, `false` | Disable reasoning mode entirely |
-| `include_venice_system_prompt` | `true`, `false` | Include Venice system prompts |
-| `character_slug` | string | Use a specific AI character |
+  <div className="venice-pricing-grid">
+    <div className="venice-pricing-card">
+      <div className="venice-pricing-card-head">
+        <span className="venice-pricing-card-name">Credits</span>
+        <span className="venice-pricing-card-badge">USD or Crypto</span>
+      </div>
+      <p className="venice-pricing-card-desc">Top up with a card or crypto. Credits never expire.</p>
+      <a className="venice-pricing-card-cta" href="https://venice.ai/settings/billing">Buy Credits</a>
+    </div>
 
-[View all parameters →](/api-reference/api-spec#venice-parameters)
+    <div className="venice-pricing-card">
+      <div className="venice-pricing-card-head">
+        <span className="venice-pricing-card-name">DIEM</span>
+        <span className="venice-pricing-card-badge">Daily allowance</span>
+      </div>
+      <p className="venice-pricing-card-desc">Stake DIEM or VVV for a daily compute allowance that refreshes at 00:00 UTC.</p>
+      <a className="venice-pricing-card-cta" href="https://venice.ai/token">Learn about DIEM</a>
+    </div>
 
-## Pricing Options
+    <div className="venice-pricing-card">
+      <div className="venice-pricing-card-head">
+        <span className="venice-pricing-card-name">x402</span>
+        <span className="venice-pricing-card-badge">USDC on Base</span>
+      </div>
+      <p className="venice-pricing-card-desc">Pay per request with USDC on Base. No account or API key required.</p>
+      <a className="venice-pricing-card-cta" href="/guides/integrations/x402-venice-api">Read x402 Guide</a>
+    </div>
+  </div>
+</div>
 
-<CardGroup cols={3}>
-  <Card title="Pro subscription" href="https://venice.ai/chat" icon="star">
-    **$10 in free credits**
-    
-    One‑time credit when you upgrade
-    
-  </Card>
-
-  <Card title="Buy DIEM" href="https://venice.ai/token" icon="coins">
-    **Permanent access**
-    
-    Stake DIEM for daily compute allocation
-  </Card>
-
-  <Card title="Pay-as-you-go (USD)" href="/overview/pricing" icon="credit-card">
-    **USD payments**
-    
-    Fund your account in USD and pay per usage
-  </Card>
-</CardGroup>
-
-## Start building today
-
-Get your API key and make your first request.
-
-<CardGroup cols={2}>
-  <Card title="Getting Started" href="/overview/getting-started" icon="rocket">
-    Step-by-step guide to your first API call
-  </Card>
-
-  <Card title="API Reference" href="/api-reference" icon="rectangle-code">
-    Complete API documentation and endpoints
-  </Card>
-  
-  <Card title="Postman Collection" href="/guides/getting-started/postman" icon="play">
-    Ready-to-use API examples and testing
-  </Card>
-  
-  <Card title="Agent Integrations" href="/guides/integrations/crypto-rpc-agents" icon="robot">
-    Build with OpenClaw, Hermes Agent, MCP, and x402 wallet auth
-  </Card>
-</CardGroup>
-
-<Warning>
-  Venice's API is rapidly evolving. Join our [Discord](https://discord.gg/askvenice) to provide feedback and request new features. Your input shapes our development roadmap.
-</Warning>
-
----
-
-These docs are open source and can be contributed to on [Github](https://github.com/veniceai/api-docs). For additional guidance, see our blog post: ["How to use Venice API"](https://venice.ai/blog/how-to-use-venice-api)
+Questions or feedback? Join us on [Discord](https://discord.gg/askvenice).

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -1,6 +1,7 @@
 ---
 title: Venice API
-"og:title": "Venice API Docs" 
+"og:title": "Venice API Docs"
+mode: "wide"
 ---
 
 The API for private, unrestricted access to intelligence.
@@ -483,7 +484,7 @@ print(response.json())
         <span className="venice-pricing-card-name">Credits</span>
         <span className="venice-pricing-card-badge">USD or Crypto</span>
       </div>
-      <p className="venice-pricing-card-desc">Top up with a card or crypto. Credits never expire.</p>
+      <p className="venice-pricing-card-desc">Pay as you go in USD or crypto. Credits never expire and work across every endpoint.</p>
       <a className="venice-pricing-card-cta" href="https://venice.ai/settings/billing">Buy Credits</a>
     </div>
 
@@ -492,7 +493,7 @@ print(response.json())
         <span className="venice-pricing-card-name">DIEM</span>
         <span className="venice-pricing-card-badge">Daily allowance</span>
       </div>
-      <p className="venice-pricing-card-desc">Stake DIEM or VVV for a daily compute allowance that refreshes at 00:00 UTC.</p>
+      <p className="venice-pricing-card-desc">Stake DIEM or VVV once and earn a fixed inference allowance every day, with no per-call charges.</p>
       <a className="venice-pricing-card-cta" href="https://venice.ai/token">Learn about DIEM</a>
     </div>
 
@@ -501,7 +502,7 @@ print(response.json())
         <span className="venice-pricing-card-name">x402</span>
         <span className="venice-pricing-card-badge">USDC on Base</span>
       </div>
-      <p className="venice-pricing-card-desc">Pay per request with USDC on Base. No account or API key required.</p>
+      <p className="venice-pricing-card-desc">Pay per request from any Base wallet in USDC. No account or API key, built for agents.</p>
       <a className="venice-pricing-card-cta" href="/guides/integrations/x402-venice-api">Read x402 Guide</a>
     </div>
   </div>

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -4,30 +4,60 @@ title: Venice API
 mode: "wide"
 ---
 
-The API for private, unrestricted access to intelligence.
-
-<div className="venice-hero-grid">
-  <a className="venice-api-card" href="/overview/getting-started">
-    <span className="venice-api-card-name">Quickstart</span>
-    <p className="venice-api-card-desc">Make your first API call in minutes.</p>
-    <span className="venice-api-card-action">Get started →</span>
-  </a>
-  <a className="venice-api-card" href="/overview/models">
-    <span className="venice-api-card-name">Browse Models</span>
-    <p className="venice-api-card-desc">Compare 250+ models by context, price, and modality.</p>
-    <span className="venice-api-card-action">View catalog →</span>
-  </a>
-  <a className="venice-api-card" href="/api-reference">
-    <span className="venice-api-card-name">API Reference</span>
-    <p className="venice-api-card-desc">Endpoints, payloads, and language examples.</p>
-    <span className="venice-api-card-action">Read reference →</span>
-  </a>
+<div className="venice-hero-copy">
+  <p className="venice-hero-tagline">The API for private, unrestricted access to intelligence.</p>
+  <p className="venice-hero-subtitle">OpenAI-compatible chat, image, audio, and video behind one API key.</p>
+  <div className="venice-hero-ctas">
+    <a className="venice-hero-cta venice-hero-cta-primary" href="https://venice.ai/settings/api">Get an API key →</a>
+    <a className="venice-hero-cta" href="/overview/getting-started">Get started</a>
+  </div>
 </div>
 
+<CodeGroup>
+```bash curl
+curl https://api.venice.ai/api/v1/chat/completions \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "zai-org-glm-5-1",
+    "messages": [{"role": "user", "content": "Build without permission."}]
+  }'
+```
+
+```ts TypeScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.VENICE_API_KEY,
+  baseURL: "https://api.venice.ai/api/v1",
+});
+
+const res = await client.chat.completions.create({
+  model: "zai-org-glm-5-1",
+  messages: [{ role: "user", content: "Build without permission." }],
+});
+```
+
+```python Python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["VENICE_API_KEY"],
+    base_url="https://api.venice.ai/api/v1",
+)
+
+res = client.chat.completions.create(
+    model="zai-org-glm-5-1",
+    messages=[{"role": "user", "content": "Build without permission."}],
+)
+```
+</CodeGroup>
+
 <div className="venice-section-header">
-  <p className="venice-section-eyebrow">APIs</p>
-  <h2 className="venice-section-title">Build with Venice APIs</h2>
-  <p className="venice-section-subtitle">Chat, image, audio, and video behind one API key. OpenAI-compatible where it applies.</p>
+  <p className="venice-section-eyebrow">Endpoints</p>
+  <h2 className="venice-section-title">Everything an agent needs</h2>
+  <p className="venice-section-subtitle">Generation, tools, and payments behind one API key.</p>
 </div>
 
 <div className="venice-apis-grid">
@@ -44,68 +74,74 @@ The API for private, unrestricted access to intelligence.
 
   <a className="venice-api-card" href="/api-reference/endpoint/image/generations">
     <span className="venice-api-card-name">Image Generation</span>
-    <p className="venice-api-card-desc">Text-to-image, edits, and upscaling across photorealistic, stylized, and uncensored models.</p>
+    <p className="venice-api-card-desc">Text-to-image, image-to-image, upscaling, and background removal across photorealistic, stylized, and uncensored models.</p>
     <div className="venice-api-card-chips">
-      <span className="venice-api-card-chip">Generate</span>
+      <span className="venice-api-card-chip">Text-to-image</span>
+      <span className="venice-api-card-chip">Image-to-image</span>
       <span className="venice-api-card-chip">Upscale</span>
-      <span className="venice-api-card-chip">Edit</span>
     </div>
     <span className="venice-api-card-action">See reference →</span>
   </a>
 
   <a className="venice-api-card" href="/api-reference/endpoint/audio/speech">
-    <span className="venice-api-card-name">Audio Synthesis</span>
-    <p className="venice-api-card-desc">Text-to-speech with 50+ multilingual voices and low-latency streaming for real-time agents.</p>
+    <span className="venice-api-card-name">Audio</span>
+    <p className="venice-api-card-desc">Text-to-speech with 50+ multilingual voices, plus speech-to-text transcription for any audio file.</p>
     <div className="venice-api-card-chips">
       <span className="venice-api-card-chip">TTS</span>
+      <span className="venice-api-card-chip">Transcription</span>
       <span className="venice-api-card-chip">50+ voices</span>
-      <span className="venice-api-card-chip">Streaming</span>
     </div>
     <span className="venice-api-card-action">See reference →</span>
   </a>
 
   <a className="venice-api-card" href="/api-reference/endpoint/video/queue">
     <span className="venice-api-card-name">Video</span>
-    <p className="venice-api-card-desc">Text-to-video, reference-to-video, and audio transcription through an async job queue.</p>
+    <p className="venice-api-card-desc">Text-to-video, image-to-video, and reference-to-video through a sync or async job queue.</p>
     <div className="venice-api-card-chips">
       <span className="venice-api-card-chip">Text-to-video</span>
+      <span className="venice-api-card-chip">Image-to-video</span>
       <span className="venice-api-card-chip">Reference-to-video</span>
-      <span className="venice-api-card-chip">Transcription</span>
     </div>
     <span className="venice-api-card-action">See reference →</span>
   </a>
 </div>
 
-[View all API endpoints →](/api-reference)
+<p className="venice-apis-extras">
+  Plus <a href="/api-reference/endpoint/embeddings/generate">embeddings</a>, <a href="/guides/features/file-inputs">file inputs</a>, <a href="/guides/integrations/venice-mcp">MCP tools</a>, and <a href="/guides/integrations/x402-venice-api">wallet payments</a>. <a className="venice-apis-extras-cta" href="/api-reference">View all endpoints →</a>
+</p>
 
-<div className="venice-agents-panel">
-  <div className="venice-agents-copy">
-    <p className="venice-agents-eyebrow">For agent builders</p>
-    <h2>Build AI agents on Venice</h2>
-    <p>Private inference, MCP tools, and wallet-funded workflows for messaging, coding, and on-chain agents.</p>
-    <a className="venice-agents-button" href="/guides/integrations/ai-agents">Explore the AI Agents hub →</a>
-  </div>
-
-  <div className="venice-agents-cards">
-    <a className="venice-agents-card" href="/guides/integrations/ai-agents#agent-apps">
-      <span className="venice-agents-card-title">Agent apps</span>
-      <span className="venice-agents-card-desc">OpenClaw, Hermes, NanoClaw</span>
-    </a>
-    <a className="venice-agents-card" href="/guides/integrations/ai-agents#coding-agents">
-      <span className="venice-agents-card-title">Coding agents</span>
-      <span className="venice-agents-card-desc">Claude Code, Cursor, Codex CLI</span>
-    </a>
-    <a className="venice-agents-card" href="/guides/integrations/ai-agents#tools-and-skills">
-      <span className="venice-agents-card-title">MCP + Skills</span>
-      <span className="venice-agents-card-desc">31 tools for any agent runtime</span>
-    </a>
-  </div>
+<div className="venice-section-header">
+  <p className="venice-section-eyebrow">Agents</p>
+  <h2 className="venice-section-title">Built for AI agents</h2>
+  <p className="venice-section-subtitle">Private inference, MCP tools, and wallet-funded workflows for messaging, coding, and onchain agents.</p>
 </div>
+
+<div className="venice-agents-cards">
+  <a className="venice-api-card" href="/guides/integrations/ai-agents#agent-apps">
+    <span className="venice-api-card-name">Agent apps</span>
+    <p className="venice-api-card-desc">Connect Venice to WhatsApp, Telegram, Discord, and more through OpenClaw, Hermes, and NanoClaw.</p>
+    <span className="venice-api-card-action">See integrations →</span>
+  </a>
+  <a className="venice-api-card" href="/guides/integrations/ai-agents#coding-agents">
+    <span className="venice-api-card-name">Coding agents</span>
+    <p className="venice-api-card-desc">Use Claude Code, Cursor, and Codex CLI with Venice models for private coding workflows.</p>
+    <span className="venice-api-card-action">See integrations →</span>
+  </a>
+  <a className="venice-api-card" href="/guides/integrations/ai-agents#tools-and-skills">
+    <span className="venice-api-card-name">MCP + Skills</span>
+    <p className="venice-api-card-desc">Expose chat, image, video, audio, and embeddings as MCP tools or runtime skills.</p>
+    <span className="venice-api-card-action">See integrations →</span>
+  </a>
+</div>
+
+<p className="venice-apis-extras">
+  <a className="venice-apis-extras-cta" href="/guides/integrations/ai-agents">Explore the AI Agents hub →</a>
+</p>
 
 <div className="venice-section-header">
   <p className="venice-section-eyebrow">Models</p>
-  <h2 className="venice-section-title">Pick a model, copy the ID, ship it</h2>
-  <p className="venice-section-subtitle">A few of the most popular models on Venice. Drop the ID straight into your `model` field.</p>
+  <h2 className="venice-section-title">Popular models</h2>
+  <p className="venice-section-subtitle">A few of the most-used models on Venice. Use the ID as your `model` parameter.</p>
 </div>
 
 <div className="venice-models-grid">

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -17,25 +17,25 @@ Build AI with no data retention, permissionless access, and compute you permanen
   </Card>
 </CardGroup>
 
-## Agent Integrations
+## Build AI Agents With Venice
 
-Use Venice as the private, OpenAI-compatible model layer for current agent stacks, messaging gateways, and tool hosts.
+Venice is more than a chat endpoint. Use one private, OpenAI-compatible API for agent frameworks, MCP tool hosts, messaging bots, media generation, and wallet-funded autonomy.
 
-<CardGroup cols={4}>
-  <Card title="OpenClaw" href="/guides/integrations/openclaw-bot" icon="robot">
-    Connect Venice to WhatsApp, Telegram, Discord, iMessage, Slack, and more.
+<CardGroup cols={2}>
+  <Card title="Messaging agents with OpenClaw" href="/guides/integrations/openclaw-bot" icon="robot">
+    Run Venice-powered agents across WhatsApp, Telegram, Discord, iMessage, Slack, and more.
   </Card>
 
-  <Card title="Hermes Agent" href="/guides/integrations/hermes-agent" icon="brain">
-    Power persistent-memory agents with Venice models, tools, and media endpoints.
+  <Card title="Persistent agents with Hermes" href="/guides/integrations/hermes-agent" icon="brain">
+    Give self-hosted agents private inference, long-running memory, and access to Venice tools.
   </Card>
 
-  <Card title="Venice MCP Server" href="/guides/integrations/venice-mcp" icon="plug">
-    Expose 31 Venice tools to Claude Desktop, Cursor, LM Studio, and other MCP hosts.
+  <Card title="Tool access through MCP" href="/guides/integrations/venice-mcp" icon="plug">
+    Add 31 Venice tools to Claude Desktop, Cursor, LM Studio, and other MCP-compatible hosts.
   </Card>
 
-  <Card title="Agent Skills" href="/guides/integrations/venice-skills" icon="screwdriver-wrench">
-    Give coding agents endpoint-specific Venice API guidance.
+  <Card title="Autonomous crypto agents" href="/guides/integrations/crypto-rpc-agents" icon="link">
+    Combine LLM inference, x402 wallet auth, and multi-chain RPC under one Venice credential.
   </Card>
 </CardGroup>
 

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -17,6 +17,28 @@ Build AI with no data retention, permissionless access, and compute you permanen
   </Card>
 </CardGroup>
 
+## Agent Integrations
+
+Use Venice as the private, OpenAI-compatible model layer for current agent stacks, messaging gateways, and tool hosts.
+
+<CardGroup cols={4}>
+  <Card title="OpenClaw" href="/guides/integrations/openclaw-bot" icon="robot">
+    Connect Venice to WhatsApp, Telegram, Discord, iMessage, Slack, and more.
+  </Card>
+
+  <Card title="Hermes Agent" href="/guides/integrations/hermes-agent" icon="brain">
+    Power persistent-memory agents with Venice models, tools, and media endpoints.
+  </Card>
+
+  <Card title="Venice MCP Server" href="/guides/integrations/venice-mcp" icon="plug">
+    Expose 31 Venice tools to Claude Desktop, Cursor, LM Studio, and other MCP hosts.
+  </Card>
+
+  <Card title="Agent Skills" href="/guides/integrations/venice-skills" icon="screwdriver-wrench">
+    Give coding agents endpoint-specific Venice API guidance.
+  </Card>
+</CardGroup>
+
 ## OpenAI Compatibility
 
 Use your existing OpenAI code with just a base URL change.
@@ -1263,8 +1285,8 @@ Get your API key and make your first request.
     Ready-to-use API examples and testing
   </Card>
   
-  <Card title="AI Agents" href="/guides/integrations/ai-agents" icon="robot">
-    Build with Eliza and other agent frameworks
+  <Card title="Agent Integrations" href="/guides/integrations/crypto-rpc-agents" icon="robot">
+    Build with OpenClaw, Hermes Agent, MCP, and x402 wallet auth
   </Card>
 </CardGroup>
 

--- a/overview/getting-started.mdx
+++ b/overview/getting-started.mdx
@@ -972,7 +972,7 @@ Now that you've made your first requests, explore more of what Venice API has to
     Learn how to get JSON responses with guaranteed schemas
   </Card>
   <Card title="AI Agents Guide" icon="robot" href="/guides/integrations/ai-agents">
-    Build autonomous AI agents with Venice API and frameworks like Eliza
+    Build with agent apps, coding agents, MCP tools, skills, and crypto workflows
   </Card>
 </CardGroup>
 

--- a/style.css
+++ b/style.css
@@ -2,144 +2,24 @@
   height: 50px;
 }
 
-/* Featured agent panel */
-.venice-agents-panel {
-  display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
-  gap: 32px;
-  align-items: center;
-  margin: 28px 0 40px;
-  padding: 36px;
-  border: 1px solid rgba(18, 93, 163, 0.22);
-  border-radius: 18px;
-  background:
-    radial-gradient(circle at top right, rgba(18, 93, 163, 0.14), transparent 40%),
-    rgba(18, 93, 163, 0.05);
-}
-
-.venice-agents-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.venice-agents-eyebrow {
-  margin: 0;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: #125DA3 !important;
-}
-
-.venice-agents-copy h2 {
-  margin: 0;
-  font-size: 30px;
-  line-height: 1.1;
-}
-
-.venice-agents-copy p {
-  margin: 0;
-  max-width: 520px;
-  font-size: 15px;
-  line-height: 1.55;
-  opacity: 0.78;
-}
-
-.venice-agents-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  width: fit-content;
-  margin-top: 4px;
-  padding: 9px 16px;
-  border: 1px solid rgba(18, 93, 163, 0.4);
-  border-radius: 999px;
-  font-size: 13px;
-  font-weight: 600;
-  color: inherit !important;
-  text-decoration: none !important;
-  transition: background 0.15s ease, border-color 0.15s ease;
-}
-
-.venice-agents-button:hover {
-  background: rgba(18, 93, 163, 0.1);
-  border-color: rgba(18, 93, 163, 0.65);
-}
-
+/* Agents card grid (3-up, uses .venice-api-card for the cards themselves) */
 .venice-agents-cards {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 12px;
-}
-
-.venice-agents-card {
-  display: block;
-  padding: 18px 20px;
-  border: 1px solid rgba(128, 128, 128, 0.22);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.55);
-  color: inherit !important;
-  text-decoration: none !important;
-  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
-}
-
-.venice-agents-card:hover {
-  transform: translateY(-1px);
-  border-color: rgba(18, 93, 163, 0.45);
-  background: rgba(255, 255, 255, 0.75);
-}
-
-.venice-agents-card-title {
-  display: block;
-  font-size: 16px;
-  font-weight: 700;
-  margin-bottom: 4px;
-}
-
-.venice-agents-card-desc {
-  display: block;
-  font-size: 13px;
-  line-height: 1.5;
-  opacity: 0.72;
-}
-
-.dark .venice-agents-panel,
-[data-theme="dark"] .venice-agents-panel {
-  border-color: rgba(80, 140, 200, 0.28);
-  background:
-    radial-gradient(circle at top right, rgba(18, 93, 163, 0.22), transparent 40%),
-    rgba(18, 93, 163, 0.08);
-}
-
-.dark .venice-agents-card,
-[data-theme="dark"] .venice-agents-card {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.12);
-}
-
-.dark .venice-agents-card:hover,
-[data-theme="dark"] .venice-agents-card:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(96, 165, 250, 0.4);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 20px 0 16px;
 }
 
 @media (max-width: 900px) {
-  .venice-agents-panel {
+  .venice-agents-cards {
     grid-template-columns: 1fr;
-    padding: 28px;
-  }
-
-  .venice-agents-copy h2 {
-    font-size: 24px;
   }
 }
 
 /* Shared section header (centered eyebrow + title + subtitle) */
 .venice-section-header {
-  text-align: center;
-  max-width: 640px;
-  margin: 56px auto 20px;
+  text-align: left;
+  margin: 56px 0 20px;
 }
 
 .venice-section-eyebrow {
@@ -462,7 +342,74 @@
   }
 }
 
-/* Hero card grid (3-up navigation under the H1) */
+/* Hero copy block (tagline + subtitle + CTA row, stacked above a full-width code sample) */
+.venice-hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 4px 0 24px;
+}
+
+.venice-hero-tagline {
+  font-size: 22px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.venice-hero-subtitle {
+  font-size: 15px;
+  line-height: 1.55;
+  margin: 0;
+  opacity: 0.7;
+}
+
+.venice-hero-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.venice-hero-cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 9px 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none !important;
+  color: inherit !important;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.venice-hero-cta:hover {
+  border-color: rgba(18, 93, 163, 0.55);
+}
+
+.venice-hero-cta-primary {
+  background: #125DA3;
+  color: #fff !important;
+  border-color: #125DA3;
+}
+
+.venice-hero-cta-primary:hover {
+  background: #0e4d87;
+  border-color: #0e4d87;
+}
+
+.dark .venice-hero-cta,
+[data-theme="dark"] .venice-hero-cta {
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.dark .venice-hero-cta:hover,
+[data-theme="dark"] .venice-hero-cta:hover {
+  border-color: rgba(96, 165, 250, 0.55);
+}
+
+/* Hero card grid (3-up navigation, kept for any pages that still use it) */
 .venice-hero-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -482,6 +429,42 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
   margin: 20px 0 16px;
+}
+
+.venice-apis-extras {
+  margin: 22px 0 0;
+  font-size: 15px;
+  line-height: 1.65;
+  opacity: 0.92;
+}
+
+.venice-apis-extras a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(128, 128, 128, 0.55);
+  text-underline-offset: 3px;
+}
+
+.venice-apis-extras a:hover {
+  text-decoration-color: currentColor;
+}
+
+.venice-apis-extras-cta {
+  color: #125DA3 !important;
+  font-weight: 600;
+  text-decoration: none !important;
+  margin-left: 6px;
+  white-space: nowrap;
+}
+
+.venice-apis-extras-cta:hover {
+  text-decoration: underline !important;
+  text-decoration-color: currentColor !important;
+}
+
+.dark .venice-apis-extras-cta,
+[data-theme="dark"] .venice-apis-extras-cta {
+  color: #6ba7e0 !important;
 }
 
 .venice-api-card {

--- a/style.css
+++ b/style.css
@@ -2,6 +2,565 @@
   height: 50px;
 }
 
+/* Featured agent panel */
+.venice-agents-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 32px;
+  align-items: center;
+  margin: 28px 0 40px;
+  padding: 36px;
+  border: 1px solid rgba(18, 93, 163, 0.22);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at top right, rgba(18, 93, 163, 0.14), transparent 40%),
+    rgba(18, 93, 163, 0.05);
+}
+
+.venice-agents-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.venice-agents-eyebrow {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #125DA3 !important;
+}
+
+.venice-agents-copy h2 {
+  margin: 0;
+  font-size: 30px;
+  line-height: 1.1;
+}
+
+.venice-agents-copy p {
+  margin: 0;
+  max-width: 520px;
+  font-size: 15px;
+  line-height: 1.55;
+  opacity: 0.78;
+}
+
+.venice-agents-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  margin-top: 4px;
+  padding: 9px 16px;
+  border: 1px solid rgba(18, 93, 163, 0.4);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: inherit !important;
+  text-decoration: none !important;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.venice-agents-button:hover {
+  background: rgba(18, 93, 163, 0.1);
+  border-color: rgba(18, 93, 163, 0.65);
+}
+
+.venice-agents-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+.venice-agents-card {
+  display: block;
+  padding: 18px 20px;
+  border: 1px solid rgba(128, 128, 128, 0.22);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.55);
+  color: inherit !important;
+  text-decoration: none !important;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+}
+
+.venice-agents-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(18, 93, 163, 0.45);
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.venice-agents-card-title {
+  display: block;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.venice-agents-card-desc {
+  display: block;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.72;
+}
+
+.dark .venice-agents-panel,
+[data-theme="dark"] .venice-agents-panel {
+  border-color: rgba(80, 140, 200, 0.28);
+  background:
+    radial-gradient(circle at top right, rgba(18, 93, 163, 0.22), transparent 40%),
+    rgba(18, 93, 163, 0.08);
+}
+
+.dark .venice-agents-card,
+[data-theme="dark"] .venice-agents-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.dark .venice-agents-card:hover,
+[data-theme="dark"] .venice-agents-card:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(96, 165, 250, 0.4);
+}
+
+@media (max-width: 900px) {
+  .venice-agents-panel {
+    grid-template-columns: 1fr;
+    padding: 28px;
+  }
+
+  .venice-agents-copy h2 {
+    font-size: 24px;
+  }
+}
+
+/* Shared section header (centered eyebrow + title + subtitle) */
+.venice-section-header {
+  text-align: center;
+  max-width: 640px;
+  margin: 56px auto 20px;
+}
+
+.venice-section-eyebrow {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #125DA3 !important;
+}
+
+.venice-section-title {
+  margin: 0 0 8px;
+  font-size: 24px;
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.venice-section-subtitle {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  opacity: 0.68;
+}
+
+@media (max-width: 900px) {
+  .venice-section-title {
+    font-size: 22px;
+  }
+}
+
+/* Featured pricing block */
+.venice-pricing {
+  margin: 32px 0;
+}
+
+.venice-pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.venice-pricing-card {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.dark .venice-pricing-card,
+[data-theme="dark"] .venice-pricing-card {
+  background: rgba(255, 255, 255, 0.025);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.venice-pricing-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.venice-pricing-card-name {
+  display: block;
+  font-size: 18px;
+  font-weight: 700;
+  color: inherit;
+  white-space: nowrap;
+}
+
+.venice-pricing-card-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(128, 128, 128, 0.12);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
+.venice-pricing-card-desc {
+  margin: 0 0 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.75;
+}
+
+.venice-pricing-card-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  flex: 1;
+}
+
+.venice-pricing-card-list li {
+  position: relative;
+  padding-left: 20px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.venice-pricing-card-list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2310b981' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'><polyline points='20 6 9 17 4 12'/></svg>");
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.venice-pricing-card-cta {
+  display: block;
+  margin-top: auto;
+  padding: 9px 14px;
+  border-radius: 8px;
+  background: #125DA3;
+  color: #fff !important;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+  text-decoration: none !important;
+  transition: background 0.15s ease;
+}
+
+.venice-pricing-card-cta:hover {
+  background: #0e4a82;
+}
+
+@media (max-width: 900px) {
+  .venice-pricing-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Popular model cards */
+.venice-models-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 20px 0 16px;
+}
+
+.venice-model-card {
+  display: flex;
+  flex-direction: column;
+  padding: 18px 20px;
+  border: 1px solid rgba(128, 128, 128, 0.22);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.55);
+  color: inherit !important;
+  text-decoration: none !important;
+  transition: border-color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+}
+
+.venice-model-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(18, 93, 163, 0.45);
+}
+
+.dark .venice-model-card,
+[data-theme="dark"] .venice-model-card {
+  background: rgba(255, 255, 255, 0.025);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.dark .venice-model-card:hover,
+[data-theme="dark"] .venice-model-card:hover {
+  background: rgba(255, 255, 255, 0.045);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.venice-model-card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 10px;
+}
+
+.venice-model-card-name {
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.venice-model-card-maker {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
+.venice-model-card-desc {
+  margin: 0 0 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.78;
+  flex: 1;
+}
+
+.venice-model-card-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.venice-model-card-stats > span {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(128, 128, 128, 0.12);
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.venice-model-card-stats .venice-model-card-privacy {
+  background: rgba(16, 185, 129, 0.12);
+  color: #10b981;
+}
+
+.venice-model-card-id {
+  display: block;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: rgba(128, 128, 128, 0.14);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 500;
+  color: inherit;
+  width: fit-content;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 900px) {
+  .venice-models-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* "View all models" CTA banner */
+.venice-models-cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 8px 0 4px;
+  padding: 16px 22px;
+  border: 1px solid rgba(18, 93, 163, 0.3);
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at right, rgba(18, 93, 163, 0.12), transparent 50%),
+    rgba(18, 93, 163, 0.05);
+  color: inherit !important;
+  text-decoration: none !important;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.venice-models-cta:hover {
+  border-color: rgba(18, 93, 163, 0.55);
+  transform: translateY(-1px);
+  background:
+    radial-gradient(circle at right, rgba(18, 93, 163, 0.18), transparent 50%),
+    rgba(18, 93, 163, 0.08);
+}
+
+.dark .venice-models-cta,
+[data-theme="dark"] .venice-models-cta {
+  border-color: rgba(80, 140, 200, 0.32);
+}
+
+.venice-models-cta-left {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.venice-models-cta-count {
+  font-size: 20px;
+  font-weight: 700;
+  color: #125DA3;
+  line-height: 1.1;
+}
+
+.dark .venice-models-cta-count,
+[data-theme="dark"] .venice-models-cta-count {
+  color: #6ba7e0;
+}
+
+.venice-models-cta-sub {
+  font-size: 13px;
+  opacity: 0.65;
+}
+
+.venice-models-cta-action {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .venice-models-cta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+}
+
+/* Hero card grid (3-up navigation under the H1) */
+.venice-hero-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 24px 0 8px;
+}
+
+@media (max-width: 700px) {
+  .venice-hero-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* "Build with Venice APIs" rich cards */
+.venice-apis-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 20px 0 16px;
+}
+
+.venice-api-card {
+  display: flex;
+  flex-direction: column;
+  padding: 22px;
+  border: 1px solid rgba(128, 128, 128, 0.22);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.55);
+  color: inherit !important;
+  text-decoration: none !important;
+  transition: border-color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+}
+
+.venice-api-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(18, 93, 163, 0.45);
+}
+
+.dark .venice-api-card,
+[data-theme="dark"] .venice-api-card {
+  background: rgba(255, 255, 255, 0.025);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.dark .venice-api-card:hover,
+[data-theme="dark"] .venice-api-card:hover {
+  background: rgba(255, 255, 255, 0.045);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.venice-api-card-name {
+  display: block;
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.venice-api-card-desc {
+  margin: 0 0 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.78;
+  flex: 1;
+}
+
+.venice-api-card-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.venice-api-card-chip {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(128, 128, 128, 0.12);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.venice-api-card-action {
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #125DA3;
+}
+
+.dark .venice-api-card-action,
+[data-theme="dark"] .venice-api-card-action {
+  color: #6ba7e0;
+}
+
+@media (max-width: 600px) {
+  .venice-apis-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Hide pricing placeholders until JS renders styled content (avoids layout flash).
    Agents still see the markdown tables in the HTML source. */
 [id$="-placeholder"] {


### PR DESCRIPTION
## Summary
- Add prominent agent/tooling CTAs to the API overview for OpenClaw, Hermes Agent, the Venice MCP Server, and Agent Skills.
- Replace the outdated Eliza-focused AI Agents card with current Venice agent integration messaging.

## Test plan
- [x] Checked edited file with IDE diagnostics.
- [x] Ran `git diff --check`.
