### PR TITLE
Replace Font Awesome icon names with their Tabler equivalents

### DIFF
--- a/api-reference/rate-limiting.mdx
+++ b/api-reference/rate-limiting.mdx
@@ -7,10 +7,10 @@ description: "Venice API rate limits — per-tier request and token quotas, mode
 Rate limits vary by model and tier. The default limits below are a useful reference, but the `/api_keys/rate_limits` API endpoint is the canonical way to fetch your current limits. You can check your exact limits anytime:
 
 <CardGroup cols={2}>
-  <Card title="View Your Limits" icon="gauge-high" href="/api-reference/endpoint/api_keys/rate_limits?playground=open">
+  <Card title="View Your Limits" icon="gauge" href="/api-reference/endpoint/api_keys/rate_limits?playground=open">
     Interactive playground
   </Card>
-  <Card title="Rate Limit Logs" icon="clock-rotate-left" href="/api-reference/endpoint/api_keys/rate_limit_logs?playground=open">
+  <Card title="Rate Limit Logs" icon="history" href="/api-reference/endpoint/api_keys/rate_limit_logs?playground=open">
     See which requests hit limits
   </Card>
 </CardGroup>

--- a/getting-started/quick-start.mdx
+++ b/getting-started/quick-start.mdx
@@ -356,7 +356,7 @@ Now that you've made your first requests, explore more of what Venice API has to
     Explore detailed API documentation with all endpoints and parameters
   </Card>
 
-  <Card title="Structured Responses" icon="brackets-curly" href="/guides/features/structured-responses">
+  <Card title="Structured Responses" icon="braces" href="/guides/features/structured-responses">
     Learn how to get JSON responses with guaranteed schemas
   </Card>
 
@@ -372,7 +372,7 @@ Now that you've made your first requests, explore more of what Venice API has to
     Understand rate limits and best practices for production usage
   </Card>
 
-  <Card title="Error Codes" icon="triangle-exclamation" href="/api-reference/error-codes">
+  <Card title="Error Codes" icon="alert-triangle" href="/api-reference/error-codes">
     Reference for handling API errors and troubleshooting issues
   </Card>
 

--- a/guides/getting-started/generating-api-key.mdx
+++ b/guides/getting-started/generating-api-key.mdx
@@ -86,7 +86,7 @@ Admin keys can manage API keys through the API reference endpoints:
     View active keys and their metadata.
   </Card>
 
-  <Card title="Update API Key" icon="pen-to-square" href="/api-reference/endpoint/api_keys/update">
+  <Card title="Update API Key" icon="edit" href="/api-reference/endpoint/api_keys/update">
     Update a key description, expiration date, or consumption limits.
   </Card>
 

--- a/guides/integrations/aider.mdx
+++ b/guides/integrations/aider.mdx
@@ -14,7 +14,7 @@ description: Configure Aider for AI pair-programming in your terminal with priva
   <Card title="OpenAI Compatible" icon="plug">
     Uses Venice's `/chat/completions` endpoint
   </Card>
-  <Card title="Any Text Model" icon="microchip">
+  <Card title="Any Text Model" icon="cpu">
     Swap in any Venice text model ID
   </Card>
 </CardGroup>
@@ -217,7 +217,7 @@ Setting `OPENAI_API_BASE` and `OPENAI_API_KEY` in your shell also affects other 
   <Card title="Aider OpenAI-compatible docs" icon="book" href="https://aider.chat/docs/llms/openai-compat.html">
     Official Aider provider setup
   </Card>
-  <Card title="Aider config with .env" icon="gear" href="https://aider.chat/docs/config/dotenv.html">
+  <Card title="Aider config with .env" icon="settings" href="https://aider.chat/docs/config/dotenv.html">
     Persist API keys and model settings
   </Card>
   <Card title="Venice API Reference" icon="code" href="/api-reference/api-spec">

--- a/guides/integrations/brave-leo.mdx
+++ b/guides/integrations/brave-leo.mdx
@@ -14,7 +14,7 @@ description: Connect Brave Leo to Venice through Bring Your Own Model settings f
   <Card title="Direct Connection" icon="plug">
     Send BYOM requests directly from Brave to Venice
   </Card>
