### PR TITLE
docs: Seedance face-media consent guide (DRAFT — gated on VEN-6191)

### DIFF
--- a/api-reference/endpoint/video/queue.mdx
+++ b/api-reference/endpoint/video/queue.mdx
@@ -13,6 +13,10 @@ Private models also return a `download_url` for the finished video. It is a shor
 
 For `seedance-2-0-*` models (text-to-video, image-to-video, reference-to-video, plus the `-fast-*` variants), see the [Seedance 2.0 Guide](/guides/media/seedance-2-0) for the four-workflow model (Reference / Edit / Extend / Stitch), canonical prompt patterns, multimodal input limits, and pricing details.
 
+### Seedance consent
+
+When a Seedance image- or reference-to-video request contains a human face, the API returns a `409 needs_consent` with the policy text, and you resubmit the same request with a `consents.seedance` attestation. See the [Seedance Face-Media Consent Guide](/guides/media/seedance-face-consent) for the full flow, the consent object, dedupe, and revocation.
+
 ### Video upscaling
 
 For the `topaz-video-upscale` model, use `upscale_factor` (1, 2, or 4) instead of `resolution`, and provide a `video_url`. Duration and FPS are detected automatically from the video file. See the [Video Upscaling Guide](/guides/media/video-upscaling) for full details and examples.

--- a/docs.json
+++ b/docs.json
@@ -66,6 +66,7 @@
               "guides/media/video-generation",
               "guides/media/reference-to-video",
               "guides/media/seedance-2-0",
+              "guides/media/seedance-face-consent",
               "guides/media/video-upscaling"
             ]
           },

--- a/guides/media/seedance-face-consent.mdx
+++ b/guides/media/seedance-face-consent.mdx
@@ -16,7 +16,7 @@ Consent is only requested when **both** are true:
 1. The model is a face-eligible Seedance variant:
    - `seedance-2-0-image-to-video`, `seedance-2-0-reference-to-video`
    - `seedance-2-0-fast-image-to-video`, `seedance-2-0-fast-reference-to-video`
-2. The submitted media actually contains a detectable human face, in any of these fields: `image_url`, `end_image_url`, `reference_image_urls`, `video_url`, `reference_video_urls`.
+2. The submitted media actually contains a detectable human face, in any of these fields: `image_url`, `end_image_url`, `reference_image_urls`, `reference_video_urls`.
 
 If there is **no face** in any of those fields, the request proceeds normally with no consent step. Text-to-video never enters this flow.
 
@@ -62,7 +62,7 @@ If a face is detected and you have not yet attested, you get a non-charging **`4
   "consent_flow": "seedance",
   "face_media_roles": ["reference_image"],
   "consent": {
-    "consent_version": "v1.0",
+    "consent_version": "v2.0",
     "policy_text": "The likeness in any media you upload is your own, or you have explicit, legal consent from any depicted individual(s). Note: an image may contain more than one face — your attestation covers all of them.\nYou own or have permission to use all media you uploaded for content generation.\nYou agree to the Venice.ai Terms of Service and Privacy Policy. Violations can lead to account suspension and legal liability.\nNo content is stored by Venice."
   },
   "docs_url": "https://docs.venice.ai/guides/media/seedance-face-consent"
@@ -71,9 +71,9 @@ If a face is detected and you have not yet attested, you get a non-charging **`4
 
 | Field | Meaning |
 |---|---|
-| `face_media_roles` | Which of your inputs contain a face: `image`, `end_image`, `reference_image`, `video`, `reference_video` |
+| `face_media_roles` | Which of your inputs contain a face: `image`, `end_image`, `reference_image`, `reference_video` |
 | `consent.policy_text` | The exact attestation text you must agree to. Present it to whoever is responsible for the request. |
-| `consent.consent_version` | The current policy version. Informational — you do **not** send it back. |
+| `consent.consent_version` | The current policy version (server-set; can change over time). Informational — you do **not** send it back. |
 
 No credits or x402 payment are charged on a `409`.
 
@@ -154,7 +154,7 @@ The consent decision always happens **before** any charge, for both payment meth
 | `409` | `needs_consent` | Face detected, no valid `consents.seedance`, no exact-media match. Resubmit with consent. |
 | `400` | validation error | Malformed `consents.seedance` — a missing/`false` confirmation or an extra field such as `consent_version`. |
 | `422` | `CONTENT_POLICY_VIOLATION` | Detected minor with suggestive/NSFW content, or a public-figure likeness. Consent does not override this. |
-| `422` | `IMAGE_ASPECT_RATIO_OUT_OF_BOUNDS` | A face input is outside the allowed `(0.4, 2.5)` width/height ratio. |
+| `422` | `IMAGE_ASPECT_RATIO_OUT_OF_BOUNDS` | A **detected-face image** is outside the allowed `(0.4, 2.5)` width/height ratio. Checked synchronously during face-asset provisioning (before charge); only applies once a face is detected in that image. |
 
 ## References
 

