### PR TITLE
Document Seedance source-matched aspect/duration on video API (ENG-986)

### DIFF
--- a/api-reference/endpoint/video/queue.mdx
+++ b/api-reference/endpoint/video/queue.mdx
@@ -11,7 +11,7 @@ Private models also return a `download_url` for the finished video. It is a shor
 
 ### Seedance 2.0 & 2.5
 
-For `seedance-2-0-*-basic` and `seedance-2-5-*-basic` models (text-to-video, image-to-video, reference-to-video, plus the Seedance 2.0 `-fast-*` variants), see the [Seedance 2.0 & 2.5 Guide](/guides/media/seedance-2-0) for the four-workflow model (Reference / Edit / Extend / Stitch), family-specific multimodal limits, public API media policy, and pricing details.
+For `seedance-2-0-*-basic` and `seedance-2-5-*-basic` models (text-to-video, image-to-video, reference-to-video, plus the Seedance 2.0 `-fast-*` variants), see the [Seedance 2.0 & 2.5 Guide](/guides/media/seedance-2-0) for the four-workflow model (Reference / Edit / Extend / Stitch), source-matched `aspect_ratio` / `duration` values, family-specific multimodal limits, public API media policy, and pricing details.
 
 ### Public Seedance media policy
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -98,6 +98,22 @@ Modify Elements:
 
 The last example combines Edit with an image reference — perfectly legal, the model uses `<Image 1>` as a visual donor for the replacement.
 
+### Source-matched aspect ratio and duration
+
+For Seedance reference-to-video **edit / extend**, you can ask the output to follow the source clip instead of picking a fixed ratio or length:
+
+| Field | Values | Behavior |
+| --- | --- | --- |
+| `aspect_ratio` | `adaptive` or `auto` | Output aspect ratio matches the source video (Seedance 2.0 and 2.5 R2V) |
+| `duration` | `-1` or `auto` | Output length matches the source video (Seedance **2.5** R2V edit; source must be 4–30s) |
+
+Requirements:
+
+- **Queue:** any source-matched value requires `reference_video_urls`.
+- **Quote:** any source-matched value requires `reference_video_total_duration`. Source-matched duration bills `ceil(reference_video_total_duration)` seconds.
+- Ratio and duration are independent — you can match one without the other.
+- For **extend**, prefer a fixed `duration` (how long to generate) and optionally `aspect_ratio: "adaptive"`. Source-matched `duration` is for edit-style “same length as source” jobs.
+
 ### Extend workflow
 
 Continue a single clip forward or backward in time. **By default Seedance returns only the new content** — not the original input concatenated with the extension. This is by design, for transition continuity; if you want the input clip preserved alongside the extension, say so explicitly:
@@ -223,6 +239,21 @@ curl -X POST https://api.venice.ai/api/v1/video/quote \
     "resolution": "1080p",
     "aspect_ratio": "16:9",
     "reference_video_total_duration": 5
+  }'
+```
+
+Source-matched Seedance 2.5 edit quote (bills from the source length):
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/quote \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-5-reference-to-video-basic",
+    "duration": "auto",
+    "resolution": "720p",
+    "aspect_ratio": "adaptive",
+    "reference_video_total_duration": 5.2
   }'
 ```
 
@@ -358,12 +389,29 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
     "model": "seedance-2-0-reference-to-video-basic",
     "prompt": "Strictly edit <Video 1>, changing its weather from sunny to a heavy rainstorm, with all original motions and camera work preserved.",
     "reference_video_urls": ["https://example.com/sunny-scene.mp4"],
-    "reference_video_total_duration": 5,
     "duration": "5s",
-    "aspect_ratio": "16:9",
+    "aspect_ratio": "adaptive",
     "resolution": "1080p"
   }'
 ```
+
+### Seedance 2.5 edit — source-matched duration and aspect
+
+```bash
+curl -X POST https://api.venice.ai/api/v1/video/queue \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-5-reference-to-video-basic",
+    "prompt": "Strictly edit <Video 1>, changing its weather from sunny to a heavy rainstorm, with all original motions and camera work preserved.",
+    "reference_video_urls": ["https://example.com/sunny-scene.mp4"],
+    "duration": "auto",
+    "aspect_ratio": "adaptive",
+    "resolution": "720p"
+  }'
+```
+
+`duration: "auto"` (or `"-1"`) and `aspect_ratio: "adaptive"` (or `"auto"`) make the output follow the source clip. See [Source-matched aspect ratio and duration](#source-matched-aspect-ratio-and-duration).
 
 ### Edit workflow with image grounding
 
@@ -376,9 +424,8 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
     "prompt": "Replace the perfume featured in <Video 1> with the face cream from <Image 1>, with all original motions and camera work preserved.",
     "reference_video_urls": ["https://example.com/perfume-ad.mp4"],
     "reference_image_urls": ["https://example.com/face-cream.png"],
-    "reference_video_total_duration": 4,
     "duration": "5s",
-    "aspect_ratio": "16:9",
+    "aspect_ratio": "adaptive",
     "resolution": "1080p"
   }'
 ```
