### PR TITLE
docs: zero usd spend callout

### DIFF
--- a/guides/getting-started/generating-api-key.mdx
+++ b/guides/getting-started/generating-api-key.mdx
@@ -16,6 +16,7 @@ Venice API requests are authenticated with Bearer API keys. This guide shows how
 * Sign in to your Venice account.
 * Make sure the account has a spendable balance before calling paid endpoints. You can create a key before funding the account, but model requests will not succeed until the account can consume DIEM, bundled credits, or USD.
 
+
 <Steps>
   <Step title="Open API settings">
     Visit [https://venice.ai/settings/api](https://venice.ai/settings/api). You can also open this page from the Venice app by selecting **API** in your settings.
@@ -58,6 +59,10 @@ Venice API requests are authenticated with Bearer API keys. This guide shows how
     A successful response returns the available models. If you receive an authentication error, confirm that the key was copied completely and that the `Authorization` header is formatted as `Bearer <api-key>`.
   </Step>
 </Steps>
+
+<Warning>
+  Disabling USD spending during API key creation in the Venice app sets your USD spend limit to zero for the given API key. API calls may fail with an insufficient balance error when your available DIEM or bundled credits cannot cover the request, even if your account has a USD balance.
+</Warning>
 
 ## Best practices
 


### PR DESCRIPTION
Adds a callout to the API key generation guide stating that disabling USD spend sets it to zero, which can cause insufficient balance issues if there is not enough DIEM.