### PR TITLE
Make the sample rate probe in the narration tutorial runnable

### DIFF
--- a/guides/media/article-narration.mdx
+++ b/guides/media/article-narration.mdx
@@ -289,6 +289,16 @@ To find the rate for any model, ask for one short clip as `wav` and read the hea
 ```python
 import wave
 
+response = requests.post(
+    f"{BASE_URL}/audio/speech",
+    headers=HEADERS,
+    json={"model": MODEL, "voice": VOICE, "input": "Probe.", "response_format": "wav"},
+    timeout=300,
+)
+response.raise_for_status()
+with open("probe.wav", "wb") as handle:
+    handle.write(response.content)
+
 with wave.open("probe.wav") as probe:
     print(probe.getframerate(), probe.getnchannels(), probe.getsampwidth())
 ```

--- a/notebooks/article-narration.ipynb
+++ b/notebooks/article-narration.ipynb
@@ -263,17 +263,18 @@
    "source": [
     "import wave\n",
     "\n",
-    "probe = requests.post(\n",
-    "    f'{BASE_URL}/audio/speech',\n",
+    "response = requests.post(\n",
+    "    f\"{BASE_URL}/audio/speech\",\n",
     "    headers=HEADERS,\n",
-    "    json={'model': MODEL, 'voice': VOICE, 'input': 'Probe.', 'response_format': 'wav'},\n",
+    "    json={\"model\": MODEL, \"voice\": VOICE, \"input\": \"Probe.\", \"response_format\": \"wav\"},\n",
     "    timeout=300,\n",
     ")\n",
-    "probe.raise_for_status()\n",
-    "open('probe.wav', 'wb').write(probe.content)\n",
+    "response.raise_for_status()\n",
+    "with open(\"probe.wav\", \"wb\") as handle:\n",
+    "    handle.write(response.content)\n",
     "\n",
-    "with wave.open('probe.wav') as handle:\n",
-    "    print(handle.getframerate(), handle.getnchannels(), handle.getsampwidth())"
+    "with wave.open(\"probe.wav\") as probe:\n",
+    "    print(probe.getframerate(), probe.getnchannels(), probe.getsampwidth())"
    ],
    "execution_count": null,
    "outputs": []

--- a/notebooks/build.py
+++ b/notebooks/build.py
@@ -230,21 +230,7 @@ NARRATION = [
         "To find the rate for any model, ask for one short clip as `wav` and read the header it "
         "comes back with."
     ),
-    extra(
-        "import wave\n"
-        "\n"
-        "probe = requests.post(\n"
-        "    f'{BASE_URL}/audio/speech',\n"
-        "    headers=HEADERS,\n"
-        "    json={'model': MODEL, 'voice': VOICE, 'input': 'Probe.', 'response_format': 'wav'},\n"
-        "    timeout=300,\n"
-        ")\n"
-        "probe.raise_for_status()\n"
-        "open('probe.wav', 'wb').write(probe.content)\n"
-        "\n"
-        "with wave.open('probe.wav') as handle:\n"
-        "    print(handle.getframerate(), handle.getnchannels(), handle.getsampwidth())"
-    ),
+    mdx("4. Join the chunks into one file", 2),
     md(
         "## 5. Prepare text that sounds right\n"
         "\n"


### PR DESCRIPTION
## The bug

The narration tutorial says to "ask for one short clip as `wav` and read the header it comes back with", but the code block only did the reading half. Nothing on the page ever creates `probe.wav`, so a reader following it literally hits:

```
FileNotFoundError: [Errno 2] No such file or directory: 'probe.wav'
```

Adding the request makes the block self-contained. Verified in a clean directory: it now prints `24000 1 2`, exactly the output the page claims.

## The notebook can now use it

The Colab notebook from #437 worked around this with a hand-written cell, added specifically because the published block could not run. Now that the page is correct, the notebook sources it like every other code cell, so `build.py` carries 16 fewer lines of duplicated tutorial code.

Regenerated and re-executed the notebook end to end against the live API: 27 cells, no errors, the probe cell prints `24000 1 2`, and the run produced 393.5s of audio.

## How it was found

By rebuilding both tutorials from their own published code blocks and running them against a live key, rather than from memory of what they should say. Everything else passed:

| Checked | Result |
|---|---|
| `research.py` assembled from the search tutorial, run end to end | works, 77s, stderr matches the page exactly |
| Every citation in the generated brief resolves to a listed source | passes |
| `limit` above 20 and `query` over 400 chars | both `400`, not clamped, as documented |
| Scraping an X URL | returns the exact error string the page quotes |
| `narrate.py` and `article_to_audio.py` as two files, as the page instructs | works, 50s, output format matches |
| Node.js blocks in both tutorials | both run, search block is self-contained |
| cURL blocks in both tutorials | all work |
| Mismatched voice and model error | matches the page verbatim |

Two captured numbers have drifted and are left alone deliberately. Both pages quote the privacy page at 7582 characters and it is now 7580, and the narration length varies run to run because the chat model writes a different script each time. Chasing either would mean re-editing after every upstream content change.