@@ -393,9 +440,8 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
     "model": "seedance-2-0-reference-to-video-basic",
     "prompt": "Extend <Video 1>, generate a dramatic chase scene through narrow alleys at dusk, with neon signs flickering and rain on the pavement.",
     "reference_video_urls": ["https://example.com/alley-intro.mp4"],
-    "reference_video_total_duration": 4,
     "duration": "5s",
-    "aspect_ratio": "16:9",
+    "aspect_ratio": "adaptive",
     "resolution": "1080p"
   }'
 ```
@@ -454,6 +500,7 @@ Seedance **2.0** caps R2V at **9 images** and **3 videos**. Seedance **2.5** rai
 
 - **2.0:** per-clip reference video/audio `[2, 15]` s; combined video/audio ≤ 15 s; output 4–15 s.
 - **2.5:** per-clip reference video/audio `[2, 30]` s; combined video/audio ≤ 30 s; output 4–30 s.
+- **Source-matched duration** (`-1` / `auto` on Seedance 2.5): source clip must be 4–30 s, and `reference_video_urls` (queue) or `reference_video_total_duration` (quote) is required.
 
 Trim clips client-side before submission.
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5,7 +5,7 @@ info:
   description: The Venice.ai API.
   termsOfService: https://venice.ai/legal/tos
   title: Venice.ai API
-  version: "20260810.003745"
+  version: "20260811.123440"
   x-guidance: >-
     Venice.ai is an OpenAI-compatible inference API supporting text, image,
     audio, and video generation.
@@ -3632,10 +3632,15 @@ components:
             - 28s
             - 29s
             - 30s
+            - "-1"
             - 1 gen
+            - auto
             - Auto
           description: The duration of the video to generate. Available options vary by
-            model.
+            model. For Seedance 2.5 reference-to-video edit jobs, `-1` or `auto`
+            matches output length to the source clip (requires
+            reference_video_urls on queue, or reference_video_total_duration on
+            quote; source must be 4–30s).
           example: 10s
         aspect_ratio:
           type: string
@@ -3654,7 +3659,10 @@ components:
             - adaptive
             - auto
           description: The aspect ratio of the video. Available options vary by model.
-            Some models do not support aspect_ratio.
+            Some models do not support aspect_ratio. For Seedance 2.x
+            reference-to-video edit/extend, `adaptive` or `auto` matches output
+            aspect ratio to the source clip (requires reference_video_urls on
+            queue, or reference_video_total_duration on quote).
           example: 16:9
         resolution:
           type: string
@@ -3848,9 +3856,15 @@ components:
             - 28s
             - 29s
             - 30s
+            - "-1"
             - 1 gen
+            - auto
             - Auto
-          description: The duration of the video. Available options vary by model.
+          description: The duration of the video. Available options vary by model. For
+            Seedance 2.5 reference-to-video edit jobs, `-1` or `auto` matches
+            output length to the source clip (requires reference_video_urls on
+            queue, or reference_video_total_duration on quote; source must be
+            4–30s).
           example: 10s
         aspect_ratio:
           type: string
@@ -3869,7 +3883,10 @@ components:
             - adaptive
             - auto
           description: The aspect ratio. Required for some models with megapixel-rate
-            pricing.
+            pricing. For Seedance 2.x reference-to-video edit/extend, `adaptive`
+            or `auto` matches output aspect ratio to the source clip (requires
+            reference_video_urls on queue, or reference_video_total_duration on
+            quote).
           example: 16:9
         resolution:
           type: string
@@ -3914,12 +3931,14 @@ components:
         reference_video_total_duration:
           type: number
           minimum: 0
-          description: For R2V models (e.g. Seedance 2.0 R2V), the aggregate duration in
-            seconds of all reference videos to include in the quote (max 150s;
-            per-clip 2–15s, total ≤15s for Seedance). When provided, the quote
-            reflects the BytePlus 'input with video' rate tier and the
-            (input+output)×pixels token formula. When omitted, the quote returns
-            the no-reference baseline.
+          description: For R2V models (e.g. Seedance 2.0 / 2.5 R2V), the aggregate
+            duration in seconds of all reference videos to include in the quote
+            (max 150s; per-clip and family caps vary by model). When provided,
+            the quote reflects the BytePlus 'input with video' rate tier and the
+            (input+output)×pixels token formula. Required when quoting Seedance
+            source-matched duration (`-1`/`auto`) or aspect ratio
+            (`adaptive`/`auto`). When omitted for ordinary fixed-duration
+            quotes, the quote returns the no-reference baseline.
           example: 5
       required:
         - model


### PR DESCRIPTION
## Summary
- Document Seedance R2V source-matched `aspect_ratio` (`adaptive`/`auto`) and `duration` (`-1`/`auto`) in the English Seedance guide, with quote/queue examples and troubleshooting.
- Sync `swagger.yaml` so OpenAPI lists `-1`/`auto` duration and Seedance source-matched field descriptions.
- Point the video queue API reference blurb at the new guide section.

Pairs with veniceai/outerface#9639.

## Test plan
- [ ] Preview Seedance guide: source-matched section, 2.5 edit example, quote example
- [ ] Confirm OpenAPI `/video/queue` and `/video/quote` show `-1` and `auto` on duration with the new descriptions
- [ ] Locale pages regenerate via Mintlify after merge (English-only edit)


Made with [Cursor](https://cursor.com)