--- a/guides/media/seedance-face-consent.mdx
+++ b/guides/media/seedance-face-consent.mdx
@@ -35,7 +35,23 @@ flowchart LR
 
 ### Call 1 — submit without consent
 
-Submit your generation request as usual. If a face is detected and you have not yet attested, you get a non-charging **`409`**:
+Submit your generation request as usual — no consent field:
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "prompt": "Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same person walking through a sunlit market.",
+    "reference_image_urls": ["https://example.com/person.jpg"],
+    "duration": "5s",
+    "aspect_ratio": "9:16",
+    "resolution": "1080p"
+  }'
+```
+
+If a face is detected and you have not yet attested, you get a non-charging **`409`**:
 
 ```json
 {

--- a/guides/media/seedance-face-consent.mdx
+++ b/guides/media/seedance-face-consent.mdx
@@ -1,0 +1,147 @@
+---
+title: "Seedance Face-Media Consent"
+description: "When a Seedance 2.0 request contains a human face, the Venice API requires a one-time consent attestation before it will process the media. This guide covers the two-call flow, the consent object, and the responses."
+'og:title': "Seedance Face-Media Consent | Venice API Docs"
+'og:description': "Submit face-bearing media to Seedance 2.0 via the Venice API: the needs_consent response, the single attestation object, dedupe, and revocation."
+---
+
+Seedance 2.0 image- and reference-to-video models can drive a video from a **human face** you supply. When the Venice API detects a face in your submitted media, it requires a one-time **consent attestation** before the media is processed. This is a provider requirement for face-bearing inputs and protects against non-consensual likeness use.
+
+This guide covers exactly what you send, what you get back, and how returning requests are handled.
+
+## When consent applies
+
+Consent is only requested when **both** are true:
+
+1. The model is a face-eligible Seedance variant:
+   - `seedance-2-0-image-to-video`, `seedance-2-0-reference-to-video`
+   - `seedance-2-0-fast-image-to-video`, `seedance-2-0-fast-reference-to-video`
+2. The submitted media actually contains a detectable human face, in any of these fields: `image_url`, `end_image_url`, `reference_image_urls`, `video_url`, `reference_video_urls`.
+
+If there is **no face** in any of those fields, the request proceeds normally with no consent step. Text-to-video never enters this flow.
+
+<Note>
+Consent does not unlock restricted content. A detected **minor combined with sexually-suggestive prompts/NSFW**, or a recognizable **public-figure likeness**, is rejected as a content-policy violation (`422`) and **cannot** be made acceptable by attesting consent.
+</Note>
+
+## The two-call flow
+
+```mermaid
+flowchart LR
+  A[POST /video/queue<br/>face media, no consent] --> B[409 needs_consent<br/>+ policy_text]
+  B --> C[Resubmit same request<br/>+ consents.seedance]
+  C --> D[200 queue_id]
+```
+
+### Call 1 — submit without consent
+
+Submit your generation request as usual. If a face is detected and you have not yet attested, you get a non-charging **`409`**:
+
+```json
+{
+  "error": {
+    "code": "needs_consent",
+    "message": "Seedance consent is required for this request."
+  },
+  "consent_flow": "seedance",
+  "face_media_roles": ["reference_image"],
+  "consent": {
+    "consent_version": "v1.0",
+    "policy_text": "The likeness in any media you upload is your own, or you have explicit, legal consent from any depicted individual(s). Note: an image may contain more than one face — your attestation covers all of them.\nYou own or have permission to use all media you uploaded for content generation.\nYou agree to the Venice.ai Terms of Service and Privacy Policy. Violations can lead to account suspension and legal liability.\nNo content is stored by Venice."
+  },
+  "docs_url": "https://docs.venice.ai/api-reference/endpoint/video/queue#seedance-consent"
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `face_media_roles` | Which of your inputs contain a face: `image`, `end_image`, `reference_image`, `video`, `reference_video` |
+| `consent.policy_text` | The exact attestation text you must agree to. Present it to whoever is responsible for the request. |
+| `consent.consent_version` | The current policy version. Informational — you do **not** send it back. |
+
+No credits or x402 payment are charged on a `409`.
+
+### Call 2 — resubmit with consent
+
+Resend the **same request body**, adding a `consents.seedance` object with three confirmations, all `true`:
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0-reference-to-video",
+    "prompt": "Refer to <Subject 1> in <Image 1> to generate a 5-second clip of the same person walking through a sunlit market.",
+    "reference_image_urls": ["https://example.com/person.jpg"],
+    "duration": "5s",
+    "aspect_ratio": "9:16",
+    "resolution": "1080p",
+    "consents": {
+      "seedance": {
+        "confirmed_terms_and_privacy": true,
+        "confirmed_legal_right": true,
+        "confirmed_screening_acknowledged": true
+      }
+    }
+  }'
+```
+
+A successful submission returns the normal queue response:
+
+```json
+{ "model": "seedance-2-0-reference-to-video", "queue_id": "..." }
+```
+
+Then poll `POST /api/v1/video/retrieve` with the `queue_id` as usual (see [Video Generation](/guides/media/video-generation)).
+
+## The consent object
+
+```json
+{
+  "confirmed_terms_and_privacy": true,
+  "confirmed_legal_right": true,
+  "confirmed_screening_acknowledged": true
+}
+```
+
+| Field | You confirm that… |
+|---|---|
+| `confirmed_terms_and_privacy` | you accept the `policy_text` returned in the `409`, including the Venice Terms of Service and Privacy Policy |
+| `confirmed_legal_right` | the likeness is your own or you have explicit, legal consent from every depicted individual |
+| `confirmed_screening_acknowledged` | you acknowledge that submitted media may be automatically screened before processing |
+
+<Warning>
+All three fields must be the boolean `true`. Any missing field, a `false`, or any **extra** field — including a `consent_version` — is rejected with a `400`. The policy version is always set by the server; clients never send or pick a version.
+</Warning>
+
+## Returning requests (dedupe)
+
+If you submit **the exact same media bytes** you have already attested to, the API recognizes it and proceeds **without** asking for consent again — you can omit `consents.seedance` on subsequent identical submissions. This match is by exact image bytes: re-encoding, resizing, or cropping produces different bytes and will prompt for consent again.
+
+A partial match (one previously-attested input plus one new face input) still requires a fresh `consents.seedance` on the new submission.
+
+## Revocation
+
+To revoke consent and erase stored face assets, sign in to the Venice web app (**Settings**). Revocation is not available through the public API. After revoking, the next request using that media will prompt for consent again.
+
+## Payment
+
+The consent decision always happens **before** any charge, for both payment methods:
+
+- **API key:** a `409`/`422` returns before the credit charge; nothing is billed for a blocked request.
+- **x402:** the consumption charge runs only after a successful generation, so a `409`/`422` settles nothing. Re-submit with consent (and a fresh x402 authorization) to proceed.
+
+## Error reference
+
+| Status | Body `error` | Cause |
+|---|---|---|
+| `409` | `needs_consent` | Face detected, no valid `consents.seedance`, no exact-media match. Resubmit with consent. |
+| `400` | validation error | Malformed `consents.seedance` — a missing/`false` confirmation or an extra field such as `consent_version`. |
+| `422` | `CONTENT_POLICY_VIOLATION` | Detected minor with suggestive/NSFW content, or a public-figure likeness. Consent does not override this. |
+| `422` | `IMAGE_ASPECT_RATIO_OUT_OF_BOUNDS` | A face input is outside the allowed `(0.4, 2.5)` width/height ratio. |
+
+## References
+
+- Video queue endpoint: [`POST /api/v1/video/queue`](/api-reference/endpoint/video/queue)
+- [Seedance 2.0 Guide](/guides/media/seedance-2-0) — variants, workflows, prompt syntax, limits
+- [Video Generation](/guides/media/video-generation) — queue / polling overview

--- a/guides/media/seedance-face-consent.mdx
+++ b/guides/media/seedance-face-consent.mdx
@@ -49,7 +49,7 @@ Submit your generation request as usual. If a face is detected and you have not 
     "consent_version": "v1.0",
     "policy_text": "The likeness in any media you upload is your own, or you have explicit, legal consent from any depicted individual(s). Note: an image may contain more than one face — your attestation covers all of them.\nYou own or have permission to use all media you uploaded for content generation.\nYou agree to the Venice.ai Terms of Service and Privacy Policy. Violations can lead to account suspension and legal liability.\nNo content is stored by Venice."
   },
