### PR TITLE
refactor: Other Integrations page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -100,6 +100,7 @@
                 "pages": [
                   "guides/integrations/claude-code",
                   "guides/integrations/cursor",
+                  "guides/integrations/cline",
                   "guides/integrations/opencode",
                   "guides/integrations/codex-cli",
                   "guides/integrations/aider"

--- a/docs.json
+++ b/docs.json
@@ -90,6 +90,7 @@
                   "guides/integrations/crypto-rpc-agents",
                   "guides/integrations/x402-venice-api",
                   "guides/integrations/jan-ai",
+                  "guides/integrations/brave-leo",
                   "guides/integrations/integrations"
                 ]
               },

--- a/guides/integrations/brave-leo.mdx
+++ b/guides/integrations/brave-leo.mdx
@@ -1,0 +1,145 @@
+---
+title: Brave Leo
+description: Connect Brave Leo to the Venice API for private, browser-native AI chat, page summaries, and optional web search.
+"og:title": "Brave Leo with Venice | Venice API Docs"
+"og:description": "Configure Brave Leo to use Venice through its Bring Your Own Model settings."
+---
+
+[Brave Leo](https://brave.com/leo/) is the AI assistant built into Brave Browser. Leo's Bring Your Own Model (BYOM) feature can connect directly to Venice's OpenAI-compatible chat completions endpoint, letting you use Venice models for chat and page-aware assistance without installing an extension.
+
+<CardGroup cols={3}>
+  <Card title="Browser Native" icon="browser">
+    Chat, summarize pages, and explain selected text in Brave
+  </Card>
+  <Card title="Direct Connection" icon="plug">
+    Send BYOM requests directly from Brave to Venice
+  </Card>
+  <Card title="Privacy Choice" icon="shield-halved">
+    Choose a Venice model with the privacy tier you need
+  </Card>
+</CardGroup>
+
+## Prerequisites
+
+- Brave Browser 1.69 or later on Windows, macOS, or Linux
+- A Venice API key from [venice.ai/settings/api](https://venice.ai/settings/api)
+- A model ID from the [Venice text model catalog](/models/text)
+
+<Note>
+Brave's BYOM feature is available on desktop. The model ID must match a Venice model ID exactly.
+</Note>
+
+## Setup
+
+<Steps>
+  <Step title="Open Leo settings">
+    Open `brave://settings/leo-ai`, or open Leo from Brave's sidebar, select the settings icon, and navigate to **Leo**.
+  </Step>
+
+  <Step title="Add a custom model">
+    Scroll to **Bring your own model** and select **Add new model**.
+  </Step>
+
+  <Step title="Configure the Venice endpoint">
+    Enter the following values:
+
+    | Field | Value |
+    | --- | --- |
+    | Label | `Venice AI` |
+    | Model request name | A model ID from the [text model catalog](/models/text) |
+    | Server endpoint | `https://api.venice.ai/api/v1/chat/completions` |
+    | API key | Your Venice API key |
+
+    If Brave displays **Context size**, set it to the context window supported by your selected model. You can also add an optional system prompt.
+
+    Enter the API key itself without a `Bearer` prefix. Brave adds the authorization header to each request.
+  </Step>
+
+  <Step title="Save and select Venice">
+    Select **Add model**, then set **Venice AI** as the default model for new conversations or choose it from Leo's model selector.
+  </Step>
+
+  <Step title="Test the connection">
+    Open Leo on a webpage and send a prompt such as:
+
+    ```txt
+    Summarize this page in five bullet points.
+    ```
+
+    Leo sends the conversation and relevant page content directly to the Venice endpoint.
+  </Step>
+</Steps>
+
+## Enable Venice web search
+
+Brave does not expose Venice-specific request-body parameters in BYOM. To enable Venice web search, append a [model feature suffix](/api-reference/endpoint/chat/model_feature_suffix) to the model ID in **Model request name**:
+
+```txt
+<model-id>:enable_web_search=auto
+```
+
+To always enable search and include citations, use:
+
+```txt
+<model-id>:enable_web_search=on&enable_web_citations=true
+```
+
+<Info>
+Web search has additional usage-based pricing. See [API pricing](/overview/pricing) for current rates.
+</Info>
+
+## Privacy
+
+When you use a remote BYOM endpoint, Brave connects directly to that provider. Requests bypass Brave's servers, so Brave's proxy and server-side retention protections do not apply to those requests.
+
+Venice does not store or log prompt and response content at its proxy. The selected model determines the runtime privacy tier:
+
+- **Private** models use zero-data-retention infrastructure.
+- **Anonymized** models hide identifying information from the upstream provider, but the provider can process the prompt.
+- **TEE** and **E2EE** models add hardware-backed isolation or client-side encryption where supported.
+
+Check the model's privacy label in the [text model catalog](/models/text) and read [Venice privacy](/overview/privacy) before sending sensitive information.
+
+Brave may keep Leo chat history in local browser storage. You can clear Leo data, use a temporary chat, or disable local chat history in Brave's Leo settings.
+
+## Configuration notes
+
+- Brave requires the full endpoint path: `https://api.venice.ai/api/v1/chat/completions`.
+- Model IDs and availability change over time. Copy the current ID from the [text model catalog](/models/text).
+- Context size should not exceed the selected model's supported context window.
+- Page summaries can send page content to Venice as part of the prompt.
+- Remote Venice requests require an internet connection and consume Venice API credits or your available DIEM allowance.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="401 or authentication error">
+    Confirm that the key comes from [venice.ai/settings/api](https://venice.ai/settings/api). Paste the raw key without `Bearer` and remove any leading or trailing spaces.
+  </Accordion>
+  <Accordion title="Model not found">
+    Copy the model ID exactly from the [text model catalog](/models/text). If you added a feature suffix, first test the model without the suffix.
+  </Accordion>
+  <Accordion title="Network error or no streamed response">
+    Confirm that the server endpoint includes `/api/v1/chat/completions`. Brave Leo expects an OpenAI-compatible streaming response.
+  </Accordion>
+  <Accordion title="Page summaries lack page context">
+    Check Leo's permission to use page content and make sure the current page is accessible to the browser. Internal Brave pages and some protected pages cannot be summarized.
+  </Accordion>
+</AccordionGroup>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Brave BYOM Guide" icon="book" href="https://support.brave.com/hc/en-us/articles/34070140231821-How-do-I-use-the-Bring-Your-Own-Model-BYOM-with-Brave-Leo">
+    Official Brave setup and privacy details
+  </Card>
+  <Card title="Venice Text Models" icon="list" href="/models/text">
+    Browse current model IDs and privacy tiers
+  </Card>
+  <Card title="Model Feature Suffixes" icon="sliders" href="/api-reference/endpoint/chat/model_feature_suffix">
+    Enable web search and other Venice features
+  </Card>
+  <Card title="Generate an API Key" icon="key" href="/guides/getting-started/generating-api-key">
+    Create and securely store a Venice API key
+  </Card>
+</CardGroup>

--- a/guides/integrations/cline.mdx
+++ b/guides/integrations/cline.mdx
@@ -1,0 +1,132 @@
+---
+title: Cline
+description: Configure the Cline coding assistant in VS Code to use private Venice models through an OpenAI-compatible API provider.
+"og:title": "Cline with Venice | Venice API Docs"
+"og:description": "Connect Cline in VS Code to Venice AI using an OpenAI-compatible base URL"
+---
+
+[Cline](https://cline.bot/) is an AI coding assistant for VS Code that can read and edit files, run commands, and work through multi-step development tasks. Venice works through Cline's OpenAI-compatible provider settings.
+
+<CardGroup cols={3}>
+  <Card title="VS Code Integration" icon="code">
+    Use Venice models without leaving your editor
+  </Card>
+  <Card title="OpenAI Compatible" icon="plug">
+    Connect through Venice's `/chat/completions` endpoint
+  </Card>
+  <Card title="Model Flexibility" icon="microchip">
+    Choose any compatible Venice text model
+  </Card>
+</CardGroup>
+
+---
+
+## Prerequisites
+
+- A Venice API key from [venice.ai/settings/api](https://venice.ai/settings/api)
+- [Visual Studio Code](https://code.visualstudio.com/) installed
+- The [Cline extension](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev) installed in VS Code
+
+---
+
+## Setup
+
+<Steps>
+  <Step title="Open Cline settings">
+    Select the Cline icon in the VS Code activity bar, then select the gear icon to open Cline's settings.
+  </Step>
+
+  <Step title="Choose the API provider">
+    Set **API Provider** to **OpenAI Compatible**.
+  </Step>
+
+  <Step title="Configure Venice">
+    Enter the following values:
+
+    | Setting | Value |
+    | --- | --- |
+    | Base URL | `https://api.venice.ai/api/v1` |
+    | API Key | Your Venice API key |
+    | Model ID | A model ID from the [text model catalog](/models/text) |
+
+    For example, use `zai-org-glm-5-1` as the Model ID.
+
+    Enter the API key itself, without a `Bearer` prefix. Keep the Base URL at `/api/v1`; Cline adds the `/chat/completions` path.
+  </Step>
+
+  <Step title="Configure model capabilities">
+    Expand **Model Configuration** and set the context window and maximum output tokens to match the selected model. Enable the capabilities that the model supports, including image input or computer use when applicable.
+
+    Check the selected model in the [text model catalog](/models/text) before enabling optional capabilities.
+  </Step>
+
+  <Step title="Save and test">
+    Save the provider settings, open a project, and give Cline a small task such as:
+
+    ```txt
+    Review the current file and suggest one safe improvement.
+    ```
+
+    Review each file or command permission before approving it.
+  </Step>
+</Steps>
+
+---
+
+## Verify the Venice API
+
+If Cline cannot connect, confirm the API key and available model IDs independently:
+
+```bash
+curl https://api.venice.ai/api/v1/models \
+  -H "Authorization: Bearer $VENICE_API_KEY"
+```
+
+Copy a model's `id` exactly into Cline's **Model ID** field.
+
+---
+
+## Configuration Notes
+
+- Use `https://api.venice.ai/api/v1` as the Base URL, not the full `/chat/completions` endpoint.
+- Model IDs can change over time. Use the [text model catalog](/models/text) or `GET /models` instead of relying on an older example.
+- Cline's context-window and output-token settings affect how it budgets requests. Match them to the selected model for the best results.
+- Keep your Venice API key private. Do not paste it into source files or commit it to git.
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="401 or authentication error">
+    Confirm that the API key comes from [venice.ai/settings/api](https://venice.ai/settings/api). Paste the raw key into Cline without `Bearer` or extra whitespace.
+  </Accordion>
+  <Accordion title="Model not found">
+    Confirm that the Model ID appears in the [text model catalog](/models/text) or the response from `GET /models`, then copy it exactly.
+  </Accordion>
+  <Accordion title="Connection or endpoint error">
+    Confirm that **API Provider** is **OpenAI Compatible** and the Base URL is exactly `https://api.venice.ai/api/v1`.
+  </Accordion>
+  <Accordion title="Cline cannot use tools or edit files">
+    Open **Model Configuration**, confirm that the selected model supports the required capabilities, and enable computer use if Cline exposes that option for the model.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Original Venice Cline Guide" icon="book" href="https://venice.ai/blog/how-to-use-the-venice-api-with-cline-in-vscode-a-developers-guide">
+    Read the canonical Venice article
+  </Card>
+  <Card title="Venice Text Models" icon="list" href="/models/text">
+    Browse available Venice model IDs
+  </Card>
+  <Card title="Cline Provider Docs" icon="gear" href="https://docs.cline.bot/provider-config/openai-compatible">
+    OpenAI-compatible provider settings
+  </Card>
+  <Card title="Venice API Reference" icon="code" href="/api-reference/api-spec">
+    Full endpoint and parameter docs
+  </Card>
+</CardGroup>

--- a/guides/integrations/integrations.mdx
+++ b/guides/integrations/integrations.mdx
@@ -1,56 +1,24 @@
 ---
-title: "Additional Integrations"
+title: "Community Integrations"
 description: "Directory of third-party tools, browsers, IDEs, agent frameworks, and community projects with Venice AI integrations and quickstart configuration tips."
 "og:title": "Additional Integrations | Venice API Docs"
 "og:description": "Third-party tools and community projects with Venice AI integrations."
 ---
+### Community projects
+The following integrations have been created by the community to help make it easier for you to use the Venice API.
 
-[How to use Venice API](https://venice.ai/blog/how-to-use-venice-api) reference guide.
+- Blog posts
+  - [Venice AI Discord Bot](https://bobbiebeach.space/blog/venice-ai-discord-bot-full-setup-guide-features/)
 
-<Note>
-Several integrations have their own dedicated guides — see [AI Agents](/guides/integrations/ai-agents), [OpenClaw](/guides/integrations/openclaw-bot), [NanoClaw](/guides/integrations/nanoclaw-venice), [Jan AI](/guides/integrations/jan-ai), [Cursor](/guides/integrations/cursor), [Claude Code](/guides/integrations/claude-code), [OpenCode](/guides/integrations/opencode), [Codex CLI](/guides/integrations/codex-cli), and [Aider](/guides/integrations/aider).
-</Note>
+- Software libraries
+  - [llm-venice](https://github.com/ar-jan/llm-venice)
+  - [unOfficial PHP SDK for Venice](https://github.com/georgeglarson/venice-ai-php)
 
-## Venice Confirmed Integrations
 
-* Coding
-
-  * [Cline](https://venice.ai/blog/how-to-use-the-venice-api-with-cline-in-vscode-a-developers-guide) (VSC Extension)
-
-  * [ROO Code](https://venice.ai/blog/how-to-use-the-roo-ai-coding-assistant-in-private-with-venice-api-a-quick-guide) (VSC Extension)
-
-  * [VOID IDE](https://venice.ai/blog/how-to-use-open-source-ai-code-editor-void-in-private-with-venice-api)
-
-* Assistants
-
-  * [Brave Leo Browser](https://venice.ai/blog/how-to-use-brave-leo-ai-with-venice-api-a-privacy-first-browser-ai-assistant)
-
-## Community Confirmed
-
-These integrations have been confirmed by the community. Venice is in the process of confirming these integrations and creating how-to guides for each of the following:
-
-* Agents/Bots
-
-  * [Venice AI Discord Bot](https://bobbiebeach.space/blog/venice-ai-discord-bot-full-setup-guide-features/)
-
-  * [JanitorAI](https://janitorai.com/)
-
-  * [1Claw](https://1claw.xyz), secure infrastructure for AI agents; routes private inference to Venice via the Shroud TEE proxy
-
-* Coding
-
-  * [Alexcodes.app](https://alexcodes.app/)
-
-* Assistants
-
-  * [llm-venice](https://github.com/ar-jan/llm-venice)
-
-  * [unOfficial PHP SDK for Venice](https://github.com/georgeglarson/venice-ai-php)
-
-  * [Msty](https://msty.app)
-
-  * [Open WebUI](https://github.com/open-webui/open-webui)
-
-  * [Librechat](https://www.librechat.ai/)
-
-  * [ScreenSnapAI](https://screensnap.ai/)
+### Third party compatible applications
+- [JanitorAI](https://janitorai.com/)
+- [1Claw](https://1claw.xyz), secure infrastructure for AI agents; routes private inference to Venice via the Shroud TEE proxy
+- [Msty](https://msty.app)
+- [Open WebUI](https://github.com/open-webui/open-webui)
+- [Librechat](https://www.librechat.ai/)
+- [ScreenSnapAI](https://screensnap.ai/)


### PR DESCRIPTION
- Refactors Brave LEO and Cline into their own integration guide pages
- Splits the Other Integrations page into two sides: a Community Projects page and a Compatible Third Party Applications page. This will set the ground work for a "Venice Works with" style page.