### PR TITLE
docs: surface venice_parameters on the Chat Completions page

### DIFF
--- a/api-reference/endpoint/chat/completions.mdx
+++ b/api-reference/endpoint/chat/completions.mdx
@@ -5,6 +5,18 @@ openapi: 'POST /chat/completions'
 "og:description": "Documentation covering Venice's chat completions API."
 ---
 
+<Info>
+  **Venice-specific parameters live in [`venice_parameters`](#body-venice-parameters).** This endpoint is OpenAI-compatible, but the `venice_parameters` object unlocks features that aren't part of the standard OpenAI API — and many integrators miss them:
+
+  - **Web search & citations** — `enable_web_search`, `enable_web_citations`, `enable_web_scraping`
+  - **Character personas** — `character_slug`
+  - **System prompt control** — `include_venice_system_prompt`
+  - **Reasoning controls** — `disable_thinking`, `strip_thinking_response`
+  - **Privacy** — `enable_e2ee`
+
+  See the full list in the [`venice_parameters`](#body-venice-parameters) section below.
+</Info>
+
 ## Postman Collection
 For additional examples, please see this [Postman Collection](https://www.postman.com/veniceai/workspace/venice-ai-workspace/folder/38652128-5a71391b-5dd8-4fe8-80be-197a958907fe?action=share&creator=38652128&ctx=documentation&active-environment=38652128-ef110f4e-d3e1-43b5-8029-4d6877e62041).
 


### PR DESCRIPTION
## Summary

Addresses feedback that integrators building on Venice often don't realize the API supports Venice-specific parameters (`venice_parameters`) — they assume it's purely OpenAI-style and walk away missing features like web search, character personas, and system-prompt control.

Adds a prominent callout at the top of the **Chat Completions** API reference page that:
- Calls out that `venice_parameters` is Venice-only and easy to miss
- Lists the key features it unlocks (web search & citations, character personas, system prompt control, reasoning controls, E2EE)
- Links to the `venice_parameters` section on the page

This keeps the OpenAPI spec untouched and simply surfaces the section above the auto-generated body params.

## Test plan

- [ ] Open the Chat Completions page on the preview; confirm the callout renders at the top with a distinct background
- [ ] Confirm the `venice_parameters` links scroll to the section
- [ ] Confirm no MDX/build errors
