### PR TITLE
Improve the OpenAI migration guide

### DIFF
--- a/guides/getting-started/openai-migration.mdx
+++ b/guides/getting-started/openai-migration.mdx
@@ -9,9 +9,8 @@ Venice AI is a **drop-in replacement** for OpenAI. Same SDK, same code — just 
 
 ## The 2-Line Migration
 
-### Python
-
-```python
+<CodeGroup>
+```python Python
 # Before (OpenAI)
 from openai import OpenAI
 client = OpenAI()
@@ -19,37 +18,36 @@ client = OpenAI()
 # After (Venice) — change api_key and base_url
 from openai import OpenAI
 client = OpenAI(
-    api_key="your-venice-api-key",          # ← Change 1
-    base_url="https://api.venice.ai/api/v1"  # ← Change 2
+    api_key="your-venice-api-key",           # ← Change 1
+    base_url="https://api.venice.ai/api/v1",  # ← Change 2
 )
 ```
 
-### Node.js
-
-```javascript
+```javascript Node.js
 // Before (OpenAI)
-import OpenAI from 'openai';
+import OpenAI from "openai";
 const client = new OpenAI();
 
 // After (Venice)
-import OpenAI from 'openai';
+import OpenAI from "openai";
 const client = new OpenAI({
-  apiKey: 'your-venice-api-key',
-  baseURL: 'https://api.venice.ai/api/v1',
+  apiKey: "your-venice-api-key",
+  baseURL: "https://api.venice.ai/api/v1",
 });
 ```
 
-### cURL
-
-```bash
+```bash cURL
 # Before
 curl https://api.openai.com/v1/chat/completions ...
 
 # After — just change the URL and key
 curl https://api.venice.ai/api/v1/chat/completions ...
 ```
+</CodeGroup>
 
-### Environment Variables
+Generate a key from [venice.ai/settings/api](https://venice.ai/settings/api) or follow the [API key guide](/guides/getting-started/generating-api-key).
+
+### Environment variables
 
 ```bash
 # Before
