### PR TITLE
Clarify embeddings accept text only, not token arrays

### DIFF
--- a/api-reference/api-spec.mdx
+++ b/api-reference/api-spec.mdx
@@ -269,6 +269,7 @@ While Venice maintains high compatibility with the OpenAI API specification, the
 3. **Model Ecosystem**: Venice offers its own [model lineup](/overview/models) including uncensored and reasoning models - use Venice model IDs rather than OpenAI mappings
 4. **Response Headers**: Unique headers for balance tracking (`x-venice-balance-usd`, `x-venice-balance-diem`), model deprecation warnings, and content safety flags
 5. **Content Policies**: More permissive policies with dedicated uncensored models and optional content filtering
+6. **Embeddings input**: `input` must be a string or an array of strings. Token ID arrays are rejected with HTTP 400. LangChain `OpenAIEmbeddings` must set `check_embedding_ctx_length=False`
 
 ## API Stability
 

--- a/api-reference/endpoint/embeddings/generate.mdx
+++ b/api-reference/endpoint/embeddings/generate.mdx
@@ -4,3 +4,7 @@ openapi: 'POST /embeddings'
 "og:title": "Embeddings | Venice API Docs"
 "og:description": "Documentation covering Venice's embeddings API."
 ---
+
+<Warning>
+`input` must be a string or an array of strings. Token ID arrays are rejected with HTTP 400. LangChain `OpenAIEmbeddings` must set `check_embedding_ctx_length=False`.
+</Warning>

--- a/guides/features/embeddings.mdx
+++ b/guides/features/embeddings.mdx
@@ -9,6 +9,10 @@ Embeddings convert text into vectors that capture semantic meaning. Use them for
 
 The Venice embeddings endpoint is OpenAI-compatible. Send one string or an array of strings to `/embeddings`, then store the returned vectors in your database or vector index.
 
+<Warning>
+Venice accepts text only. Send a string or an array of strings. Token ID arrays are rejected with HTTP 400. LangChain `OpenAIEmbeddings` must set `check_embedding_ctx_length=False`, or it tokenizes locally with tiktoken and sends integer arrays.
+</Warning>
+
 ## Basic Usage
 
 <CodeGroup>
@@ -61,7 +65,7 @@ curl https://api.venice.ai/api/v1/embeddings \
 
 ## Batch Inputs
 
-Pass an array of strings to embed multiple texts in one request:
+Pass an array of strings to embed multiple texts in one request. Each item must be text, not a token ID array:
 
 ```json
 {
@@ -99,4 +103,5 @@ Use the same embedding model for indexing and querying. Mixing models can make s
 
 - [Embeddings API](/api-reference/endpoint/embeddings/generate)
 - [Embedding Models](/models/embeddings)
+- [LangChain](/guides/integrations/langchain#embeddings)
 - [Private RAG Bot Guide](/guides/projects/private-rag-bot)

--- a/guides/getting-started/openai-migration.mdx
+++ b/guides/getting-started/openai-migration.mdx
@@ -78,7 +78,7 @@ Browse the live catalog on [Text models](/models/text) and [Pricing](/overview/p
 | Function Calling | ✅ | ✅ | Same `tools` parameter |
 | Structured Output | ✅ | ✅ | Same `response_format` |
 | Vision | ✅ | ✅ | Same content array format |
-| Embeddings | ✅ | ✅ | Same API |
+| Embeddings | ✅ | ✅ | Text only; token arrays return HTTP 400 |
 | Image Generation | ✅ | ✅ | OpenAI-compatible via `/images/generations` |
 | TTS | ✅ | ✅ | Compatible |
 | STT | ✅ | ✅ | Compatible |
@@ -115,7 +115,7 @@ Most AI frameworks work with Venice by changing the base URL:
 
 <CardGroup cols={3}>
   <Card title="LangChain" icon="link" href="/guides/integrations/langchain">
-    `base_url` in `ChatOpenAI`
+    `base_url` in `ChatOpenAI`; `check_embedding_ctx_length=False` on `OpenAIEmbeddings`
   </Card>
   <Card title="Vercel AI SDK" icon="link" href="/guides/integrations/vercel-ai-sdk">
     `baseURL` in `createOpenAI`

--- a/guides/integrations/langchain.mdx
+++ b/guides/integrations/langchain.mdx
@@ -40,6 +40,8 @@ for chunk in llm.stream("Write a haiku about decentralization."):
 
 ## Embeddings
 
+Venice embeds text only. LangChain's `OpenAIEmbeddings` defaults to `check_embedding_ctx_length=True`, which tokenizes with tiktoken and can send integer token arrays. Venice rejects those with HTTP 400, so set `check_embedding_ctx_length=False`.
+
 ```python
 from langchain_openai import OpenAIEmbeddings
 
@@ -47,7 +49,7 @@ embeddings = OpenAIEmbeddings(
     model="text-embedding-bge-m3",
     api_key="your-venice-api-key",
     base_url="https://api.venice.ai/api/v1",
-    check_embedding_ctx_length=False,  # Required for Venice
+    check_embedding_ctx_length=False,  # Required: send text, not token IDs
 )
 
 vectors = embeddings.embed_documents([
@@ -117,7 +119,7 @@ embeddings = OpenAIEmbeddings(
     model="text-embedding-bge-m3",
     api_key="your-venice-api-key",
     base_url="https://api.venice.ai/api/v1",
-    check_embedding_ctx_length=False,
+    check_embedding_ctx_length=False,  # Required: send text, not token IDs
 )
 
 # Load and split documents


### PR DESCRIPTION
## Summary
- Document that `/embeddings` accepts a string or an array of strings only; token ID arrays return HTTP 400.
- Tell LangChain users to set `check_embedding_ctx_length=False` on `OpenAIEmbeddings` so tiktoken IDs are not sent.
- Align the OpenAI migration guide and API spec differences with the OpenAPI contract already published from outerface.

## Test plan
- [ ] Confirm the embeddings guide warning and batch-input wording on `/guides/features/embeddings`
- [ ] Confirm the LangChain embeddings and RAG snippets include `check_embedding_ctx_length=False`
- [ ] Confirm `/api-reference/endpoint/embeddings/generate` shows the warning above the generated OpenAPI spec
- [ ] Confirm the OpenAI migration embeddings row no longer says "Same API"


Made with [Cursor](https://cursor.com)