### PR TITLE
docs: update deprecation notice period from 30-60 days to 7-15 days

### DIFF
--- a/overview/deprecations.mdx
+++ b/overview/deprecations.mdx
@@ -21,7 +21,7 @@ We may deprecate a model when:
 
 ## Deprecation Process
 
-When a model meets deprecation criteria, we announce the change with 30–60 days' notice. Deprecation notices are published via the [changelog](https://featurebase.venice.ai/changelog) and our [Discord server](https://discord.gg/askvenice). When you call a deprecated model during the notice period, the API response will include a deprecation warning.
+When a model meets deprecation criteria, we announce the change with 7–15 days' notice. Deprecation notices are published via the [changelog](https://featurebase.venice.ai/changelog) and our [Discord server](https://discord.gg/askvenice). When you call a deprecated model during the notice period, the API response will include a deprecation warning.
 
 During the notice period, the model remains available, though in some cases we may reduce infrastructure capacity. We always provide a recommended replacement, and when needed, offer migration guidance to help the transition.
 

--- a/overview/deprecations.mdx
+++ b/overview/deprecations.mdx
@@ -21,7 +21,14 @@ We may deprecate a model when:
 
 ## Deprecation Process
 
-When a model meets deprecation criteria, we announce the change with 7–15 days' notice. Deprecation notices are published via the [changelog](https://featurebase.venice.ai/changelog), our [Discord server](https://discord.gg/askvenice), the [Model Deprecation Tracker](#model-deprecation-tracker) below, and the [List Models](/api-reference/endpoint/models/list) API endpoint. If you've used the model in the past 15 days, you'll also receive an email notification. When you call a deprecated model during the notice period, the API response will include a deprecation warning.
+When a model meets deprecation criteria, we provide 7–15 days' notice before removal. You can track upcoming deprecations through:
+
+- The [Model Deprecation Tracker](#model-deprecation-tracker) below
+- The [List Models](/api-reference/endpoint/models/list) API endpoint (models with a scheduled retirement include a `deprecation` object)
+- Our [changelog](https://featurebase.venice.ai/changelog)
+- Email notifications, sent automatically if you've called the model in the past 15 days
+
+During the notice period, calls to a deprecated model will include a deprecation warning in the API response.
 
 During the notice period, the model remains available, though in some cases we may reduce infrastructure capacity. We always provide a recommended replacement, and when needed, offer migration guidance to help the transition.
 

--- a/overview/deprecations.mdx
+++ b/overview/deprecations.mdx
@@ -21,7 +21,7 @@ We may deprecate a model when:
 
 ## Deprecation Process
 
-When a model meets deprecation criteria, we announce the change with 7–15 days' notice. Deprecation notices are published via the [changelog](https://featurebase.venice.ai/changelog) and our [Discord server](https://discord.gg/askvenice). When you call a deprecated model during the notice period, the API response will include a deprecation warning.
+When a model meets deprecation criteria, we announce the change with 7–15 days' notice. Deprecation notices are published via the [changelog](https://featurebase.venice.ai/changelog), our [Discord server](https://discord.gg/askvenice), the [Model Deprecation Tracker](#model-deprecation-tracker) below, and the [List Models](/api-reference/endpoint/models/list) API endpoint. If you've used the model in the past 15 days, you'll also receive an email notification. When you call a deprecated model during the notice period, the API response will include a deprecation warning.
 
 During the notice period, the model remains available, though in some cases we may reduce infrastructure capacity. We always provide a recommended replacement, and when needed, offer migration guidance to help the transition.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrites the Deprecation Process section with updated notice period and clearer notification channels.

## Changes

- Changed deprecation notice window from 30–60 days to **7–15 days**
- Restructured notification channels as a scannable bullet list:
  - Model Deprecation Tracker
  - List Models API endpoint
  - Changelog
  - Email notifications (for users who called the model in the past 15 days)
- Removed Discord as a notification channel
- Improved readability and flow of the section
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://veniceai.slack.com/archives/D0AA9GPR6UD/p1781452831381569?thread_ts=1781452831.381569&cid=D0AA9GPR6UD)

<div><a href="https://cursor.com/agents/bc-2eba8bd5-ad71-5e78-b6bb-26f0caa8c40e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eba8bd5-ad71-5e78-b6bb-26f0caa8c40e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

