### PR TITLE
Fix API reference content/code-rail collision

### DIFF
--- a/style.css
+++ b/style.css
@@ -2680,6 +2680,18 @@
     margin-right: auto !important;
   }
 
+  /* API endpoint pages (frontmatter `openapi:`) use a two-column body: prose on
+     the left and a sticky request/response code rail on the right. Our fixed
+     820px + viewport-centering above ignores that rail, so on narrower viewports
+     the prose slides under it. Scope our centering off for these pages (their
+     path always contains /api-reference/endpoint/, across all locales) and let
+     Mintlify's native layout size the prose so the rail keeps its space. */
+  html[data-current-path*="/api-reference/endpoint/"] #content-area {
+    max-width: none !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
   /* Taller top navigation bar.
      Mintlify sets the navbar content row to h-12 (48px) with items-center, and
      paints the bottom border on an absolute h-full background layer. Growing the

--- a/style.css
+++ b/style.css
@@ -2680,16 +2680,16 @@
     margin-right: auto !important;
   }
 
-  /* API endpoint pages (frontmatter `openapi:`) use a two-column body: prose on
-     the left and a sticky request/response code rail on the right. Our fixed
-     820px + viewport-centering above ignores that rail, so on narrower viewports
-     the prose slides under it. Scope our centering off for these pages (their
-     path always contains /api-reference/endpoint/, across all locales) and let
-     Mintlify's native layout size the prose so the rail keeps its space. */
+  /* API endpoint pages (frontmatter `openapi:`) render a sticky request/response
+     code rail (#content-side-layout, ~28rem) as a flex sibling to the right of
+     the content column. Our viewport-based centering above pushes the column
+     rightward past ~1650px and overruns that rail. Keep the same 820px column,
+     but center it within its own flex track instead of the viewport so it never
+     crosses into the rail. Scoped by path (covers all locales); the plain API
+     pages (Introduction/Rate Limits/Error Codes) are unaffected. */
   html[data-current-path*="/api-reference/endpoint/"] #content-area {
-    max-width: none !important;
-    margin-left: 0 !important;
-    margin-right: 0 !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
 
   /* Taller top navigation bar.


### PR DESCRIPTION
## Summary
- On API reference endpoint pages, the main content column could overlap the sticky request/response code rail at certain viewport widths (~1650–1765px and when zoomed out).
- Root cause: the global `#content-area` rule uses viewport-based centering (`50vw`), which above 1650px pushes the 820px column rightward into the rail's flex track.
- Fix: keep the same 820px column, but on `/api-reference/endpoint/` pages center it within its own flex track instead of the viewport, so it can never cross into the rail. Scoped by path (covers all locales); plain API pages (Introduction/Rate Limits/Error Codes) and all normal docs pages are unaffected.

## Test plan
- [ ] Load an endpoint page (e.g. `/api-reference/endpoint/image/generate`, `/api-reference/endpoint/chat/completions`).
- [ ] Resize/zoom across ~1440px → 1920px; confirm the prose never overlaps the code rail (verified gaps: 1700px→60px, 1765px→92px, 1920px→170px).
- [ ] Confirm normal doc pages keep the existing viewport-centered column.
- [ ] Spot-check a localized endpoint page (e.g. `/es/api-reference/endpoint/image/generate`).

Made with [Cursor](https://cursor.com)