### PR TITLE
Let each page generate its own social preview image

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3032,20 +3032,10 @@
   "seo": {
     "metatags": {
       "og:site_name": "Venice API Docs",
-      "og:title": "Venice API",
-      "og:description": "The API for private, unrestricted access to intelligence. OpenAI-compatible chat, image, audio, and video behind one API key.",
-      "og:url": "https://docs.venice.ai",
-      "og:image": "https://venice.ai/images/landing-social-preview.png",
       "og:locale": "en_US",
       "og:logo": "/logo/light.svg",
       "article:publisher": "Venice AI",
-      "twitter:title": "Venice API",
-      "twitter:description": "The API for private, unrestricted access to intelligence. OpenAI-compatible chat, image, audio, and video behind one API key.",
-      "twitter:url": "https://docs.venice.ai",
-      "twitter:image": "https://venice.ai/images/venice_social_preview_x.png",
-      "twitter:site": "@AskVenice",
-      "og:image:width": "1200",
-      "og:image:height": "630"
+      "twitter:site": "@AskVenice"
     },
     "indexing": "navigable"
   },


### PR DESCRIPTION
## What

Mintlify already generates an OG image per page, overlaying the **page title** and description on the site logo and primary color. We were not getting it, because a global `og:image` in `seo.metatags` replaces the generated image with a static one. All 128 pages shared one picture with no title on it.

This removes the globals that were suppressing per-page values, which is all it takes. No new assets and no build step.

## The same globals were also breaking the text

Verified against the live site rather than inferred from the config:

| Tag | On production today | Should be |
|---|---|---|
| `og:image` | same static image on every page | per-page, with the title rendered on it |
| `twitter:image` | same static image on every page | per-page |
| `twitter:title` | `Venice API` on **every** page | the page title |
| `twitter:description` | site blurb on **every** page | the page description |
| `twitter:url` | `https://docs.venice.ai` on **every** page | the page URL |
| `og:title` | correct on 125 of 128 pages | correct everywhere |
| `og:description` | correct on 125 of 128 pages | correct everywhere |

So an X card cannot currently tell two Venice docs pages apart. `og:title` looks fine only because 125 pages set it in frontmatter; the three that do not, including `api-reference/error-codes`, report `Venice API` as their title:

```
$ curl -sL https://docs.venice.ai/api-reference/error-codes | grep og:title
<meta property="og:title" content="Venice API"/>
```

## What is kept

The tags that genuinely are site-wide stay: `og:site_name`, `og:locale`, `og:logo`, `article:publisher`, `twitter:site`. Page frontmatter continues to override anything it sets explicitly, so the 125 pages with their own `og:title` are unaffected.

## Follow-up available

`thumbnails.background` in `docs.json` puts a custom background behind the generated overlay, and `thumbnails.appearance` and `thumbnails.font` control mode and typeface. Left out here so the default can be reviewed first.