### PR TITLE
Add a Colab notebook for the narration tutorial

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,3 +1,6 @@
 # Mintlify injects every .js file in the content directory into every page.
 # These are build-time Node scripts run by CI, not browser code.
 scripts/
+
+# Colab notebooks and their generator, linked from the docs but not pages themselves.
+notebooks/

--- a/guides/media/article-narration.mdx
+++ b/guides/media/article-narration.mdx
@@ -14,6 +14,10 @@ In this tutorial we work through all four. The result is a script that turns a U
 python article_to_audio.py https://docs.venice.ai/overview/privacy
 ```
 
+<Card title="Run this tutorial in Google Colab" icon="notebook" href="https://colab.research.google.com/github/veniceai/api-docs/blob/main/notebooks/article-narration.ipynb">
+  Every step below as an executable notebook, with the narration playing inline. Nothing to install.
+</Card>
+
 We will:
 
 1. Pick a model and a voice that suit long form narration
@@ -44,6 +48,7 @@ curl "https://api.venice.ai/api/v1/models?type=tts" \
 
 ```
 tts-kokoro  formats=["mp3","opus","aac","flac","wav","pcm"]  voices=54
+tts-qwen3-0-6b  formats=["mp3"]  voices=9
 tts-qwen3-1-7b  formats=["mp3"]  voices=9
 tts-xai-v1  formats=["mp3","wav","pcm"]  voices=26
 tts-inworld-1-5-max  formats=["wav"]  voices=14

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,48 @@
+# Notebooks
+
+Colab notebooks that accompany the tutorial pages.
+
+| Notebook | Tutorial |
+|---|---|
+| [`article-narration.ipynb`](article-narration.ipynb) | [Narrating Articles with Text-to-Speech](../guides/media/article-narration.mdx) |
+
+## These are generated
+
+Do not edit the `.ipynb` files by hand. The tutorial page is the source of truth
+for its code, and the notebook is built from it:
+
+```bash
+python notebooks/build.py
+```
+
+Run this after changing the Python in a tutorial that has a notebook, and commit
+the result. To find out whether anything is stale without writing files:
+
+```bash
+python notebooks/build.py --check
+```
+
+The build fails loudly rather than producing a stale notebook if a page is
+rewritten in a way the spec no longer matches, such as a renamed section or a
+removed code block. Fix `notebooks/build.py` to match the new page.
+
+## Why the notebook is not just the page
+
+A tutorial is ordered to be read, but a notebook has to run top to bottom, and
+the two orders differ. The narration page inspects `chunks` before the text
+being chunked exists, splits its code across two files that import each other,
+and guards its entry point behind `__main__`. So `build.py` holds an explicit
+running order and adds the cells that only make sense in Colab: reading the key
+from Colab secrets, and playing the audio back inline.
+
+Code that comes from a page is pulled in verbatim by section, so it cannot drift.
+Prose is written for the notebook, since the page's surrounding narration does
+not read well as cell markdown.
+
+## Conventions
+
+- Commit notebooks with outputs stripped. `build.py` emits empty outputs, so
+  just do not paste an executed notebook over the generated one.
+- Never commit an API key. The setup cell reads `VENICE_API_KEY` from Colab
+  secrets, falling back to the environment and then to a `getpass` prompt.
+- Notebooks consume real credit when run. Say so near the top of the notebook.

