### PR TITLE
docs: fix og:image to use new landing-social-preview asset

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -301,7 +301,7 @@
       "og:title": "Venice API Docs",
       "og:description": "Harness the full capabilities of Venice AI with the Venice API, a private and uncensored AI API enabling the development of advanced applications that generate text and images.",
       "og:url": "https://docs.venice.ai",
-      "og:image": "https://venice.ai/images/venice_social_preview_x.png",
+      "og:image": "https://venice.ai/images/landing-social-preview.png",
       "og:locale": "en_US",
       "og:logo": "/logo/light.svg",
       "article:publisher": "Venice AI",
@@ -310,7 +310,7 @@
       "twitter:url": "https://docs.venice.ai",
       "twitter:image": "https://venice.ai/images/venice_social_preview_x.png",
       "twitter:site": "@AskVenice",
-      "og:image:width": "630",
+      "og:image:width": "1200",
       "og:image:height": "630"
     },
     "indexing": "navigable"

--- a/docs.json
+++ b/docs.json
@@ -301,7 +301,7 @@
       "og:title": "Venice API Docs",
       "og:description": "Harness the full capabilities of Venice AI with the Venice API, a private and uncensored AI API enabling the development of advanced applications that generate text and images.",
       "og:url": "https://docs.venice.ai",
-      "og:image": "https://venice.ai/images/venice_social_preview.png",
+      "og:image": "https://venice.ai/images/venice_social_preview_x.png",
       "og:locale": "en_US",
       "og:logo": "/logo/light.svg",
       "article:publisher": "Venice AI",
@@ -310,7 +310,7 @@
       "twitter:url": "https://docs.venice.ai",
       "twitter:image": "https://venice.ai/images/venice_social_preview_x.png",
       "twitter:site": "@AskVenice",
-      "og:image:width": "1200",
+      "og:image:width": "630",
       "og:image:height": "630"
     },
     "indexing": "navigable"


### PR DESCRIPTION
## Summary

The default `og:image` for `docs.venice.ai` was 404ing, so any link shared on Discord / Slack / LinkedIn / Facebook / email rendered without a preview image.

### Background

The Venice web team confirmed the old asset was removed and replaced. New canonical URL:

```text
https://venice.ai/images/landing-social-preview.png  → 200 image/png, 1200x630, 604KB
```

### Fix

- Point `og:image` at the new `landing-social-preview.png` URL.
- `og:image:width` stays at `1200` and `og:image:height` at `630` — matches the actual file dimensions, which is the standard Open Graph 1.91:1 ratio expected by Facebook, LinkedIn, Slack, Discord, and email clients.
- `twitter:image` continues to point at `venice_social_preview_x.png` (still exists, 630×630), since that asset was designed for Twitter's `summary_large_image` card.

### Verification

```bash
$ curl -sI https://venice.ai/images/landing-social-preview.png
200 OK
content-type: image/png
```

PNG header confirms dimensions: **1200×630**.

## Test plan

- [ ] After deploy, run `curl -I https://venice.ai/images/landing-social-preview.png` to confirm 200 OK.
- [ ] Paste `https://docs.venice.ai` into the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) and click **Scrape Again** to bust Facebook's cache. Confirm the new image renders.
- [ ] Repeat for [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) and confirm the preview.
- [ ] Drop a link to `docs.venice.ai` in Discord / Slack and confirm the unfurl shows the new social card.