-  <Card title="Privacy Choice" icon="shield-halved">
+  <Card title="Privacy Choice" icon="shield-half">
     Choose a Venice model with the privacy tier you need
   </Card>
 </CardGroup>
@@ -136,7 +136,7 @@ Brave may keep Leo chat history in local browser storage. You can clear Leo data
   <Card title="Venice Text Models" icon="list" href="/models/text">
     Browse current model IDs and privacy tiers
   </Card>
-  <Card title="Model Feature Suffixes" icon="sliders" href="/api-reference/endpoint/chat/model_feature_suffix">
+  <Card title="Model Feature Suffixes" icon="adjustments" href="/api-reference/endpoint/chat/model_feature_suffix">
     Enable web search and other Venice features
   </Card>
   <Card title="Generate an API Key" icon="key" href="/guides/getting-started/generating-api-key">

--- a/guides/integrations/claude-code.mdx
+++ b/guides/integrations/claude-code.mdx
@@ -11,7 +11,7 @@ description: Configure the Claude Code CLI to route Anthropic Claude Opus and So
   <Card title="Pay Per Token" icon="coins">
     No subscription. Pay only for what you use
   </Card>
-  <Card title="Claude Models" icon="microchip">
+  <Card title="Claude Models" icon="cpu">
     Access Opus 4.5/4.6/4.7/4.8, Sonnet 4.5/4.6/4.7/4.8, and Fable 5 through Venice
   </Card>
   <Card title="Prompt Caching" icon="bolt">
@@ -24,10 +24,10 @@ description: Configure the Claude Code CLI to route Anthropic Claude Opus and So
 Claude Code connects directly to Anthropic's API by default. To use it with Venice, you need [claude-code-router](https://github.com/musistudio/claude-code-router), an open-source local proxy that:
 
 <Steps>
-  <Step title="Intercepts" icon="hand">
+  <Step title="Intercepts" icon="hand-stop">
     Catches Claude Code's outgoing requests before they reach Anthropic
   </Step>
-  <Step title="Transforms" icon="arrows-rotate">
+  <Step title="Transforms" icon="refresh">
     Converts request format and maps model IDs (e.g., `claude-opus-4-5`)
   </Step>
   <Step title="Redirects" icon="route">
@@ -43,7 +43,7 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
   <Card title="Venice Account" icon="user" href="https://venice.ai/settings/api">
     With Venice credits
   </Card>
-  <Card title="Node.js" icon="node-js" href="https://nodejs.org/">
+  <Card title="Node.js" icon="brand-nodejs" href="https://nodejs.org/">
     v18 or higher
   </Card>
   <Card title="Claude Code" icon="terminal" href="https://docs.anthropic.com/en/docs/claude-code">
@@ -276,7 +276,7 @@ Venice [prompt caching](/guides/features/prompt-caching) works alongside Claude 
   <Card title="Venice API Docs" icon="book" href="/api-reference/api-spec">
     Full API reference
   </Card>
-  <Card title="claude-code-router" icon="github" href="https://github.com/musistudio/claude-code-router">
+  <Card title="claude-code-router" icon="brand-github" href="https://github.com/musistudio/claude-code-router">
     Source code and issues
   </Card>
 </CardGroup>

--- a/guides/integrations/cline.mdx
+++ b/guides/integrations/cline.mdx
@@ -14,7 +14,7 @@ description: Configure the Cline coding assistant in VS Code to use private Veni
   <Card title="OpenAI Compatible" icon="plug">
     Connect through Venice's `/chat/completions` endpoint
   </Card>
-  <Card title="Model Flexibility" icon="microchip">
+  <Card title="Model Flexibility" icon="cpu">
     Choose any compatible Venice text model
   </Card>
 </CardGroup>
@@ -123,7 +123,7 @@ Copy a model's `id` exactly into Cline's **Model ID** field.
   <Card title="Venice Text Models" icon="list" href="/models/text">
     Browse available Venice model IDs
   </Card>
