### PR TITLE
Fix models catalog sort when searching

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -2613,7 +2613,7 @@
                matchesPrivacy(model);
       });
 
-      let sorted = sortModels(filtered);
+      let candidates = filtered;
       let showingClosestMatches = false;
 
       if (query) {
@@ -2630,8 +2630,12 @@
         const visibleScored = strongScored.length > 0 ? strongScored : (directScored.length > 0 ? directScored : scored);
 
         showingClosestMatches = scored.length > 0 && directScored.length === 0;
-        sorted = visibleScored.map(item => item.model);
+        // Keep search-relevance order for Recommended; otherwise apply the
+        // selected sort (Newest/Oldest/etc.) after search filtering.
+        candidates = visibleScored.map(item => item.model);
       }
+
+      const sorted = sortModels(candidates);
 
       const n = sorted.length;
       const countLabel = (LOCALE === 'en')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Searching on the Model Catalog (e.g. `gpt` + **Newest**) discarded the selected sort and kept search-relevance / API order, so older GPT models appeared above newer ones.

## Fix
In `renderModels`, apply `sortModels` after search filtering. Recommended (`default`) still preserves search-relevance order; Newest/Oldest/Name/Price now apply to the matched results.

## Test plan
- [ ] Open Model Catalog, search `gpt`, sort **Newest** — GPT-5.6 / newest GPT entries should appear first
- [ ] Same search with **Oldest** — oldest GPT entries first
- [ ] Clear search with **Newest** — still newest-first across all models
- [ ] **Recommended** with a search query — still relevance-ordered
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://veniceai.slack.com/archives/C08KMNC77N1/p1786312738847899?thread_ts=1786312738.847899&cid=C08KMNC77N1)

<div><a href="https://cursor.com/agents/bc-d212581f-724f-51e5-ad3d-0741b224ed5f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d212581f-724f-51e5-ad3d-0741b224ed5f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

