### PR TITLE
fix: correct four stale facts in the hosted skill.md

### DIFF
--- a/skill.md
+++ b/skill.md
@@ -33,7 +33,7 @@ curl https://api.venice.ai/api/v1/chat/completions \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "venice-uncensored-1-2",
+    "model": "kimi-k3",
     "messages": [{"role": "user", "content": "Hello"}]
   }'
 ```
@@ -104,7 +104,7 @@ Venice-only features ride in a `venice_parameters` object on `/chat/completions`
 - `enable_e2ee`: end-to-end encryption on E2EE-capable models
 
 Feature suffixes on the model ID do the same thing, for example
-`venice-uncensored-1-2:web` or `venice-uncensored-1-2:enable_web_search=on`.
+`kimi-k3:web` or `kimi-k3:enable_web_search=on`.
 
 `POST /responses` accepts a narrower set: `character_slug`, `enable_e2ee`,
 `enable_web_search`, `enable_web_scraping`, `enable_web_citations`,

--- a/skill.md
+++ b/skill.md
@@ -33,7 +33,7 @@ curl https://api.venice.ai/api/v1/chat/completions \
   -H "Authorization: Bearer $VENICE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "venice-uncensored",
+    "model": "venice-uncensored-1-2",
     "messages": [{"role": "user", "content": "Hello"}]
   }'
 ```
@@ -49,8 +49,11 @@ curl https://api.venice.ai/api/v1/models/traits \
   -H "Authorization: Bearer $VENICE_API_KEY"
 ```
 
-Traits like `text:default`, `text:uncensored`, and `image:fast` always map to a
-live model. Filter the full catalog with `GET /models?type=image|video|audio|tts|embedding`.
+The response maps trait names to whichever model currently fills that role. Text
+traits are `default`, `most_intelligent`, `most_uncensored`, `default_reasoning`,
+`default_vision`, `default_code`, and `function_calling_default`; image traits
+include `default`, `fastest`, `highest_quality`, and `most_uncensored`.
+Filter the full catalog with `GET /models?type=image|video|audio|tts|embedding`.
 Before relying on a feature, check that model's `model_spec.capabilities` flags
 (`supportsWebSearch`, `supportsReasoning`, `supportsE2EE`, `supportsFunctionCalling`,
 `supportsVision`, and similar). Per-model pricing is on `model_spec.pricing`.
@@ -101,10 +104,13 @@ Venice-only features ride in a `venice_parameters` object on `/chat/completions`
 - `enable_e2ee`: end-to-end encryption on E2EE-capable models
 
 Feature suffixes on the model ID do the same thing, for example
-`venice-uncensored:web` or `venice-uncensored:enable_web_search=on`.
+`venice-uncensored-1-2:web` or `venice-uncensored-1-2:enable_web_search=on`.
 
-`venice_parameters` is **rejected** on `POST /responses`. Use `/chat/completions`
-when you need it.
+`POST /responses` accepts a narrower set: `character_slug`, `enable_e2ee`,
+`enable_web_search`, `enable_web_scraping`, `enable_web_citations`,
+`include_venice_system_prompt`, and `include_search_results_in_stream`.
+Anything else is dropped without an error, so use `/chat/completions` when you
+need `enable_x_search` or the thinking controls.
 
 ## Authentication
 
@@ -160,7 +166,7 @@ This file is a map. Venice maintains one self-contained skill per API surface,
 versioned against the OpenAPI spec, at **https://github.com/veniceai/skills**.
 
 ```bash
-npx skills add docs.venice.ai
+npx skills add https://docs.venice.ai
 # or, for the full per-surface set:
 git clone https://github.com/veniceai/skills.git ~/src/venice-skills
 ln -s ~/src/venice-skills/skills ~/.claude/skills/venice


### PR DESCRIPTION
Follow-up to #377. David spotted two of these on the marketing-cms copy of this file ([veniceai/marketing-cms#163](https://github.com/veniceai/marketing-cms/pull/163)), and since that PR was derived from this one, the same problems are already live at `docs.venice.ai/skill.md`. Verifying them turned up two more.

Everything below was checked against the live API or the outerface source, not against `swagger.yaml`.

## The install command fails

`npx skills add docs.venice.ai` does not work. I ran it:

```
$ npx skills add docs.venice.ai
x  Failed to clone repository
   Failed to clone docs.venice.ai: fatal: repository 'docs.venice.ai' does not exist
```

`parseSource()` in `vercel-labs/skills` has no bare-domain branch. A bare domain has no slash, so the `owner/repo` shorthand regex misses it; `isWellKnownUrl()` returns false because it requires an `http(s)://` prefix; and it falls through to the `{ type: 'git' }` default and tries to clone.

Adding the scheme fixes it. `npx skills add https://docs.venice.ai` resolves through `/.well-known/agent-skills/index.json` and installs cleanly, which I confirmed end to end. The advertised artifact URL returns 200 and its SHA-256 matches the digest in the index.

## The example model is hidden from `GET /models`

`venice-uncensored` does work, because `VeniceUncensored12` carries it in `aliasIds` and `find-api-model.ts` resolves aliases at request time. But the old catalog entry is `apiModel: false`, so the ID is absent from all 105 text models in the live `GET /models` and absent from `compatibility_mapping`.

That matters here specifically, because line 23 of this file tells the agent to never hardcode model IDs and to resolve them from `GET /models`. An agent that follows our own instruction cannot verify our own example. Switched to `venice-uncensored-1-2`, which is the listed canonical ID and also what the `most_uncensored` trait resolves to.

## Three of the named traits do not exist

The file cited `text:default`, `text:uncensored`, and `image:fast`. Against the live endpoint, the text traits are `default`, `most_intelligent`, `most_uncensored`, `default_reasoning`, `default_vision`, `default_code`, and `function_calling_default`. The image traits are `default`, `fastest`, `highest_quality`, `most_uncensored`, and `eliza-default`. So `uncensored` and `fast` were both wrong, and I could find no evidence that the `text:` prefix is usable as a model ID; traits come back as a name-to-ID map. Replaced with the real names and a description of how the response is shaped.

## `/responses` does not reject `venice_parameters`

The file claimed it was rejected outright. `api-responses-schema.ts` has `venice_parameters: ResponsesVeniceParametersSchema` and the handler reads it. What's true is that it accepts a narrower set than `/chat/completions`: `character_slug`, `enable_e2ee`, `enable_web_search`, `enable_web_scraping`, `enable_web_citations`, `include_venice_system_prompt`, and `include_search_results_in_stream`. The inner schema has no `.passthrough()`, so anything else is silently stripped rather than erroring. Documented the real list and the silent-drop behaviour.

## Also checked, no change needed

I validated all nine model IDs in this file against the 286 live models and every one resolves, including the whole "Common text models" table. The upscale gotcha section is accurate. All six outbound links in the footer return 200. The model feature suffix syntax is real; `processModelFeatureSuffixes` splits on `:` and then `&`.

## Related

The same two fixes are pushed to [veniceai/marketing-cms#163](https://github.com/veniceai/marketing-cms/pull/163). The MCP server had the same hidden-alias default and is fixed in [veniceai/venice-mcp-server#26](https://github.com/veniceai/venice-mcp-server/pull/26).
