### PR TITLE
docs: clarify Rig Venice transcription/image/speech constructors

### DIFF
--- a/guides/integrations/rig.mdx
+++ b/guides/integrations/rig.mdx
@@ -249,10 +249,10 @@ async fn search_with_citations(client: &venice::Client) -> Result<()> {
 
 ## Other capabilities
 
-The same `venice::Client` also drives:
+The same `venice::Client` also covers transcription, image generation, and speech. Bring the matching client trait into scope (`TranscriptionClient`, `ImageGenerationClient`, or `AudioGenerationClient`) before calling the constructor:
 
 - **Transcription** — `client.transcription_model(venice::WHISPER_LARGE_V3)`
-- **Image generation** — `client.image_generation_model(...)` (enable Rig's `image` feature)
+- **Image generation** — `client.image_generation_model(venice::Z_IMAGE_TURBO)` (enable Rig's `image` feature)
 - **Speech** — `client.audio_generation_model(venice::TTS_KOKORO)` (enable Rig's `audio` feature)
 
 Video, music, image editing, `/augment/*`, and crypto RPC have no Rig trait and are not wrapped. Call those Venice endpoints directly.


### PR DESCRIPTION
## Summary
- Follow-up to #415: the Rig guide's other-capabilities one-liners now say to bring `TranscriptionClient`, `ImageGenerationClient`, or `AudioGenerationClient` into scope before calling the constructors.
- Image generation uses `venice::Z_IMAGE_TURBO` instead of a placeholder, and still notes the `image` / `audio` features.

## Test plan
- [ ] Confirm `guides/integrations/rig.mdx` Other capabilities section reads as intended
- [ ] Confirm English-only nav/docs change (no locale copies)


Made with [Cursor](https://cursor.com)