@@ -62,150 +60,101 @@ OPENAI_BASE_URL=https://api.venice.ai/api/v1
 ```
 
 <Tip>
-Many libraries and tools read `OPENAI_API_KEY` and `OPENAI_BASE_URL` automatically. Just updating these env vars may be all you need.
+Many libraries and tools read `OPENAI_API_KEY` and `OPENAI_BASE_URL` automatically. Updating these env vars may be all you need. Some tools still use `OPENAI_API_BASE` for the same URL.
 </Tip>
 
-## Model Mapping
+## Models
 
-| OpenAI Model | Venice Equivalent | Type | Pricing (Input/Output per 1M) |
-|-------------|-------------------|------|------|
-| gpt-4o | `zai-org-glm-4.7` (Private) | Text | $0.55 / $2.65 |
-| gpt-4o | `openai-gpt-52` (Anonymized) | Text | $2.19 / $17.50 |
-| gpt-4o-mini | `qwen3-4b` | Text | $0.05 / $0.15 |
-| gpt-4-turbo | `mistral-31-24b` | Text | $0.50 / $2.00 |
-| o1 / o3 | `qwen3-235b-a22b-thinking-2507` (Private) | Reasoning | $0.45 / $3.50 |
-| o1 / o3 | `grok-41-fast` (Anonymized) | Reasoning | $0.50 / $1.25 |
-| gpt-4-vision | `mistral-31-24b` or `qwen3-vl-235b-a22b` | Vision | $0.50 / $2.00 |
-| text-embedding-3-small | `text-embedding-bge-m3` | Embeddings | $0.15 / $0.60 |
-| dall-e-3 | `qwen-image` (Private, $0.01) or `flux-2-pro` | Image | From $0.01 |
-| whisper | `nvidia/parakeet-tdt-0.6b-v3` | STT | $0.0001/sec |
-| tts-1 | `tts-kokoro` | TTS | $3.50/1M chars |
+Pass a Venice model ID, a trait such as `default` or `most_uncensored`, or a familiar OpenAI-style name. Venice maps OpenAI names through [compatibility mapping](/api-reference/endpoint/models/compatibility_mapping). Traits always resolve to the current model for that role — see [model traits](/api-reference/endpoint/models/traits).
 
-## Feature Compatibility
+Browse the live catalog on [Text models](/models/text) and [Pricing](/overview/pricing). For a first-request walkthrough, see the [Quickstart](/getting-started/quick-start).
+
+## Feature compatibility
 
 | Feature | OpenAI | Venice | Notes |
 |---------|--------|--------|-------|
 | Chat Completions | ✅ | ✅ | Fully compatible |
-| Streaming | ✅ | ✅ | SSE format identical |
+| Streaming | ✅ | ✅ | Same SSE format |
 | Function Calling | ✅ | ✅ | Same `tools` parameter |
 | Structured Output | ✅ | ✅ | Same `response_format` |
 | Vision | ✅ | ✅ | Same content array format |
 | Embeddings | ✅ | ✅ | Same API |
-| Image Generation | ✅ | ✅ | OpenAI-compatible via `/images/generations`* |
+| Image Generation | ✅ | ✅ | OpenAI-compatible via `/images/generations` |
 | TTS | ✅ | ✅ | Compatible |
 | STT | ✅ | ✅ | Compatible |
-| Assistants API | ✅ | ❌ | Use Characters or Minds instead |
+| Responses API | ✅ | ✅ | Alpha |
+| Assistants API | ✅ | ❌ | Use [Characters](/guides/features/characters) or [function calling](/guides/features/function-calling) |
 | Batch API | ✅ | ❌ | Not yet available |
 | Fine-tuning | ✅ | ❌ | Not available |
 
-*Venice also provides an OpenAI-compatible endpoint at `POST /images/generations` for easier migration from DALL-E. For Venice's native image API with additional options, see [Image Generate](/api-reference/endpoint/image/generate).
+For native image options beyond the OpenAI-compatible endpoint, see [Image generation](/guides/media/image-generation).
 
-## Venice-Only Features
+## Venice-only features
 
-Venice offers capabilities OpenAI doesn't:
+Pass Venice-specific options through `extra_body` as `venice_parameters`. Built-in web search is the usual first extra:
 
-### 1. Built-in Web Search
 ```python
 response = client.chat.completions.create(
-    model="venice-uncensored",
+    model="default",
     messages=[{"role": "user", "content": "Latest AI news today"}],
     extra_body={
         "venice_parameters": {
             "enable_web_search": "auto"
         }
-    }
+    },
 )
 ```
 
-### 2. Web Scraping
-```python
-response = client.chat.completions.create(
-    model="venice-uncensored",
-    messages=[{"role": "user", "content": "Summarize https://example.com/article"}],
-    extra_body={
-        "venice_parameters": {
-            "enable_web_scraping": True
-        }
-    }
-)
-```
+The same pattern covers web scraping, citations, and [Characters](/guides/features/characters). If a client cannot change the request body, append a [model feature suffix](/api-reference/endpoint/chat/model_feature_suffix) such as `default:enable_web_search=auto`.
 
-### 3. Characters (AI Personas)
-```python
-response = client.chat.completions.create(
-    model="venice-uncensored",
-    messages=[{"role": "user", "content": "Tell me about yourself"}],
-    extra_body={
-        "venice_parameters": {
-            "character_slug": "venice-ai"
-        }
-    }
-)
-```
+Venice also has native [video](/guides/media/video-generation), [music](/guides/media/music-and-sound-effects), [web retrieval](/guides/tools/web-retrieval), and [x402](/guides/integrations/x402-venice-api) APIs alongside the OpenAI-compatible surface.
 
-### 4. Uncensored Models
-Venice's private models have no content filtering, making them suitable for:
-- Creative writing without guardrails
-- Security research and red teaming
-- Honest analysis without refusal patterns
-- Medical/legal information without disclaimers
-
-### 5. Video Generation
-```python
-# Queue a video generation job
-import requests
-
-response = requests.post(
-    "https://api.venice.ai/api/v1/video/queue",
-    headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-    json={
-        "model": "wan-2.6-text-to-video",
-        "prompt": "A serene lake at sunset with gentle waves",
-        "resolution": "720p",
-        "duration": 5,
-    }
-)
-job_id = response.json()["id"]
-```
-
-## Why Migrate?
-
-### Privacy
-- **Zero data retention** on private models — your prompts are never stored
-- **No training on your data** — ever
-- OpenAI retains data for 30 days and may use it for safety research
-
-### Cost
-- Private models are **often cheaper** than OpenAI equivalents
-- `qwen3-4b` at $0.05/1M input is 10x cheaper than gpt-4o-mini
-- `venice-uncensored` at $0.20/1M input vs gpt-4o at $2.50/1M
-
-### Freedom
-- **No content filtering** on uncensored models
-- No account suspensions for controversial use cases
-- Web3-native with crypto payment options
-- DIEM staking for daily credits
-
-### Model Diversity
-- Access to models from multiple providers (Qwen, Llama, Mistral, Gemma, Claude, GPT, Grok, etc.)
-- Switch between private and anonymized models per request
-- New models added regularly
-
-## Framework Migration
+## Frameworks
 
 Most AI frameworks work with Venice by changing the base URL:
 
-| Framework | Change Required |
-|-----------|----------------|
-| LangChain | `base_url` in `ChatOpenAI` |
-| Vercel AI SDK | `baseURL` in `createOpenAI` |
-| CrewAI | `OPENAI_API_BASE` env var |
-| LlamaIndex | `api_base` in `OpenAI` |
-| AutoGen | `base_url` in config |
-| Haystack | `api_base_url` in `OpenAIGenerator` |
-| Claude Code | `--api-base` flag or env var |
-| Cursor | Custom API endpoint in settings |
-| Continue.dev | `apiBase` in config.json |
+<CardGroup cols={3}>
+  <Card title="LangChain" icon="link" href="/guides/integrations/langchain">
+    `base_url` in `ChatOpenAI`
+  </Card>
+  <Card title="Vercel AI SDK" icon="link" href="/guides/integrations/vercel-ai-sdk">
+    `baseURL` in `createOpenAI`
+  </Card>
+  <Card title="LlamaIndex" icon="link" href="/guides/integrations/llamaindex">
+    `api_base` on the OpenAI-compatible client
+  </Card>
+  <Card title="CrewAI" icon="link" href="/guides/integrations/crewai">
+    `OPENAI_API_BASE` env var
+  </Card>
+  <Card title="PydanticAI" icon="link" href="/guides/integrations/pydanticai">
+    OpenAI-compatible model with Venice base URL
+  </Card>
+  <Card title="Cursor" icon="link" href="/guides/integrations/cursor">
+    Custom API endpoint in settings
+  </Card>
+  <Card title="Claude Code" icon="link" href="/guides/integrations/claude-code">
+    Route Claude Code through Venice
+  </Card>
+  <Card title="Codex CLI" icon="link" href="/guides/integrations/codex-cli">
+    `config.toml` model provider
+  </Card>
+  <Card title="Aider" icon="link" href="/guides/integrations/aider">
+    `OPENAI_API_BASE` env var
+  </Card>
+</CardGroup>
+
+More coding agents and tools are listed in [AI Agents](/guides/integrations/ai-agents).
+
+## Uncensored models
+
+Venice's private uncensored models have no content filtering, making them suitable for:
+
+- Creative writing without guardrails
+- Security research and red teaming
+- Honest analysis without refusal patterns
+- Medical and legal information without extra disclaimers
+
+Use the `most_uncensored` trait or a current uncensored model ID from [Text models](/models/text).
 
 <Card title="Get Your API Key" icon="key" href="https://venice.ai/settings/api">
   Generate a Venice API key and start migrating in minutes


### PR DESCRIPTION
## Summary
- Rewrite the English OpenAI migration guide as a two-line swap page: keep the drop-in voice, replace the stale model/price table with traits and compatibility mapping, and point at live catalogs instead of hardcoded IDs.
- Collapse Venice-only extras to one `extra_body` example plus links (no video/scraping tutorials), add Responses to the compatibility table, and turn the framework list into cards that link to existing integration guides.
- Keep the uncensored closer; drop the Why migrate pitch. English only — Mintlify regenerates locales after merge.

## Test plan
- [x] Preview `/guides/getting-started/openai-migration` locally with `yarn dev`
- [x] Confirm the 2-line Python/Node/cURL examples and env-var tip render
- [x] Click through trait, compatibility mapping, models, pricing, and framework cards
- [x] Confirm locale copies were not hand-edited


Made with [Cursor](https://cursor.com)