### PR TITLE
docs: add 1Claw to Community Confirmed integrations

### DIFF
--- a/guides/integrations/integrations.mdx
+++ b/guides/integrations/integrations.mdx
@@ -35,6 +35,8 @@ These integrations have been confirmed by the community. Venice is in the proces
 
   * [JanitorAI](https://janitorai.com/)
 
+  * [1Claw](https://1claw.xyz), secure infrastructure for AI agents; routes private inference to Venice via the Shroud TEE proxy
+
 * Coding
 
   * [Aider](https://github.com/Aider-AI/aider), AI pair programming in your terminal


### PR DESCRIPTION
Adds **1Claw** ([1claw.xyz](https://1claw.xyz)) under *Community Confirmed → Agents/Bots*.

1Claw is secure infrastructure for AI agents. Its **Shroud** TEE proxy routes private inference to the Venice API, supporting Venice's Private, TEE, and E2EE modes so agent prompts and secrets never land in provider logs.

Reference: https://1claw.xyz/blog/private-ai-agents-shroud-darkbloom-venice

Single-line addition, follows the existing list format. Happy to add a dedicated `guides/integrations/1claw.mdx` how-to guide if useful.