-  <Card title="Cline Provider Docs" icon="gear" href="https://docs.cline.bot/provider-config/openai-compatible">
+  <Card title="Cline Provider Docs" icon="settings" href="https://docs.cline.bot/provider-config/openai-compatible">
     OpenAI-compatible provider settings
   </Card>
   <Card title="Venice API Reference" icon="code" href="/api-reference/api-spec">

--- a/guides/integrations/codex-cli.mdx
+++ b/guides/integrations/codex-cli.mdx
@@ -8,13 +8,13 @@ description: Point the OpenAI Codex CLI at Venice models with a local config.tom
 This guide shows how to run OpenAI Codex CLI with Venice using Codex's official config paths: `~/.codex/config.toml` (user-level) or `.codex/config.toml` (project-level).
 
 <CardGroup cols={3}>
-  <Card title="Simple Setup" icon="gear">
+  <Card title="Simple Setup" icon="settings">
     One config file in your project
   </Card>
   <Card title="OpenAI Compatible" icon="plug">
     Uses Venice's OpenAI-compatible API
   </Card>
-  <Card title="Model Flexibility" icon="microchip">
+  <Card title="Model Flexibility" icon="cpu">
     Swap in any supported Venice text model
   </Card>
 </CardGroup>

--- a/guides/integrations/crypto-rpc-agents.mdx
+++ b/guides/integrations/crypto-rpc-agents.mdx
@@ -385,7 +385,7 @@ These categories of methods are intentionally rejected:
   <Card title="Autonomous Agent API Key" icon="robot" href="/guides/integrations/generating-api-key-agent">
     Mint your own key by staking VVV
   </Card>
-  <Card title="Postman Collection" icon="play" href="https://www.postman.com/veniceai/workspace/venice-ai-workspace/folder/38652128-2cf5a817-41cd-438b-ad37-5d07c3f13005?action=share&creator=48156591&active-environment=38652128-ef110f4e-d3e1-43b5-8029-4d6877e62041">
+  <Card title="Postman Collection" icon="player-play" href="https://www.postman.com/veniceai/workspace/venice-ai-workspace/folder/38652128-2cf5a817-41cd-438b-ad37-5d07c3f13005?action=share&creator=48156591&active-environment=38652128-ef110f4e-d3e1-43b5-8029-4d6877e62041">
     27 ready-to-run Crypto RPC examples
   </Card>
   <Card title="Pricing" icon="coins" href="/overview/pricing">

--- a/guides/integrations/cursor.mdx
+++ b/guides/integrations/cursor.mdx
@@ -11,7 +11,7 @@ description: Configure Cursor IDE to use Venice models including Claude, GPT, De
   <Card title="Pay Per Token" icon="coins">
     No subscription. Pay only for what you use
   </Card>
-  <Card title="All Models" icon="microchip">
+  <Card title="All Models" icon="cpu">
     Access Claude, GPT, DeepSeek, Llama, and more
   </Card>
   <Card title="OpenAI Compatible" icon="plug">

