### PR TITLE
Disable Seedance 2.0 guides in navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -71,8 +71,6 @@
                   "guides/media/image-editing",
                   "guides/media/video-generation",
                   "guides/media/reference-to-video",
-                  "guides/media/seedance-2-0",
-                  "guides/media/seedance-face-consent",
                   "guides/media/voice-cloning",
                   "guides/media/video-upscaling"
                 ]
@@ -335,8 +333,6 @@
                   "pt-BR/guides/media/image-editing",
                   "pt-BR/guides/media/video-generation",
                   "pt-BR/guides/media/reference-to-video",
-                  "pt-BR/guides/media/seedance-2-0",
-                  "pt-BR/guides/media/seedance-face-consent",
                   "pt-BR/guides/media/voice-cloning",
                   "pt-BR/guides/media/video-upscaling"
                 ]
@@ -599,8 +595,6 @@
                   "ar/guides/media/image-editing",
                   "ar/guides/media/video-generation",
                   "ar/guides/media/reference-to-video",
-                  "ar/guides/media/seedance-2-0",
-                  "ar/guides/media/seedance-face-consent",
                   "ar/guides/media/voice-cloning",
                   "ar/guides/media/video-upscaling"
                 ]
@@ -863,8 +857,6 @@
                   "it/guides/media/image-editing",
                   "it/guides/media/video-generation",
                   "it/guides/media/reference-to-video",
-                  "it/guides/media/seedance-2-0",
-                  "it/guides/media/seedance-face-consent",
                   "it/guides/media/voice-cloning",
                   "it/guides/media/video-upscaling"
                 ]
@@ -1127,8 +1119,6 @@
                   "de/guides/media/image-editing",
                   "de/guides/media/video-generation",
                   "de/guides/media/reference-to-video",
-                  "de/guides/media/seedance-2-0",
-                  "de/guides/media/seedance-face-consent",
                   "de/guides/media/voice-cloning",
                   "de/guides/media/video-upscaling"
                 ]
@@ -1391,8 +1381,6 @@
                   "es/guides/media/image-editing",
                   "es/guides/media/video-generation",
                   "es/guides/media/reference-to-video",
-                  "es/guides/media/seedance-2-0",
-                  "es/guides/media/seedance-face-consent",
                   "es/guides/media/voice-cloning",
                   "es/guides/media/video-upscaling"
                 ]
@@ -1655,8 +1643,6 @@
                   "fr/guides/media/image-editing",
                   "fr/guides/media/video-generation",
                   "fr/guides/media/reference-to-video",
-                  "fr/guides/media/seedance-2-0",
-                  "fr/guides/media/seedance-face-consent",
                   "fr/guides/media/voice-cloning",
                   "fr/guides/media/video-upscaling"
                 ]
@@ -1919,8 +1905,6 @@
                   "zh/guides/media/image-editing",
                   "zh/guides/media/video-generation",
                   "zh/guides/media/reference-to-video",
-                  "zh/guides/media/seedance-2-0",
-                  "zh/guides/media/seedance-face-consent",
                   "zh/guides/media/voice-cloning",
                   "zh/guides/media/video-upscaling"
                 ]
@@ -2183,8 +2167,6 @@
                   "ko/guides/media/image-editing",
                   "ko/guides/media/video-generation",
                   "ko/guides/media/reference-to-video",
-                  "ko/guides/media/seedance-2-0",
-                  "ko/guides/media/seedance-face-consent",
                   "ko/guides/media/voice-cloning",
                   "ko/guides/media/video-upscaling"
                 ]

--- a/llms.txt
+++ b/llms.txt
@@ -114,8 +114,6 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Image Editing Guide](https://docs.venice.ai/guides/media/image-editing): Image editing and inpainting techniques
 - [Video Generation Guide](https://docs.venice.ai/guides/media/video-generation): Video generation best practices
 - [Reference to Video](https://docs.venice.ai/guides/media/reference-to-video): Lock in characters, objects, and scenes across AI video generations using reference images on Kling O3 and Grok Imagine R2V
-- [Seedance 2.0](https://docs.venice.ai/guides/media/seedance-2-0): Venice's flagship multimodal video model — text/image/reference-to-video with four workflows (Reference, Edit, Extend, Stitch) inferred from prompt shape
-- [Seedance Face-Media Consent](https://docs.venice.ai/guides/media/seedance-face-consent): One-time consent attestation flow required when Seedance 2.0 requests contain a human face
 - [Voice Cloning](https://docs.venice.ai/guides/media/voice-cloning): Clone a voice from a short reference sample with Chatterbox HD, then generate speech with Venice text-to-speech
 - [Video Upscaling](https://docs.venice.ai/guides/media/video-upscaling): Enhance existing videos to higher resolution (2x/4x) or quality using the Topaz Video Upscale model
 - [x402 Wallet API](https://docs.venice.ai/guides/integrations/x402-venice-api): Use Venice API with Ethereum wallet authentication (no API key required)


### PR DESCRIPTION
## Summary
- Hide the **Seedance 2.0** and **Seedance Face-Media Consent** guides from the docs navigation without deleting them
- Removed both page entries from `docs.json` across all 9 locale trees (root, ar, de, es, fr, it, ko, pt-BR, zh)
- Removed the two matching index entries from `llms.txt`

The `.mdx` guide files are untouched, so re-enabling is just restoring these entries. Note: as Mintlify hidden pages, the guides remain reachable by direct URL — they're only removed from the sidebar and the LLM index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)