-  "docs_url": "https://docs.venice.ai/api-reference/endpoint/video/queue#seedance-consent"
+  "docs_url": "https://docs.venice.ai/guides/media/seedance-face-consent"
 }
 ```
 


### PR DESCRIPTION
## Seedance face-media consent guide

Adds a user-facing guide for the public-API Seedance face consent flow.

- **New page** `guides/media/seedance-face-consent.mdx` — when consent applies, the `409 needs_consent` → resubmit two-call flow, the single `consents.seedance` attestation (3 booleans), dedupe, revocation (web-app only), payment ordering (API key + x402), and an error reference.
- Registered in nav (`docs.json`, Image & Video group).
- Added a `### Seedance consent` cross-link section on the `video/queue` endpoint page.
- `docs_url` example points at this guide (matches the API's `SEEDANCE_CONSENT_DOCS_URL`).

Pairs with the backend in outerface PR #7950 (VEN-6206). Kept as draft until that merges so the docs don't describe an endpoint before it's live.

Note: the example shows `consent_version: "v1.0"` (current branch) — reconcile with the in-product modal version before publish. The client never sends the version, so this is low-risk.

Mintlify renders cleanly under 4.0.491 (0 parse errors). A fresh install pulls the pinned `mintlify@^4.2.506`, which has a regression that fails to parse all `guides/` pages — unrelated to this PR.
