### PR TITLE
Remove em dashes from the descriptions rendered on social cards

### DIFF
--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Error Codes
-description: "Venice API error code reference — HTTP status codes, error response format, refund status, retry guidance, and validation details for failed requests."
+description: "Venice API error code reference covering HTTP status codes, error response format, refund status, retry guidance, and validation details for failed requests."
 ---
 
 When an error occurs, the Venice API returns an HTTP status code and a descriptive message. Some errors also include additional fields, such as refund status, suggested retry models, validation details, or request IDs.

--- a/api-reference/rate-limiting.mdx
+++ b/api-reference/rate-limiting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rate Limits"
-description: "Venice API rate limits — per-tier request and token quotas, model-specific limits, headers exposing remaining capacity, and how to handle 429 responses."
+description: "Venice API rate limits, including per-tier request and token quotas, model-specific limits, headers exposing remaining capacity, and how to handle 429 responses."
 "og:title": "Rate Limits | Venice API Docs"
 ---
 

--- a/getting-started/quick-start.mdx
+++ b/getting-started/quick-start.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Quickstart for the Venice API — generate an API key, send your first chat completion, and explore image, video, and audio endpoints in minutes."
+description: "Quickstart for the Venice API. Generate an API key, send your first chat completion, and explore image, video, and audio endpoints in minutes."
 og:title: "Quickstart | Venice API Docs"
 ---
 

--- a/guides/getting-started/openai-migration.mdx
+++ b/guides/getting-started/openai-migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Migrate from OpenAI"
-description: "Move OpenAI-compatible chat, embeddings, and image apps to Venice in minutes by swapping the base URL and API key — same SDK, more privacy."
+description: "Move OpenAI-compatible chat, embeddings, and image apps to Venice in minutes by swapping the base URL and API key. Same SDK, more privacy."
 "og:title": "Migrate from OpenAI | Venice API Docs"
 "og:description": "Drop-in replacement for OpenAI with privacy, no censorship, and competitive pricing"
 ---

--- a/guides/integrations/crewai.mdx
+++ b/guides/integrations/crewai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CrewAI"
-description: "Build multi-agent crews with CrewAI and Venice — configure private, uncensored Venice models as the LLM backend for role-based agent collaboration."
+description: "Build multi-agent crews with CrewAI and Venice. Configure private, uncensored Venice models as the LLM backend for role-based agent collaboration."
 "og:title": "CrewAI | Venice API Docs"
 "og:description": "Create autonomous AI agent crews powered by Venice's private, uncensored models"
 ---

--- a/guides/integrations/crypto-rpc-agents.mdx
+++ b/guides/integrations/crypto-rpc-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Crypto RPC for Agents
-description: Use Venice as both the model provider and the blockchain RPC layer for autonomous AI agents — one credential, 230+ models, 11 chains, no MetaMask.
+description: Use Venice as both the model provider and the blockchain RPC layer for autonomous AI agents. One credential, 230+ models, 11 chains, no MetaMask.
 "og:title": "Crypto RPC for Agents | Venice API Docs"
 "og:description": "Use Venice as both the model provider and the blockchain RPC layer for autonomous AI agents. One credential, 230+ models, 11 chains."
 ---

--- a/guides/media/video-generation.mdx
+++ b/guides/media/video-generation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Video Generation
-description: Generate videos from text prompts or images on Venice's async queue API — submit a job, poll for status, and download the finished video.
+description: Generate videos from text prompts or images on Venice's async queue API. Submit a job, poll for status, and download the finished video.
 "og:title": "Video Generation | Venice API Docs"
 "og:description": "Learn how to generate videos from text prompts or images using Venice's async video generation API."
 ---

--- a/guides/media/video-upscaling.mdx
+++ b/guides/media/video-upscaling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Video Upscaling"
-description: "Enhance video resolution and quality on the Venice API using the Topaz Video Upscale model — submit a source clip, pick a scale, and retrieve the result."
+description: "Enhance video resolution and quality on the Venice API using the Topaz Video Upscale model. Submit a source clip, pick a scale, and retrieve the result."
 'og:title': "Video Upscaling Guide | Venice API Docs"
 'og:description': "Enhance video resolution and quality using the Topaz Video Upscale model via the Venice API"
 ---

--- a/guides/projects/overview.mdx
+++ b/guides/projects/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Demos & Projects"
 sidebarTitle: "Overview"
-description: "End-to-end demo projects built on the Venice API — LLM gateways, agents, and sample apps with runnable code you can read and adapt for your own builds."
+description: "End-to-end demo projects built on the Venice API, including LLM gateways, agents, and sample apps with runnable code you can read and adapt for your own builds."
 "og:title": "Demos | Venice API Docs"
 ---
 

--- a/overview/beta-models.mdx
+++ b/overview/beta-models.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Beta Models"
-description: "Preview new Venice models in beta — try upcoming chat, image, video, and audio models for evaluation before they reach general availability on the API."
+description: "Preview new Venice models in beta. Try upcoming chat, image, video, and audio models for evaluation before they reach general availability on the API."
 "og:title": "Beta Models | Venice API Docs"
 ---
 

--- a/overview/vvv-diem.mdx
+++ b/overview/vvv-diem.mdx
@@ -1,6 +1,6 @@
 ---
 title: VVV & DIEM
-description: "Fund Venice API inference with staked DIEM tokens — $1 per day of compute per token — minted from staked VVV or acquired on Base with no per-request billing."
+description: "Fund Venice API inference with staked DIEM tokens, worth $1 per day of compute each, minted from staked VVV or acquired on Base with no per-request billing."
 "og:title": "VVV & DIEM | Venice API Docs"
 "og:description": "Use VVV and DIEM to fund Venice API inference with a daily allowance that refreshes every epoch."
 ---


### PR DESCRIPTION
Follow-up to #439, which makes each page generate its own social preview image. Independent of it, no overlapping files.

## What

Once the OG image is generated per page, the `description` frontmatter is **rendered onto the card** rather than only living in a meta tag. Eleven descriptions used an em dash to bolt a list of specifics onto a summary, which reads worse as display text than as a search snippet.

Each becomes a sentence break or a joining word:

| Page | Before | After |
|---|---|---|
| `error-codes` | `error code reference — HTTP status codes, ...` | `error code reference covering HTTP status codes, ...` |
| `quick-start` | `Quickstart for the Venice API — generate an API key, ...` | `Quickstart for the Venice API. Generate an API key, ...` |
| `vvv-diem` | `staked DIEM tokens — $1 per day of compute per token — minted from ...` | `staked DIEM tokens, worth $1 per day of compute each, minted from ...` |

The other eight follow the same pattern. This is punctuation, not a rewrite: the longest description grows by 9 characters and every one stays inside the range search engines display. No em or en dash remains in any English page's frontmatter.

## The truncation audit, and why it changed nothing

Worth recording, since the conclusion was to not make the change.

A card fits roughly 100 characters of description before it ellipsizes, and **80 of 128 descriptions are longer than that**, with a median of 148. That sounds like a widespread problem and is not one. They already lead with the subject and verb, so the cut only drops trailing detail:

```
Generate vector embeddings with Venice for semantic search, RAG retrieval, clustering, and recommend...
Force Venice chat models to return JSON that matches your schema using response_format and JSON Sche...
```

Both are perfectly legible at the cut. Shortening them to fit would have traded snippet length in search results, where 150 to 160 characters is the useful range, for a cosmetic gain on a social card. The em dash cases were the exception, because a dash mid-truncation reads as an unfinished thought, and those are what this PR fixes.