--- a/notebooks/article-narration.ipynb
+++ b/notebooks/article-narration.ipynb
@@ -1,0 +1,516 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Narrating Articles with Venice Text-to-Speech\n",
+    "\n",
+    "Turn any web article into a single narrated audio file, and play it back here.\n",
+    "\n",
+    "This notebook accompanies [Narrating Articles with Text-to-Speech](https://docs.venice.ai/guides/media/article-narration), which explains the reasoning behind each step. Run the cells in order.\n",
+    "\n",
+    "You need a Venice API key from [venice.ai/settings/api](https://docs.venice.ai/guides/getting-started/generating-api-key). A full run scrapes one page, makes one chat completion, and synthesizes about six minutes of speech, so it consumes a small amount of credit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Store the key with the key icon in the Colab sidebar, as a secret named `VENICE_API_KEY`, so it is not saved into the notebook when you share it. If no secret is set you will be prompted for it, and the value stays in memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%pip install -q requests\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "\n",
+    "def load_api_key() -> str:\n",
+    "    try:\n",
+    "        from google.colab import userdata\n",
+    "\n",
+    "        return userdata.get('VENICE_API_KEY')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    if os.environ.get('VENICE_API_KEY'):\n",
+    "        return os.environ['VENICE_API_KEY']\n",
+    "    from getpass import getpass\n",
+    "\n",
+    "    return getpass('Venice API key: ')\n",
+    "\n",
+    "\n",
+    "# The tutorial code reads the key from the environment.\n",
+    "os.environ['VENICE_API_KEY'] = load_api_key()\n",
+    "print('Key loaded.')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Choose a model and a voice\n",
+    "\n",
+    "Voices belong to models, and sending a voice from one family to a model from another is the most common first mistake. `model_spec.voices` is the authoritative voice list for a model, and `supported_formats` tells you which `response_format` values it accepts.\n",
+    "\n",
+    "We use `tts-xai-v1` with the voice `eve`. It supports `pcm`, which is what makes joining chunks straightforward in section 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import requests\n",
+    "\n",
+    "models = requests.get(\n",
+    "    'https://api.venice.ai/api/v1/models',\n",
+    "    headers={'Authorization': f\"Bearer {os.environ['VENICE_API_KEY']}\"},\n",
+    "    params={'type': 'tts'},\n",
+    "    timeout=60,\n",
+    ").json()['data']\n",
+    "\n",
+    "for model in models:\n",
+    "    spec = model['model_spec']\n",
+    "    print(f\"{model['id']:28} formats={spec['supported_formats']} \"\n",
+    "          f\"voices={len(spec['voices'])}\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Make a single request\n",
+    "\n",
+    "The response body is raw audio rather than JSON, so write the bytes straight to a file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "response = requests.post(\n",
+    "    \"https://api.venice.ai/api/v1/audio/speech\",\n",
+    "    headers={\n",
+    "        \"Authorization\": f\"Bearer {os.environ['VENICE_API_KEY']}\",\n",
+    "        \"Content-Type\": \"application/json\",\n",
+    "    },\n",
+    "    json={\n",
+    "        \"model\": \"tts-xai-v1\",\n",
+    "        \"voice\": \"eve\",\n",
+    "        \"input\": \"Hello from Venice.\",\n",
+    "        \"response_format\": \"mp3\",\n",
+    "    },\n",
+    "    timeout=300,\n",
+    ")\n",
+    "\n",
+    "response.raise_for_status()\n",
+    "Path(\"hello.mp3\").write_bytes(response.content)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from IPython.display import Audio\n",
+    "\n",
+    "Audio('hello.mp3')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Split text at the 4096 character limit\n",
+    "\n",
+    "The `input` field accepts at most 4096 characters, and longer text is rejected outright rather than truncated silently. Splitting on sentence boundaries matters, because a chunk that ends mid sentence produces an audible stumble at the join.\n",
+    "\n",
+    "The default `max_chars` is 1500 rather than something near the ceiling, and that is deliberate. Synthesis time grows with input length, so smaller chunks come back sooner and, because they run in parallel, finish the whole job faster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import os\n",
+    "import re\n",
+    "import sys\n",
+    "import wave\n",
+    "from concurrent.futures import ThreadPoolExecutor\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "BASE_URL = \"https://api.venice.ai/api/v1\"\n",
+    "HEADERS = {\n",
+    "    \"Authorization\": f\"Bearer {os.environ['VENICE_API_KEY']}\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n",
+    "\n",
+    "MODEL = \"tts-xai-v1\"\n",
+    "VOICE = \"eve\"\n",
+    "SAMPLE_RATE = 24000  # tts-xai-v1 returns 24 kHz mono signed 16-bit PCM.\n",
+    "\n",
+    "SENTENCE_END = re.compile(r\"(?<=[.!?])\\s+\")\n",
+    "\n",
+    "\n",
+    "def split_into_chunks(text: str, max_chars: int = 1500) -> list[str]:\n",
+    "    \"\"\"Split text on sentence boundaries into chunks under the 4096-character cap.\"\"\"\n",
+    "    chunks: list[str] = []\n",
+    "    current = \"\"\n",
+    "\n",
+    "    for sentence in SENTENCE_END.split(text.strip()):\n",
+    "        if not sentence:\n",
+    "            continue\n",
+    "        if len(sentence) > max_chars:\n",
+    "            raise ValueError(f\"Sentence longer than {max_chars} characters: {sentence[:80]}...\")\n",
+    "        if len(current) + len(sentence) + 1 > max_chars:\n",
+    "            chunks.append(current)\n",
+    "            current = sentence\n",
+    "        else:\n",
+    "            current = f\"{current} {sentence}\" if current else sentence\n",
+    "\n",
+    "    if current:\n",
+    "        chunks.append(current)\n",
+    "    return chunks"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Join the chunks into one file\n",
+    "\n",
+    "Concatenating encoded audio such as MP3 is unreliable, because every chunk carries its own frame headers. Requesting `pcm` avoids the problem entirely. PCM is raw samples with no container, so joining is just appending bytes, and the standard library `wave` module writes the header for us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def synthesize(text: str, speed: float = 1.0) -> bytes:\n",
+    "    \"\"\"Return raw PCM audio for one chunk.\"\"\"\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/audio/speech\",\n",
+    "        headers=HEADERS,\n",
+    "        json={\n",
+    "            \"model\": MODEL,\n",
+    "            \"voice\": VOICE,\n",
+    "            \"input\": text,\n",
+    "            \"response_format\": \"pcm\",\n",
+    "            \"speed\": speed,\n",
+    "        },\n",
+    "        timeout=300,\n",
+    "    )\n",
+    "    if response.status_code != 200:\n",
+    "        raise RuntimeError(f\"TTS failed ({response.status_code}): {response.text}\")\n",
+    "    return response.content\n",
+    "\n",
+    "\n",
+    "def narrate(text: str, out_path: str) -> str:\n",
+    "    chunks = split_into_chunks(text)\n",
+    "    print(f\"Synthesizing {len(chunks)} chunks\", file=sys.stderr)\n",
+    "\n",
+    "    with ThreadPoolExecutor(max_workers=4) as pool:\n",
+    "        audio = list(pool.map(synthesize, chunks))\n",
+    "\n",
+    "    with wave.open(out_path, \"wb\") as output:\n",
+    "        output.setnchannels(1)\n",
+    "        output.setsampwidth(2)\n",
+    "        output.setframerate(SAMPLE_RATE)\n",
+    "        for part in audio:\n",
+    "            output.writeframes(part)\n",
+    "\n",
+    "    seconds = sum(len(part) for part in audio) / 2 / SAMPLE_RATE\n",
+    "    print(f\"Wrote {out_path} ({seconds:.1f}s of audio)\", file=sys.stderr)\n",
+    "    return out_path"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Raw PCM carries no sample rate, so you have to supply the correct one when writing the WAV header, and it is model specific. `tts-xai-v1` returns 24 kHz while `tts-gradium-v1` returns 48 kHz. Guess wrong and the narration plays at the wrong speed and pitch.\n",
+    "\n",
+    "To find the rate for any model, ask for one short clip as `wav` and read the header it comes back with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import wave\n",
+    "\n",
+    "probe = requests.post(\n",
+    "    f'{BASE_URL}/audio/speech',\n",
+    "    headers=HEADERS,\n",
+    "    json={'model': MODEL, 'voice': VOICE, 'input': 'Probe.', 'response_format': 'wav'},\n",
+    "    timeout=300,\n",
+    ")\n",
+    "probe.raise_for_status()\n",
+    "open('probe.wav', 'wb').write(probe.content)\n",
+    "\n",
+    "with wave.open('probe.wav') as handle:\n",
+    "    print(handle.getframerate(), handle.getnchannels(), handle.getsampwidth())"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Prepare text that sounds right\n",
+    "\n",
+    "Scraped Markdown read aloud verbatim is close to unlistenable. A speech model spells URLs out one character at a time, so `https://docs.venice.ai/llms.txt` comes out as *h t t p s colon slash slash docs dot venice dot a i*. Rather than fighting Markdown with regular expressions, we ask a chat model to rewrite the article as something meant to be spoken.\n",
+    "\n",
+    "The page keeps this in a second file that imports `narrate`. Here everything shares one namespace, so that import is dropped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import os\n",
+    "import re\n",
+    "import sys\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "\n",
+    "BASE_URL = \"https://api.venice.ai/api/v1\"\n",
+    "HEADERS = {\n",
+    "    \"Authorization\": f\"Bearer {os.environ['VENICE_API_KEY']}\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n",
+    "\n",
+    "URL_PATTERN = re.compile(r\"https?://\\S+|www\\.\\S+\")\n",
+    "\n",
+    "\n",
+    "def scrape(url: str) -> str:\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/augment/scrape\", headers=HEADERS, json={\"url\": url}, timeout=120\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()[\"content\"]\n",
+    "\n",
+    "\n",
+    "def write_script(markdown: str, minutes: int = 6) -> str:\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/chat/completions\",\n",
+    "        headers=HEADERS,\n",
+    "        json={\n",
+    "            \"model\": \"zai-org-glm-5-1\",\n",
+    "            \"messages\": [\n",
+    "                {\n",
+    "                    \"role\": \"system\",\n",
+    "                    \"content\": (\n",
+    "                        \"You rewrite articles as scripts to be read aloud. Output plain prose only: \"\n",
+    "                        \"no Markdown, no headings, no bullet points, no URLs, no code, no emoji. \"\n",
+    "                        \"Spell out abbreviations and numbers the way a narrator would say them. \"\n",
+    "                        \"Use short sentences with clear punctuation so speech synthesis paces well.\"\n",
+    "                    ),\n",
+    "                },\n",
+    "                {\n",
+    "                    \"role\": \"user\",\n",
+    "                    \"content\": f\"Rewrite this article as a {minutes}-minute spoken summary.\\n\\n{markdown[:20000]}\",\n",
+    "                },\n",
+    "            ],\n",
+    "            \"temperature\": 0.4,\n",
+    "        },\n",
+    "        timeout=300,\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    script = response.json()[\"choices\"][0][\"message\"][\"content\"]\n",
+    "    return URL_PATTERN.sub(\"\", script).strip()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Put it together\n",
+    "\n",
+    "The page guards its entry point behind `__main__` and takes the URL from the command line. In the notebook we set it directly, so change `URL` to narrate a different page.\n",
+    "\n",
+    "Saving `script.txt` next to the audio is worth the two lines. When a narration sounds wrong the script almost always shows why, and you can fix it without paying to synthesize again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "URL = 'https://docs.venice.ai/overview/privacy'\n",
+    "\n",
+    "print('Scraping', URL)\n",
+    "markdown = scrape(URL)\n",
+    "\n",
+    "print(f'Writing script from {len(markdown)} characters of Markdown')\n",
+    "script = write_script(markdown)\n",
+    "\n",
+    "with open('script.txt', 'w') as handle:\n",
+    "    handle.write(script)\n",
+    "\n",
+    "print(f'Script is {len(script)} characters')\n",
+    "print(script[:400] + '...')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that `script` exists, the two inspection cells from the tutorial can run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "chunks = split_into_chunks(script)\n",
+    "print(f\"len(chunks) = {len(chunks)}\")\n",
+    "for index, chunk in enumerate(chunks):\n",
+    "    print(f\"chunk {index}: {len(chunk)} chars\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "pcm = synthesize(chunks[0])\n",
+    "print(f\"bytes   = {len(pcm)}\")\n",
+    "print(f\"audio   = {len(pcm) / 2 / SAMPLE_RATE:.1f}s\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Synthesize the whole article and listen to it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "narrate(script, 'article.wav')\n",
+    "\n",
+    "Audio('article.wav')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Streaming for interactive use\n",
+    "\n",
+    "Batch narration optimizes total time. A voice interface has the opposite priority, which is getting the first audio out as fast as possible. Setting `streaming: true` returns the body sentence by sentence as it is generated, so playback can start in about a second instead of waiting for the complete clip."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import time\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "start = time.time()\n",
+    "first_byte = None\n",
+    "\n",
+    "with requests.post(\n",
+    "    \"https://api.venice.ai/api/v1/audio/speech\",\n",
+    "    headers=HEADERS,\n",
+    "    json={\n",
+    "        \"model\": \"tts-xai-v1\",\n",
+    "        \"voice\": \"eve\",\n",
+    "        \"input\": \"Streaming returns audio while the rest is still being generated.\",\n",
+    "        \"response_format\": \"mp3\",\n",
+    "        \"streaming\": True,\n",
+    "    },\n",
+    "    stream=True,\n",
+    "    timeout=300,\n",
+    ") as response:\n",
+    "    response.raise_for_status()\n",
+    "    with open(\"streamed.mp3\", \"wb\") as audio:\n",
+    "        for chunk in response.iter_content(chunk_size=4096):\n",
+    "            if first_byte is None:\n",
+    "                first_byte = time.time() - start\n",
+    "            audio.write(chunk)\n",
+    "\n",
+    "print(f\"first byte: {first_byte:.2f}s   complete: {time.time() - start:.2f}s\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "Audio('streamed.mp3')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- [Text-to-Speech](https://docs.venice.ai/guides/media/text-to-speech), reference for the endpoint and its parameters\n",
+    "- [Voice Cloning](https://docs.venice.ai/guides/media/voice-cloning), narrate with a custom voice instead of a preset\n",
+    "- [Cited Answers with Web Search](https://docs.venice.ai/guides/tools/cited-web-answers), generate the text this notebook narrates\n",
+    "- [Speech-to-Text](https://docs.venice.ai/guides/media/speech-to-text), transcribe the audio back and compare it against `script.txt` to verify the chunks joined in the right order"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/build.py
+++ b/notebooks/build.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Build the Colab notebooks from the tutorial pages they mirror.
+
+The MDX page is the source of truth for tutorial code. Cells that carry code
+declare where it comes from with `mdx(section, index)`, and the build fails if
+that anchor stops resolving, so a rewritten tutorial cannot silently leave a
+stale notebook behind.
+
+The notebook cannot be a straight concatenation of the page, because a tutorial
+is ordered to be read while a notebook has to run top to bottom. The page
+inspects `chunks` before the text being chunked exists, imports `narrate` as a
+module, and guards its entry point behind `__main__`. Cells marked `extra` cover
+those gaps and the things that only make sense in Colab, such as reading the key
+from Colab secrets and playing the audio back inline.
+
+Usage: python notebooks/build.py [--check]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DOCS_URL = "https://docs.venice.ai"
+GITHUB_REPO = "veniceai/api-docs"
+
+
+def code_blocks(mdx: Path) -> dict[str, list[str]]:
+    """Return the Python blocks on a page, grouped by their enclosing heading."""
+    src = mdx.read_text(encoding="utf-8")
+    headings = [(m.start(), m.group(1).strip()) for m in re.finditer(r"^## (.+)$", src, re.M)]
+
+    blocks: dict[str, list[str]] = {}
+    for match in re.finditer(r"```python[^\n]*\n(.*?)```", src, re.S):
+        section = "(intro)"
+        for start, name in headings:
+            if start > match.start():
+                break
+            section = name
+        blocks.setdefault(section, []).append(match.group(1).rstrip())
+    return blocks
+
+
+class Cell:
+    def __init__(self, kind: str, body: str, drop: tuple[str, ...] = ()):
+        self.kind, self.body, self.drop = kind, body, drop
+
+
+def md(body: str) -> Cell:
+    return Cell("markdown", body)
+
+
+def extra(body: str) -> Cell:
+    """Code that exists only in the notebook, not on the page."""
+    return Cell("extra", body)
+
+
+def mdx(section: str, index: int = 0, drop: tuple[str, ...] = ()) -> Cell:
+    return Cell("mdx", f"{section}\u0000{index}", drop)
+
+
+def resolve(cells: list[Cell], blocks: dict[str, list[str]], page: str) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for cell in cells:
+        if cell.kind != "mdx":
+            out.append(("markdown" if cell.kind == "markdown" else "code", cell.body))
+            continue
+
+        section, raw_index = cell.body.split("\u0000")
+        index = int(raw_index)
+        if section not in blocks:
+            raise SystemExit(
+                f"{page}: no section titled {section!r}.\n"
+                f"  available: {sorted(blocks)}\n"
+                f"  Update notebooks/build.py to match the rewritten page."
+            )
+        if index >= len(blocks[section]):
+            raise SystemExit(
+                f"{page}: section {section!r} has {len(blocks[section])} Python block(s), "
+                f"needed index {index}.\n  Update notebooks/build.py to match the rewritten page."
+            )
+
+        code = blocks[section][index]
+        for line in cell.drop:
+            if line not in code:
+                raise SystemExit(f"{page}: expected to drop {line!r} from {section!r}, not found.")
+            code = "\n".join(l for l in code.splitlines() if l.strip() != line.strip())
+        out.append(("code", code.strip("\n")))
+    return out
+
+
+def notebook(cells: list[tuple[str, str]]) -> dict:
+    def cell(kind: str, source: str) -> dict:
+        base = {"cell_type": kind, "metadata": {}, "source": source.splitlines(keepends=True)}
+        if kind == "code":
+            base |= {"execution_count": None, "outputs": []}
+        return base
+
+    return {
+        "cells": [cell(k, s) for k, s in cells],
+        "metadata": {
+            "colab": {"provenance": [], "toc_visible": True},
+            "kernelspec": {"name": "python3", "display_name": "Python 3"},
+            "language_info": {"name": "python"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 0,
+    }
+
+
+# --------------------------------------------------------------------------
+# notebooks/article-narration.ipynb
+# --------------------------------------------------------------------------
+
+NARRATION_PAGE = "guides/media/article-narration.mdx"
+
+NARRATION = [
+    md(
+        "# Narrating Articles with Venice Text-to-Speech\n"
+        "\n"
+        "Turn any web article into a single narrated audio file, and play it back here.\n"
+        "\n"
+        "This notebook accompanies "
+        f"[Narrating Articles with Text-to-Speech]({DOCS_URL}/guides/media/article-narration), "
+        "which explains the reasoning behind each step. Run the cells in order.\n"
+        "\n"
+        "You need a Venice API key from "
+        f"[venice.ai/settings/api]({DOCS_URL}/guides/getting-started/generating-api-key). "
+        "A full run scrapes one page, makes one chat completion, and synthesizes about six "
+        "minutes of speech, so it consumes a small amount of credit."
+    ),
+    md(
+        "## Setup\n"
+        "\n"
+        "Store the key with the key icon in the Colab sidebar, as a secret named "
+        "`VENICE_API_KEY`, so it is not saved into the notebook when you share it. "
+        "If no secret is set you will be prompted for it, and the value stays in memory."
+    ),
+    extra(
+        "%pip install -q requests\n"
+        "\n"
+        "import os\n"
+        "\n"
+        "\n"
+        "def load_api_key() -> str:\n"
+        "    try:\n"
+        "        from google.colab import userdata\n"
+        "\n"
+        "        return userdata.get('VENICE_API_KEY')\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "    if os.environ.get('VENICE_API_KEY'):\n"
+        "        return os.environ['VENICE_API_KEY']\n"
+        "    from getpass import getpass\n"
+        "\n"
+        "    return getpass('Venice API key: ')\n"
+        "\n"
+        "\n"
+        "# The tutorial code reads the key from the environment.\n"
+        "os.environ['VENICE_API_KEY'] = load_api_key()\n"
+        "print('Key loaded.')"
+    ),
+    md(
+        "## 1. Choose a model and a voice\n"
+        "\n"
+        "Voices belong to models, and sending a voice from one family to a model from another "
+        "is the most common first mistake. `model_spec.voices` is the authoritative voice list "
+        "for a model, and `supported_formats` tells you which `response_format` values it "
+        "accepts.\n"
+        "\n"
+        "We use `tts-xai-v1` with the voice `eve`. It supports `pcm`, which is what makes "
+        "joining chunks straightforward in section 4."
+    ),
+    extra(
+        "import requests\n"
+        "\n"
+        "models = requests.get(\n"
+        "    'https://api.venice.ai/api/v1/models',\n"
+        "    headers={'Authorization': f\"Bearer {os.environ['VENICE_API_KEY']}\"},\n"
+        "    params={'type': 'tts'},\n"
+        "    timeout=60,\n"
+        ").json()['data']\n"
+        "\n"
+        "for model in models:\n"
+        "    spec = model['model_spec']\n"
+        "    print(f\"{model['id']:28} formats={spec['supported_formats']} \"\n"
+        "          f\"voices={len(spec['voices'])}\")"
+    ),
+    md(
+        "## 2. Make a single request\n"
+        "\n"
+        "The response body is raw audio rather than JSON, so write the bytes straight to a file."
+    ),
+    mdx("2. Make a single request"),
+    extra(
+        "from IPython.display import Audio\n"
+        "\n"
+        "Audio('hello.mp3')"
+    ),
+    md(
+        "## 3. Split text at the 4096 character limit\n"
+        "\n"
+        "The `input` field accepts at most 4096 characters, and longer text is rejected outright "
+        "rather than truncated silently. Splitting on sentence boundaries matters, because a "
+        "chunk that ends mid sentence produces an audible stumble at the join.\n"
+        "\n"
+        "The default `max_chars` is 1500 rather than something near the ceiling, and that is "
+        "deliberate. Synthesis time grows with input length, so smaller chunks come back sooner "
+        "and, because they run in parallel, finish the whole job faster."
+    ),
+    mdx("3. Split text at the 4096 character limit"),
+    md(
+        "## 4. Join the chunks into one file\n"
+        "\n"
+        "Concatenating encoded audio such as MP3 is unreliable, because every chunk carries its "
+        "own frame headers. Requesting `pcm` avoids the problem entirely. PCM is raw samples "
+        "with no container, so joining is just appending bytes, and the standard library `wave` "
+        "module writes the header for us."
+    ),
+    mdx("4. Join the chunks into one file"),
+    md(
+        "Raw PCM carries no sample rate, so you have to supply the correct one when writing the "
+        "WAV header, and it is model specific. `tts-xai-v1` returns 24 kHz while `tts-gradium-v1` "
+        "returns 48 kHz. Guess wrong and the narration plays at the wrong speed and pitch.\n"
+        "\n"
+        "To find the rate for any model, ask for one short clip as `wav` and read the header it "
+        "comes back with."
+    ),
+    extra(
+        "import wave\n"
+        "\n"
+        "probe = requests.post(\n"
+        "    f'{BASE_URL}/audio/speech',\n"
+        "    headers=HEADERS,\n"
+        "    json={'model': MODEL, 'voice': VOICE, 'input': 'Probe.', 'response_format': 'wav'},\n"
+        "    timeout=300,\n"
+        ")\n"
+        "probe.raise_for_status()\n"
+        "open('probe.wav', 'wb').write(probe.content)\n"
+        "\n"
+        "with wave.open('probe.wav') as handle:\n"
+        "    print(handle.getframerate(), handle.getnchannels(), handle.getsampwidth())"
+    ),
+    md(
+        "## 5. Prepare text that sounds right\n"
+        "\n"
+        "Scraped Markdown read aloud verbatim is close to unlistenable. A speech model spells "
+        "URLs out one character at a time, so `https://docs.venice.ai/llms.txt` comes out as "
+        "*h t t p s colon slash slash docs dot venice dot a i*. Rather than fighting Markdown "
+        "with regular expressions, we ask a chat model to rewrite the article as something meant "
+        "to be spoken.\n"
+        "\n"
+        "The page keeps this in a second file that imports `narrate`. Here everything shares one "
+        "namespace, so that import is dropped."
+    ),
+    mdx("5. Prepare text that sounds right", drop=("from narrate import narrate",)),
+    md(
+        "## 6. Put it together\n"
+        "\n"
+        "The page guards its entry point behind `__main__` and takes the URL from the command "
+        "line. In the notebook we set it directly, so change `URL` to narrate a different page.\n"
+        "\n"
+        "Saving `script.txt` next to the audio is worth the two lines. When a narration sounds "
+        "wrong the script almost always shows why, and you can fix it without paying to "
+        "synthesize again."
+    ),
+    extra(
+        "URL = 'https://docs.venice.ai/overview/privacy'\n"
+        "\n"
+        "print('Scraping', URL)\n"
+        "markdown = scrape(URL)\n"
+        "\n"
+        "print(f'Writing script from {len(markdown)} characters of Markdown')\n"
+        "script = write_script(markdown)\n"
+        "\n"
+        "with open('script.txt', 'w') as handle:\n"
+        "    handle.write(script)\n"
+        "\n"
+        "print(f'Script is {len(script)} characters')\n"
+        "print(script[:400] + '...')"
+    ),
+    md("Now that `script` exists, the two inspection cells from the tutorial can run."),
+    mdx("3. Split text at the 4096 character limit", 1),
+    mdx("4. Join the chunks into one file", 1),
+    md("Synthesize the whole article and listen to it."),
+    extra(
+        "narrate(script, 'article.wav')\n"
+        "\n"
+        "Audio('article.wav')"
+    ),
+    md(
+        "## Streaming for interactive use\n"
+        "\n"
+        "Batch narration optimizes total time. A voice interface has the opposite priority, "
+        "which is getting the first audio out as fast as possible. Setting `streaming: true` "
+        "returns the body sentence by sentence as it is generated, so playback can start in "
+        "about a second instead of waiting for the complete clip."
+    ),
+    mdx("Streaming for interactive use"),
+    extra("Audio('streamed.mp3')"),
+    md(
+        "## Next steps\n"
+        "\n"
+        f"- [Text-to-Speech]({DOCS_URL}/guides/media/text-to-speech), reference for the endpoint "
+        "and its parameters\n"
+        f"- [Voice Cloning]({DOCS_URL}/guides/media/voice-cloning), narrate with a custom voice "
+        "instead of a preset\n"
+        f"- [Cited Answers with Web Search]({DOCS_URL}/guides/tools/cited-web-answers), generate "
+        "the text this notebook narrates\n"
+        f"- [Speech-to-Text]({DOCS_URL}/guides/media/speech-to-text), transcribe the audio back "
+        "and compare it against `script.txt` to verify the chunks joined in the right order"
+    ),
+]
+
+BUILDS = [(NARRATION_PAGE, "notebooks/article-narration.ipynb", NARRATION)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="fail if a notebook is out of date")
+    args = parser.parse_args()
+
+    stale = []
+    for page, out, cells in BUILDS:
+        built = notebook(resolve(cells, code_blocks(REPO / page), page))
+        text = json.dumps(built, indent=1, ensure_ascii=False) + "\n"
+        target = REPO / out
+
+        if args.check:
+            current = target.read_text(encoding="utf-8") if target.exists() else ""
+            if current != text:
+                stale.append(out)
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+        code = sum(1 for k, _ in resolve(cells, code_blocks(REPO / page), page) if k == "code")
+        print(f"wrote {out} ({len(built['cells'])} cells, {code} code) from {page}")
+
+    if stale:
+        print("out of date, run python notebooks/build.py:", ", ".join(stale), file=sys.stderr)
+        return 1
+    if args.check:
+        print("notebooks are up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Stacked on #432.

## Why

The payoff of the narration tutorial is *audio*, and a static page cannot deliver it. In a notebook, `IPython.display.Audio` plays the result inline, so the reader hears the narration one click after opening the page, with no venv and nothing installed. A full run takes about 48 seconds.

I did not add one for the cited-answers tutorial. Its output is text, which the page already shows inline, so a notebook would mostly save a copy-paste.

## Generated, not hand-maintained

The tutorial page stays the single source of truth for its code. `notebooks/build.py` pulls the Python in verbatim, anchored by section heading:

```bash
python notebooks/build.py          # regenerate
python notebooks/build.py --check  # report staleness, write nothing
```

A notebook that silently goes stale is worse than no notebook, so the build fails loudly instead. Verified against three real failure modes:

| Change to the page | Result |
|---|---|
| Section the notebook depends on is renamed | fails, lists the headings it did find |
| A line the spec drops is removed upstream | fails, names the line |
| Code inside a block is edited | `--check` reports the notebook out of date |

## Why it is not just a concatenation of the page

Worth knowing before reviewing, because it is the reason `build.py` exists at all. The tutorial is ordered to be *read*, and four of its nine Python blocks will not run in page order: it inspects `chunks` before the text being chunked exists, reads a `probe.wav` it never creates, does `from narrate import narrate` across two files, and guards its entry point behind `__main__` with `sys.argv`.

So the build holds an explicit running order, which moves the two inspection cells to after `script` exists, and adds the cells that only make sense in Colab. Definitions come first, then the driver, then inspection. Prose is written for the notebook, since the page's narration does not read well as cell markdown.

## Verified by running it

Executed end to end with `nbclient` against the live API, not just built:

- 27 cells, 14 code, no errors
- four chunks, 383.2s of 24 kHz mono audio in `article.wav`
- sample rate probe returns `24000 1 2`
- streaming first byte at 0.80s, complete at 1.34s
- all three inline audio players render

Committed with outputs stripped, and confirmed no key is embedded. The setup cell reads `VENICE_API_KEY` from Colab secrets, falling back to the environment and then a `getpass` prompt, so a shared notebook never carries a key.

## Also in here

The page's captured model listing had gone stale: the API now returns `tts-qwen3-0-6b` alongside `tts-qwen3-1-7b`. Found by running the notebook and diffing its output against the page. Everything else in that listing still matches.

## Note

The Colab badge 404s until this merges to `main`, since Colab loads the notebook from GitHub.