--- a/guides/integrations/hermes-agent.mdx
+++ b/guides/integrations/hermes-agent.mdx
@@ -7,7 +7,7 @@ description: Set up Venice as the model provider in Hermes Agent for private, un
 
 [Hermes Agent](https://hermes-agent.nousresearch.com) is an open-source, self-hosted AI agent built by [Nous Research](https://nousresearch.com). It features persistent memory, autonomous skill creation, and a built-in learning loop that gets more capable the longer it runs. Point it at the Venice API and your agent gets access to 230+ models and tools across text, image, video, audio, embeddings, and more.
 
-<Card title="Hermes Agent Docs" icon="arrow-up-right-from-square" href="https://hermes-agent.nousresearch.com/docs/">
+<Card title="Hermes Agent Docs" icon="external-link" href="https://hermes-agent.nousresearch.com/docs/">
   Full documentation, provider setup, and configuration options on the official Hermes Agent docs.
 </Card>
 
@@ -25,13 +25,13 @@ The Venice API gives your Hermes Agent access to the full Venice platform throug
 | **Tools** | Web scraping, web search, text parsing, and crypto RPC |
 
 <CardGroup cols={3}>
-  <Card title="Private Inference" icon="shield-halved">
+  <Card title="Private Inference" icon="shield-half">
     Zero data retention. Prompts are never stored or logged
   </Card>
   <Card title="Persistent Memory" icon="brain">
     Hermes remembers context across sessions and restarts
   </Card>
-  <Card title="15+ Platforms" icon="comments">
+  <Card title="15+ Platforms" icon="messages">
     Reach your agent on Telegram, Discord, Slack, WhatsApp, and more
   </Card>
 </CardGroup>
@@ -193,13 +193,13 @@ Hermes will discover each skill by its `SKILL.md` frontmatter and load it on dem
   <Card title="Hermes Agent Docs" icon="book" href="https://hermes-agent.nousresearch.com/docs/">
     Official documentation
   </Card>
-  <Card title="GitHub" icon="github" href="https://github.com/NousResearch/hermes-agent">
+  <Card title="GitHub" icon="brand-github" href="https://github.com/NousResearch/hermes-agent">
     Source code and releases
   </Card>
   <Card title="Venice Model Catalog" icon="list" href="/models/text">
     Browse available models
   </Card>
-  <Card title="Venice Privacy" icon="shield-halved" href="/overview/privacy">
+  <Card title="Venice Privacy" icon="shield-half" href="/overview/privacy">
     How Venice protects your data
   </Card>
 </CardGroup>

--- a/guides/integrations/jan-ai.mdx
+++ b/guides/integrations/jan-ai.mdx
@@ -8,13 +8,13 @@ description: Configure Jan AI to use Venice models through an OpenAI-compatible 
 [Jan](https://jan.ai/) is an open-source AI assistant for running local and remote models from one desktop app. Venice works in Jan through its OpenAI-compatible remote model provider support.
 
 <CardGroup cols={3}>
-  <Card title="Desktop Assistant" icon="desktop">
+  <Card title="Desktop Assistant" icon="device-desktop">
     Use Venice models inside Jan's chat interface
   </Card>
   <Card title="OpenAI Compatible" icon="plug">
     Use Venice's OpenAI-compatible chat API
   </Card>
-  <Card title="Local + Remote" icon="layer-group">
+  <Card title="Local + Remote" icon="stack">
     Keep local Jan models alongside Venice cloud models
   </Card>
 </CardGroup>

--- a/guides/integrations/kilo-code.mdx
+++ b/guides/integrations/kilo-code.mdx
@@ -14,7 +14,7 @@ description: Configure Kilo Code's native Venice provider in VS Code or the CLI 
   <Card title="VS Code + CLI" icon="terminal">
     Same `kilo.json` config works across the extension and CLI
   </Card>
-  <Card title="Reasoning Models" icon="microchip">
+  <Card title="Reasoning Models" icon="cpu">
     Kilo maps Venice reasoning controls when the model supports them
   </Card>
 </CardGroup>

--- a/guides/integrations/nanoclaw-venice.mdx
+++ b/guides/integrations/nanoclaw-venice.mdx
@@ -11,7 +11,7 @@ description: Deploy NanoClaw, a lightweight personal AI assistant for WhatsApp a
   <Card title="Pay Per Token" icon="coins">
     No subscription. Pay only for what you use
   </Card>
-  <Card title="Private Inference" icon="shield-halved">
+  <Card title="Private Inference" icon="shield-half">
     Zero data retention on Venice servers
   </Card>
   <Card title="Docker Isolation" icon="cube">
@@ -70,10 +70,10 @@ NanoClaw is a clean, minimal alternative to larger platforms like OpenClaw. It's
 ## Prerequisites
 
 <CardGroup cols={2}>
-  <Card title="Node.js 20+" icon="node-js" href="https://nodejs.org/">
+  <Card title="Node.js 20+" icon="brand-nodejs" href="https://nodejs.org/">
     Check with `node --version`
   </Card>
-  <Card title="Docker" icon="docker" href="https://docker.com/products/docker-desktop">
+  <Card title="Docker" icon="brand-docker" href="https://docker.com/products/docker-desktop">
     Install and open once so it's running
   </Card>
   <Card title="Claude Code CLI" icon="terminal" href="https://claude.ai/download">
@@ -445,16 +445,16 @@ You (WhatsApp/Telegram)
 ## Resources
 
 <CardGroup cols={2}>
-  <Card title="NanoClaw Venice Repo" icon="github" href="https://github.com/lorenzovenice/nanoclaw-venice">
+  <Card title="NanoClaw Venice Repo" icon="brand-github" href="https://github.com/lorenzovenice/nanoclaw-venice">
     Source code and full README
   </Card>
-  <Card title="Original NanoClaw" icon="github" href="https://github.com/qwibitai/nanoclaw">
+  <Card title="Original NanoClaw" icon="brand-github" href="https://github.com/qwibitai/nanoclaw">
     Upstream project by qwibitai
   </Card>
   <Card title="Venice Model Catalog" icon="list" href="/models/text">
     Browse available models
   </Card>
-  <Card title="Venice Privacy" icon="shield-halved" href="/overview/privacy">
+  <Card title="Venice Privacy" icon="shield-half" href="/overview/privacy">
     How Venice protects your data
   </Card>
 </CardGroup>

--- a/guides/integrations/openclaw-bot.mdx
+++ b/guides/integrations/openclaw-bot.mdx
@@ -7,7 +7,7 @@ description: Configure Venice as the model provider in OpenClaw for private, unc
 
 [OpenClaw](https://openclaw.ai) is an open-source, self-hosted AI gateway that connects messaging platforms (WhatsApp, Telegram, Discord, iMessage, Slack) to AI models. Venice AI is available as a built-in provider, giving you access to private and uncensored models from any connected channel.
 
-<Card title="Official Venice Provider Guide" icon="arrow-up-right-from-square" href="https://docs.openclaw.ai/providers/venice">
+<Card title="Official Venice Provider Guide" icon="external-link" href="https://docs.openclaw.ai/providers/venice">
   Full setup instructions, model list, and configuration options on the OpenClaw docs.
 </Card>
 
@@ -109,7 +109,7 @@ openclaw skills install nhannah/venice-ai-media
   <Card title="OpenClaw Docs" icon="book" href="https://docs.openclaw.ai/">
     Official documentation
   </Card>
-  <Card title="Venice Provider Guide" icon="puzzle-piece" href="https://docs.openclaw.ai/providers/venice">
+  <Card title="Venice Provider Guide" icon="puzzle" href="https://docs.openclaw.ai/providers/venice">
     Full Venice setup reference
   </Card>
 </CardGroup>

--- a/guides/integrations/opencode.mdx
+++ b/guides/integrations/opencode.mdx
@@ -8,7 +8,7 @@ description: Wire OpenCode to Venice through an OpenAI-compatible custom provide
 [OpenCode](https://opencode.ai/) is an AI coding agent for the terminal. Venice works through OpenCode's custom provider config using the OpenAI-compatible adapter and a custom base URL.
 
 <CardGroup cols={3}>
-  <Card title="Custom Provider" icon="sliders">
+  <Card title="Custom Provider" icon="adjustments">
     Add Venice as a provider in `opencode.json`
   </Card>
   <Card title="OpenAI Compatible" icon="plug">

--- a/guides/integrations/venice-cli.mdx
+++ b/guides/integrations/venice-cli.mdx
@@ -7,7 +7,7 @@ description: Install the official Venice command-line tool for chat, web search,
 
 The [Venice CLI](https://github.com/veniceai/venice-cli) is the official command-line interface for Venice. Chat with AI models, generate images, convert text to speech, transcribe audio, generate video, and more—all from your terminal, with optional end-to-end encryption.
 
-<Card title="GitHub: veniceai/venice-cli" icon="github" href="https://github.com/veniceai/venice-cli">
+<Card title="GitHub: veniceai/venice-cli" icon="brand-github" href="https://github.com/veniceai/venice-cli">
   Published as [`veniceai-cli`](https://www.npmjs.com/package/veniceai-cli) on npm. MIT licensed.
 </Card>
 
@@ -15,7 +15,7 @@ The [Venice CLI](https://github.com/veniceai/venice-cli) is the official command
   <Card title="Privacy-first" icon="lock">
     Optional E2EE and TEE attestation. No telemetry, no browser tracking.
   </Card>
-  <Card title="Every modality" icon="layer-group">
+  <Card title="Every modality" icon="stack">
     Chat, search, image, upscale, TTS, transcription, video, and embeddings
   </Card>
   <Card title="Scriptable" icon="terminal">
@@ -260,10 +260,10 @@ venice chat "Generate code" | pbcopy
 ## Resources
 
 <CardGroup cols={2}>
-  <Card title="GitHub" icon="github" href="https://github.com/veniceai/venice-cli">
+  <Card title="GitHub" icon="brand-github" href="https://github.com/veniceai/venice-cli">
     Source code, issues, and releases
   </Card>
-  <Card title="npm" icon="npm" href="https://www.npmjs.com/package/veniceai-cli">
+  <Card title="npm" icon="brand-npm" href="https://www.npmjs.com/package/veniceai-cli">
     `veniceai-cli`
   </Card>
   <Card title="Venice MCP Server" icon="plug" href="/guides/integrations/venice-mcp">

--- a/guides/integrations/venice-mcp.mdx
+++ b/guides/integrations/venice-mcp.mdx
@@ -7,12 +7,12 @@ description: The official Venice Model Context Protocol server exposes 31 Venice
 
 The [Venice MCP Server](https://github.com/veniceai/venice-mcp-server) is the official [Model Context Protocol](https://modelcontextprotocol.io/) server for Venice. It exposes the full Venice API (chat, image, video, audio, music, embeddings, web augment, and characters) as **31 tools** that any MCP-compatible agent can call.
 
-<Card title="GitHub: veniceai/venice-mcp-server" icon="github" href="https://github.com/veniceai/venice-mcp-server">
+<Card title="GitHub: veniceai/venice-mcp-server" icon="brand-github" href="https://github.com/veniceai/venice-mcp-server">
   Published as [`@veniceai/mcp-server`](https://www.npmjs.com/package/@veniceai/mcp-server) on npm. MIT licensed.
 </Card>
 
 <CardGroup cols={3}>
-  <Card title="31 Tools" icon="toolbox">
+  <Card title="31 Tools" icon="tool">
     Every Venice modality in one config block
   </Card>
   <Card title="Any MCP Host" icon="plug">
@@ -203,16 +203,16 @@ The server is now available at `http://localhost:3333/mcp`. HTTP clients must se
 ## Resources
 
 <CardGroup cols={2}>
-  <Card title="GitHub" icon="github" href="https://github.com/veniceai/venice-mcp-server">
+  <Card title="GitHub" icon="brand-github" href="https://github.com/veniceai/venice-mcp-server">
     Source code, issues, and releases
   </Card>
-  <Card title="npm" icon="npm" href="https://www.npmjs.com/package/@veniceai/mcp-server">
+  <Card title="npm" icon="brand-npm" href="https://www.npmjs.com/package/@veniceai/mcp-server">
     `@veniceai/mcp-server`
   </Card>
   <Card title="Venice Skills" icon="book" href="/guides/integrations/venice-skills">
     Companion skills that teach agents how to use these tools
   </Card>
-  <Card title="MCP Spec" icon="arrow-up-right-from-square" href="https://modelcontextprotocol.io/">
+  <Card title="MCP Spec" icon="external-link" href="https://modelcontextprotocol.io/">
     Learn more about the Model Context Protocol
   </Card>
 </CardGroup>

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -7,12 +7,12 @@ description: Official Venice Agent Skills that load endpoint knowledge into Clau
 
 [Venice Skills](https://github.com/veniceai/skills) is the canonical collection of [Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) for the Venice API. Each skill is a self-contained folder with a `SKILL.md` that an LLM agent loads on demand to work correctly against a specific surface area of the API.
 
-<Card title="GitHub: veniceai/skills" icon="github" href="https://github.com/veniceai/skills">
+<Card title="GitHub: veniceai/skills" icon="brand-github" href="https://github.com/veniceai/skills">
   19 skills covering the full Venice API. MIT licensed. Kept in sync with the public [`swagger.yaml`](/api-reference/api-spec).
 </Card>
 
 <CardGroup cols={3}>
-  <Card title="19 Skills" icon="layer-group">
+  <Card title="19 Skills" icon="stack">
     One per Venice API surface area
   </Card>
   <Card title="Runtime-agnostic" icon="plug">
@@ -193,13 +193,13 @@ See the repository's `CONTRIBUTING.md` for style conventions (short first paragr
 ## Resources
 
 <CardGroup cols={2}>
-  <Card title="GitHub" icon="github" href="https://github.com/veniceai/skills">
+  <Card title="GitHub" icon="brand-github" href="https://github.com/veniceai/skills">
     Source code, contributing guide, and skill template
   </Card>
   <Card title="Venice MCP Server" icon="plug" href="/guides/integrations/venice-mcp">
     Pair skills with the official MCP server for runtime tool access
   </Card>
-  <Card title="Agent Skills Spec" icon="arrow-up-right-from-square" href="https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview">
+  <Card title="Agent Skills Spec" icon="external-link" href="https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview">
     Learn the underlying format
   </Card>
   <Card title="Venice API Spec" icon="book" href="/api-reference/api-spec">

--- a/guides/integrations/venice-video-harness.mdx
+++ b/guides/integrations/venice-video-harness.mdx
@@ -7,7 +7,7 @@ description: Drive Venice from Claude Code or Cursor with a Venice-optimized har
 
 The [Venice Video Harness](https://github.com/jordanurbs/venice-video-harness) is a community, agent-first, Venice-optimized toolkit for **consistency-first video creation at any length**. It turns an IDE agent (Claude Code, Cursor, Codex, etc.) into an operator of a reusable Venice production system covering 50+ Venice video, image, audio, and music models.
 
-<Card title="GitHub: venice-video-harness" icon="github" href="https://github.com/jordanurbs/venice-video-harness">
+<Card title="GitHub: venice-video-harness" icon="brand-github" href="https://github.com/jordanurbs/venice-video-harness">
   MIT licensed. Community-maintained.
 </Card>
 
@@ -15,7 +15,7 @@ The [Venice Video Harness](https://github.com/jordanurbs/venice-video-harness) i
   <Card title="Character-consistent video" icon="users">
     Lock characters, voices, and aesthetics across an entire series
   </Card>
-  <Card title="Storyboard-to-video" icon="film">
+  <Card title="Storyboard-to-video" icon="movie">
     Two-pass panel generation with Venice multi-edit refinement
   </Card>
   <Card title="Text-first editing" icon="scissors">
@@ -48,7 +48,7 @@ Built for creators producing:
 ### Requirements
 
 <CardGroup cols={3}>
-  <Card title="Node.js 20+" icon="node-js" href="https://nodejs.org/">
+  <Card title="Node.js 20+" icon="brand-nodejs" href="https://nodejs.org/">
     Latest LTS recommended
   </Card>
   <Card title="ffmpeg + ffprobe" icon="terminal" href="https://ffmpeg.org/">
@@ -287,13 +287,13 @@ const longModels = listVideoModels({ minDurationSec: 20 });
 ## Resources
 
 <CardGroup cols={2}>
-  <Card title="GitHub" icon="github" href="https://github.com/jordanurbs/venice-video-harness">
+  <Card title="GitHub" icon="brand-github" href="https://github.com/jordanurbs/venice-video-harness">
     Source code, issues, and releases
   </Card>
-  <Card title="Venice Video Generation" icon="film" href="/guides/media/video-generation">
+  <Card title="Venice Video Generation" icon="movie" href="/guides/media/video-generation">
     The underlying API the harness drives
   </Card>
-  <Card title="Reference-to-Video" icon="image" href="/guides/media/reference-to-video">
+  <Card title="Reference-to-Video" icon="photo" href="/guides/media/reference-to-video">
     R2V guide for character consistency
   </Card>
   <Card title="Seedance 2.0" icon="bolt" href="/guides/media/seedance-2-0">

--- a/guides/integrations/x402-venice-api.mdx
+++ b/guides/integrations/x402-venice-api.mdx
@@ -303,7 +303,7 @@ The flow is the same. Store private keys in environment variables or a secret ma
 ## Related resources
 
 <CardGroup cols={2}>
-  <Card title="x402 Client SDK" icon="npm" href="https://github.com/veniceai/x402-client">
+  <Card title="x402 Client SDK" icon="brand-npm" href="https://github.com/veniceai/x402-client">
     Official Venice x402 client for Node.js/TypeScript.
   </Card>
 

--- a/overview/pricing.mdx
+++ b/overview/pricing.mdx
@@ -467,7 +467,7 @@ These charges apply in addition to standard model token pricing.
   <Card title="USD" icon="credit-card" href="https://venice.ai/settings/api">
     Buy Venice credits with credit card. Credits never expire.
   </Card>
-  <Card title="Crypto" icon="bitcoin" href="https://venice.ai/settings/api">
+  <Card title="Crypto" icon="currency-bitcoin" href="https://venice.ai/settings/api">
     Buy Venice credits with cryptocurrency. Same rates as USD.
   </Card>
   <Card title="Stake DIEM" icon="coins" href="https://venice.ai/token">

--- a/overview/privacy.mdx
+++ b/overview/privacy.mdx
@@ -77,7 +77,7 @@ TEE and E2EE are currently available on text models only.
 Both modes use the same model ID. The request flow determines whether the model runs in TEE-only mode or uses client-side E2EE.
 
 <CardGroup cols={2}>
-  <Card title="Use TEE when" icon="shield-halved">
+  <Card title="Use TEE when" icon="shield-half">
     You want the model to run inside an attested hardware enclave, but your client can send plaintext prompts over the normal API request.
   </Card>
   <Card title="Use E2EE when" icon="lock">


### PR DESCRIPTION
## What

`docs.json` sets the icon library to `tabler`, but 59 icon references across 23 pages still use **Font Awesome** names. Those names do not resolve, so the affected cards and steps currently render with a blank space where the icon should be.

Found while investigating a report that the Search group icon was missing in the sidebar. That specific one is fixed in #433; this PR covers the same bug everywhere else.

## Verification

Every name was checked against the icon list shipped in `@tabler/icons` 3.46.0 (5,130 icons), rather than assumed. After this change no English page references a name outside that set.

The diff is 59 insertions and 59 deletions, a 1:1 line swap in every case, with no content changes.

## The renames

Most are mechanical, where the same glyph simply has a different name in Tabler:

| Font Awesome | Tabler | Uses |
|---|---|---|
| `github` | `brand-github` | 12 |
| `shield-halved` | `shield-half` | 6 |
| `microchip` | `cpu` | 6 |
| `arrow-up-right-from-square` | `external-link` | 4 |
| `layer-group` | `stack` | 3 |
| `npm` | `brand-npm` | 3 |
| `gear` | `settings` | 3 |
| `node-js` | `brand-nodejs` | 3 |
| `triangle-exclamation` | `alert-triangle` | 1 |
| `pen-to-square` | `edit` | 1 |
| `clock-rotate-left` | `history` | 1 |
| `gauge-high` | `gauge` | 1 |
| `brackets-curly` | `braces` | 1 |
| `bitcoin` | `currency-bitcoin` | 1 |
| `docker` | `brand-docker` | 1 |
| `desktop` | `device-desktop` | 1 |
| `puzzle-piece` | `puzzle` | 1 |
| `arrows-rotate` | `refresh` | 1 |
| `comments` | `messages` | 1 |
| `play` | `player-play` | 1 |
| `image` | `photo` | 1 |

Four had no exact counterpart and use the nearest match. These are the ones worth a look:

| Font Awesome | Tabler | Where |
|---|---|---|
| `hand` | `hand-stop` | "Intercepts" step in the Claude Code guide |
| `toolbox` | `tool` | "31 Tools" card in the MCP guide |
| `film` | `movie` | video harness cards |
| `sliders` | `adjustments` | "Custom Provider" and "Model Feature Suffixes" cards |

## Scope

English pages only, per the translation policy in the README, as Mintlify regenerates locale copies after merge to `main`. Independent of #432 and #433 and can merge in any order.