### PR TITLE
docs: size page descriptions to fit the social card

### DIFF
--- a/api-reference/api-spec.mdx
+++ b/api-reference/api-spec.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Venice API reference covering authentication, debugging, OpenAI compatibility, response headers, error handling, and the full list of supported endpoints.
+description: "Full Venice API reference: auth, OpenAI compatibility, headers, and every endpoint."
 "og:title": "API Reference | Venice API Docs"
 "og:description": "Complete API reference including authentication, debugging, OpenAI compatibility, and response headers"
 ---

--- a/api-reference/endpoint/chat/model_feature_suffix.mdx
+++ b/api-reference/endpoint/chat/model_feature_suffix.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Model Feature Suffix'
-description: "Enable Venice features like web search and character personas by appending suffixes to the model ID when you cannot modify the chat completions request body."
+description: "Enable web search and character personas by appending suffixes to the model ID."
 "og:title": "Model Feature Suffix | Venice API Docs"
 "og:description": "Documentation covering Venice's Model Feature Suffix feature."
 ---

--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Error Codes
-description: "Venice API error code reference — HTTP status codes, error response format, refund status, retry guidance, and validation details for failed requests."
+description: "Venice API error codes: HTTP statuses, response format, refund status, and retry guidance."
 ---
 
 When an error occurs, the Venice API returns an HTTP status code and a descriptive message. Some errors also include additional fields, such as refund status, suggested retry models, validation details, or request IDs.

--- a/api-reference/rate-limiting.mdx
+++ b/api-reference/rate-limiting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rate Limits"
-description: "Venice API rate limits — per-tier request and token quotas, model-specific limits, headers exposing remaining capacity, and how to handle 429 responses."
+description: "Venice API rate limits by tier, the headers that expose capacity, and handling 429s."
 "og:title": "Rate Limits | Venice API Docs"
 ---
 

--- a/getting-started/quick-start.mdx
+++ b/getting-started/quick-start.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Quickstart for the Venice API — generate an API key, send your first chat completion, and explore image, video, and audio endpoints in minutes."
+description: "Generate an API key and send your first Venice chat completion in minutes."
 og:title: "Quickstart | Venice API Docs"
 ---
 

--- a/guides/features/characters.mdx
+++ b/guides/features/characters.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Characters"
-description: "Discover public Venice characters, look up their slugs, and chat with their personas through the OpenAI-compatible Venice chat completions API."
+description: "Discover public Venice characters and chat with their personas via chat completions."
 'og:title': "Characters | Venice API Docs"
 'og:description': "Learn how to discover and chat with public Venice characters through the API."
 ---

--- a/guides/features/embeddings.mdx
+++ b/guides/features/embeddings.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Embeddings"
-description: "Generate vector embeddings with Venice for semantic search, RAG retrieval, clustering, and recommendations using the /embeddings endpoint."
+description: "Generate vector embeddings with Venice for semantic search, RAG retrieval, and clustering."
 'og:title': "Embeddings | Venice API Docs"
 'og:description': "Learn how to generate vector embeddings with the Venice API."
 ---

--- a/guides/features/file-inputs.mdx
+++ b/guides/features/file-inputs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "File Inputs"
-description: "Attach PDFs, Office documents, text, data, and source-code files to Venice chat completion requests for summarization, Q&A, and transformation."
+description: "Attach PDFs, documents, and source code to Venice chat completions for summarization."
 'og:title': "File Inputs | Venice API Docs"
 'og:description': "Learn how to send PDF, Office, text, data, and source-code files to chat models with the Venice API."
 ---

--- a/guides/features/function-calling.mdx
+++ b/guides/features/function-calling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Function Calling"
-description: "Let Venice chat models call your application tools and functions with OpenAI-compatible function calling, tool schemas, and the /chat/completions API."
+description: "Let Venice chat models call your tools with OpenAI-compatible function calling."
 'og:title': "Function Calling | Venice API Docs"
 'og:description': "Learn how to use function calling with Venice chat models."
 ---

--- a/guides/features/prompt-caching.mdx
+++ b/guides/features/prompt-caching.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prompt Caching
-description: Cut Venice API costs and latency by caching repeated prompt content like system prompts, conversation history, and document context across requests.
+description: "Cut Venice API cost and latency by caching repeated prompt content across requests."
 "og:title": "Prompt Caching | Venice API Docs"
 "og:description": "Learn how to use prompt caching to reduce costs and latency for repeated content in your API requests."
 ---

--- a/guides/features/reasoning-models.mdx
+++ b/guides/features/reasoning-models.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Reasoning Models"
-description: "Call Venice reasoning models that expose chain-of-thought tokens, control thinking effort, and surface step-by-step answers in chat completions."
+description: "Call Venice reasoning models that expose thinking tokens and control effort."
 'og:title': "Reasoning Models | Venice API Docs"
 'og:description': "Using reasoning models with visible thinking in the Venice API"
 ---

--- a/guides/features/structured-responses.mdx
+++ b/guides/features/structured-responses.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Structured Responses"
-description: "Force Venice chat models to return JSON that matches your schema using response_format and JSON Schema for reliable, parseable output."
+description: "Force Venice chat models to return JSON matching your schema with response_format."
 'og:title': "Structured Responses | Venice API Docs"
 'og:description': "Using structured responses within the Venice API"
 ---

--- a/guides/features/tee-e2ee-models.mdx
+++ b/guides/features/tee-e2ee-models.mdx
@@ -1,6 +1,6 @@
 ---
 title: "TEE & E2EE Models"
-description: "Run private inference on Venice with Trusted Execution Environment (TEE) models and end-to-end encryption that keep prompts unreadable to the host."
+description: "Run private inference on Venice with TEE models and end-to-end encryption."
 'og:title': "TEE & E2EE Models | Venice API Docs"
 'og:description': "Learn how to use TEE and E2EE models for maximum privacy in your AI applications"
 ---

--- a/guides/features/vision.mdx
+++ b/guides/features/vision.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Vision"
-description: "Analyze images with Venice vision-capable chat models using multimodal message content in the OpenAI-compatible chat completions API."
+description: "Analyze images with Venice vision models using multimodal content in chat completions."
 'og:title': "Vision | Venice API Docs"
 'og:description': "Learn how to send images to Venice vision models."
 ---

--- a/guides/getting-started/generating-api-key.mdx
+++ b/guides/getting-started/generating-api-key.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generating an API Key
-description: "Create a Venice API key from the dashboard, store the bearer token securely, and verify it works with a first authenticated chat completions request."
+description: "Create a Venice API key, store the token securely, and verify it with a request."
 "og:title": "Generating an API Key | Venice API Docs"
 "og:description": "Create, store, and verify a Venice API key from the API settings dashboard."
 ---

--- a/guides/getting-started/openai-migration.mdx
+++ b/guides/getting-started/openai-migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Migrate from OpenAI"
-description: "Move OpenAI-compatible chat, embeddings, and image apps to Venice in minutes by swapping the base URL and API key — same SDK, more privacy."
+description: "Move OpenAI-compatible apps to Venice by swapping the base URL and API key."
 "og:title": "Migrate from OpenAI | Venice API Docs"
 "og:description": "Drop-in replacement for OpenAI with privacy, no censorship, and competitive pricing"
 ---

--- a/guides/getting-started/postman.mdx
+++ b/guides/getting-started/postman.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using Postman
-description: "Explore and test every Venice API endpoint with the official Postman collection, including pre-configured requests, examples, and environment variables."
+description: "Explore and test every Venice API endpoint with the official Postman collection."
 "og:title": "Postman | Venice API Docs"
 ---
 

--- a/guides/integrations/ai-agents.mdx
+++ b/guides/integrations/ai-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI Agents
-description: Build private AI agents on Venice with coding tools, MCP hosts, agent frameworks, Venice Skills, and on-chain crypto workflows from a single API.
+description: "Build private AI agents on Venice with coding tools, MCP hosts, and agent frameworks."
 "og:title": "AI Agents | Venice API Docs"
 "og:description": "Use Venice as the private model, tools, media, and wallet layer for AI agents."
 ---

--- a/guides/integrations/aider.mdx
+++ b/guides/integrations/aider.mdx
@@ -1,6 +1,6 @@
 ---
 title: Aider
-description: Configure Aider for AI pair-programming in your terminal with private Venice chat models using Aider's OpenAI-compatible API base URL and model prefix.
+description: "Configure Aider for terminal pair-programming with private Venice chat models."
 "og:title": "Aider with Venice | Venice API Docs"
 "og:description": "Point Aider at Venice's OpenAI-compatible API for private AI pair programming in your terminal"
 ---

--- a/guides/integrations/brave-leo.mdx
+++ b/guides/integrations/brave-leo.mdx
@@ -1,6 +1,6 @@
 ---
 title: Brave Leo
-description: Connect Brave Leo to Venice through Bring Your Own Model settings for private, browser-native AI chat, page summaries, and optional web search.
+description: "Connect Brave Leo to Venice for private, browser-native AI chat and page summaries."
 "og:title": "Brave Leo with Venice | Venice API Docs"
 "og:description": "Configure Brave Leo to use Venice through its Bring Your Own Model settings."
 ---

--- a/guides/integrations/claude-code.mdx
+++ b/guides/integrations/claude-code.mdx
@@ -1,6 +1,6 @@
 ---
 title: Claude Code
-description: Configure the Claude Code CLI to route Anthropic Claude Opus and Sonnet requests through Venice for private, usage-based coding agent inference.
+description: "Route Claude Code CLI requests through Venice for private, usage-based coding inference."
 "og:title": "Claude Code with Venice | Venice API Docs"
 "og:description": "Set up Claude Code to use Claude Opus 4.5/4.6/4.7/4.8, Sonnet 4.5/4.6/4.7/4.8, and Fable 5 through Venice AI"
 ---

--- a/guides/integrations/cline.mdx
+++ b/guides/integrations/cline.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cline
-description: Configure the Cline coding assistant in VS Code to use private Venice models through an OpenAI-compatible API provider.
+description: "Configure the Cline coding assistant in VS Code to use private Venice models."
 "og:title": "Cline with Venice | Venice API Docs"
 "og:description": "Connect Cline in VS Code to Venice AI using an OpenAI-compatible base URL"
 ---

--- a/guides/integrations/codex-cli.mdx
+++ b/guides/integrations/codex-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: Codex CLI
-description: Point the OpenAI Codex CLI at Venice models with a local config.toml so coding agent requests run through Venice's private, OpenAI-compatible API.
+description: "Point the OpenAI Codex CLI at Venice models with a local config.toml."
 "og:title": "Codex CLI with Venice | Venice API Docs"
 "og:description": "Configure Codex CLI to send requests to Venice AI using a simple model provider config"
 ---

--- a/guides/integrations/crewai.mdx
+++ b/guides/integrations/crewai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CrewAI"
-description: "Build multi-agent crews with CrewAI and Venice — configure private, uncensored Venice models as the LLM backend for role-based agent collaboration."
+description: "Build multi-agent crews with CrewAI using private Venice models as the LLM backend."
 "og:title": "CrewAI | Venice API Docs"
 "og:description": "Create autonomous AI agent crews powered by Venice's private, uncensored models"
 ---

--- a/guides/integrations/crypto-rpc-agents.mdx
+++ b/guides/integrations/crypto-rpc-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Crypto RPC for Agents
-description: Use Venice as both the model provider and the blockchain RPC layer for autonomous AI agents — one credential, 230+ models, 11 chains, no MetaMask.
+description: "Use Venice as both model provider and blockchain RPC layer for autonomous agents."
 "og:title": "Crypto RPC for Agents | Venice API Docs"
 "og:description": "Use Venice as both the model provider and the blockchain RPC layer for autonomous AI agents. One credential, 230+ models, 11 chains."
 ---

--- a/guides/integrations/cursor.mdx
+++ b/guides/integrations/cursor.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cursor IDE
-description: Configure Cursor IDE to use Venice models including Claude, GPT, DeepSeek, and Qwen via an OpenAI-compatible base URL and the venice- model prefix.
+description: "Configure Cursor IDE to use Venice models through an OpenAI-compatible base URL."
 "og:title": "Cursor IDE with Venice | Venice API Docs"
 "og:description": "Set up Cursor IDE to use Venice AI models including Claude, GPT, DeepSeek, and more"
 ---

--- a/guides/integrations/generating-api-key-agent.mdx
+++ b/guides/integrations/generating-api-key-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: Autonomous Agent API Key Creation
-description: "Mint a Venice API key autonomously from an on-chain AI agent by staking VVV on Base and signing a Venice-issued validation token with a wallet."
+description: "Mint a Venice API key from an on-chain agent by staking VVV on Base."
 'og:title': "Autonomous Agent API Key | Venice API Docs"
 'og:description': How an autonomous AI agent can mint its own Venice API key by signing a Venice-issued token with a wallet that holds staked VVV on Base.
 ---

--- a/guides/integrations/hermes-agent.mdx
+++ b/guides/integrations/hermes-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hermes Agent
-description: Set up Venice as the model provider in Hermes Agent for private, uncensored AI with persistent memory, custom skills, and multi-platform messaging.
+description: "Set up Venice in Hermes Agent for private AI with persistent memory and custom skills."
 "og:title": "Hermes Agent with Venice | Venice API Docs"
 "og:description": "Set up Venice AI as a provider in Hermes Agent for privacy-focused, uncensored AI with persistent memory, skills, and multi-platform messaging."
 ---

--- a/guides/integrations/jan-ai.mdx
+++ b/guides/integrations/jan-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jan AI
-description: Configure Jan AI to use Venice models through an OpenAI-compatible remote model provider for private, local-feeling chat with cloud inference.
+description: "Configure Jan AI to use Venice models as a remote provider for private chat."
 "og:title": "Jan AI with Venice | Venice API Docs"
 "og:description": "Configure Jan AI to use Venice models through an OpenAI-compatible custom endpoint"
 ---

--- a/guides/integrations/kilo-code.mdx
+++ b/guides/integrations/kilo-code.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kilo Code
-description: Configure Kilo Code's native Venice provider in VS Code or the CLI so agentic coding requests, edits, and terminal actions run on private Venice models.
+description: "Configure Kilo Code's native Venice provider in VS Code or the CLI for agentic coding."
 "og:title": "Kilo Code with Venice | Venice API Docs"
 "og:description": "Connect Kilo Code to Venice AI with the native Venice provider in VS Code or the CLI"
 ---

--- a/guides/integrations/langchain.mdx
+++ b/guides/integrations/langchain.mdx
@@ -1,6 +1,6 @@
 ---
 title: "LangChain"
-description: "Wire Venice models into LangChain for chains, agents, tool use, and RAG pipelines using the OpenAI-compatible ChatOpenAI client and Python or JS SDKs."
+description: "Wire Venice models into LangChain for chains, agents, tool use, and RAG pipelines."
 "og:title": "LangChain | Venice API Docs"
 "og:description": "Build LangChain applications powered by Venice AI's private, uncensored models"
 ---

--- a/guides/integrations/livekit-agents.mdx
+++ b/guides/integrations/livekit-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "LiveKit Agents"
-description: "Build realtime voice agents with LiveKit Agents and Venice, wiring Venice STT, LLM, and TTS through the OpenAI-compatible plugin in an STT-LLM-TTS pipeline."
+description: "Build realtime voice agents with LiveKit using Venice STT, LLM, and TTS."
 "og:title": "LiveKit Agents | Venice API Docs"
 "og:description": "Power LiveKit voice agents with Venice's private, uncensored STT, LLM, and TTS models."
 ---

--- a/guides/integrations/llamaindex.mdx
+++ b/guides/integrations/llamaindex.mdx
@@ -1,6 +1,6 @@
 ---
 title: "LlamaIndex"
-description: "Build RAG pipelines, agents, and query engines with LlamaIndex using Venice's private, OpenAI-compatible chat models and embeddings via the OpenAILike client."
+description: "Build RAG pipelines and agents with LlamaIndex using Venice chat models and embeddings."
 "og:title": "LlamaIndex | Venice API Docs"
 "og:description": "Build LlamaIndex applications powered by Venice AI's private, uncensored models"
 ---

--- a/guides/integrations/mastra.mdx
+++ b/guides/integrations/mastra.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mastra"
-description: "Build TypeScript AI agents, tools, and workflows with Mastra using Venice's private, uncensored, OpenAI-compatible chat models as the LLM provider."
+description: "Build TypeScript agents and workflows with Mastra using Venice as the provider."
 "og:title": "Mastra | Venice API Docs"
 "og:description": "Build Mastra agents and workflows powered by Venice AI's private models"
 ---

--- a/guides/integrations/nanoclaw-venice.mdx
+++ b/guides/integrations/nanoclaw-venice.mdx
@@ -1,6 +1,6 @@
 ---
 title: NanoClaw
-description: Deploy NanoClaw, a lightweight personal AI assistant for WhatsApp and Telegram, on Venice for private, uncensored chat and media generation.
+description: "Deploy NanoClaw, a personal AI assistant for WhatsApp and Telegram, on Venice."
 "og:title": "NanoClaw with Venice | Venice API Docs"
 "og:description": "Set up NanoClaw, a lightweight AI assistant for WhatsApp and Telegram, using Venice AI for private, uncensored inference."
 ---

--- a/guides/integrations/openclaw-bot.mdx
+++ b/guides/integrations/openclaw-bot.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenClaw
-description: Configure Venice as the model provider in OpenClaw for private, uncensored AI across WhatsApp, Telegram, Discord, and other messaging surfaces.
+description: "Configure Venice in OpenClaw for private AI across WhatsApp, Telegram, and Discord."
 "og:title": "OpenClaw with Venice | Venice API Docs"
 "og:description": "Set up Venice AI as a provider in OpenClaw for privacy-focused, uncensored AI across WhatsApp, Telegram, Discord, and more."
 ---

--- a/guides/integrations/opencode.mdx
+++ b/guides/integrations/opencode.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenCode
-description: Wire OpenCode to Venice through an OpenAI-compatible custom provider so your coding agent runs on private Venice models with one configuration file.
+description: "Wire OpenCode to Venice so your coding agent runs on private models with one config file."
 "og:title": "OpenCode with Venice | Venice API Docs"
 "og:description": "Configure OpenCode to send coding-agent requests to Venice AI using a custom provider"
 ---

--- a/guides/integrations/pydanticai.mdx
+++ b/guides/integrations/pydanticai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "PydanticAI"
-description: "Build typed Python agents with PydanticAI using Venice's private, OpenAI-compatible chat models for tools, structured output, and streaming."
+description: "Build typed Python agents with PydanticAI using Venice chat models."
 "og:title": "PydanticAI | Venice API Docs"
 "og:description": "Build PydanticAI agents powered by Venice AI's private, uncensored models"
 ---

--- a/guides/integrations/rig.mdx
+++ b/guides/integrations/rig.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rig"
-description: "Build typed Rust agents with Rig's native Venice provider for tools, structured output, streaming, embeddings, and venice_parameters."
+description: "Build typed Rust agents with Rig's native Venice provider for tools and streaming."
 "og:title": "Rig | Venice API Docs"
 "og:description": "Build Rig agents in Rust with Venice's first-party provider"
 ---

--- a/guides/integrations/venice-cli.mdx
+++ b/guides/integrations/venice-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: Venice CLI
-description: Install the official Venice command-line tool for chat, web search, image generation, text-to-speech, transcription, video, and embeddings in your terminal.
+description: "Official Venice command-line tool for chat, search, images, speech, and video."
 "og:title": "Venice CLI | Venice API Docs"
 "og:description": "Chat, search, generate images, convert text to speech, and more from your terminal with Venice's official privacy-first CLI."
 ---

--- a/guides/integrations/venice-mcp.mdx
+++ b/guides/integrations/venice-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: Venice MCP Server
-description: The official Venice Model Context Protocol server exposes 31 Venice tools for chat, image, video, audio, music, and characters in any MCP host.
+description: "The official Venice MCP server exposes 31 tools for chat, image, video, and audio."
 "og:title": "Venice MCP Server | Venice API Docs"
 "og:description": "Plug Venice's chat, image, video, audio, music, and character models into Claude Desktop, Cursor, LM Studio, and any other MCP host."
 ---

--- a/guides/integrations/venice-skills.mdx
+++ b/guides/integrations/venice-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Venice Skills
-description: Official Venice Agent Skills that load endpoint knowledge into Claude Code, Cursor, Codex, OpenCode, Hermes, and Cline for reliable coding agents.
+description: "Official Venice Agent Skills that load endpoint knowledge into your coding agent."
 "og:title": "Venice Skills | Venice API Docs"
 "og:description": "Drop-in Agent Skills that teach your coding agent how to use every Venice endpoint correctly."
 ---

--- a/guides/integrations/venice-video-harness.mdx
+++ b/guides/integrations/venice-video-harness.mdx
@@ -1,6 +1,6 @@
 ---
 title: Venice Video Harness
-description: Drive Venice from Claude Code or Cursor with a Venice-optimized harness for character-consistent videos, storyboards, trailers, and long-form narrative.
+description: "Drive Venice from Claude Code or Cursor for character-consistent videos and storyboards."
 "og:title": "Venice Video Harness | Venice API Docs"
 "og:description": "Drive Venice from Claude Code or Cursor with a reusable production system for character-consistent videos, storyboards, trailers, and long-form narrative content."
 ---

--- a/guides/integrations/vercel-ai-sdk.mdx
+++ b/guides/integrations/vercel-ai-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Vercel AI SDK"
-description: "Stream Venice chat completions in Next.js and React apps using the Vercel AI SDK's OpenAI-compatible provider for production AI UIs and chatbots."
+description: "Stream Venice chat completions in Next.js and React with the Vercel AI SDK."
 "og:title": "Vercel AI SDK | Venice API Docs"
 "og:description": "Stream Venice AI responses in Next.js apps with the Vercel AI SDK"
 ---

--- a/guides/integrations/x402-venice-api.mdx
+++ b/guides/integrations/x402-venice-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: X402
-description: Access the Venice API without an API key by paying per request with the x402 protocol and authenticating with a crypto wallet on Base.
+description: "Access the Venice API with no key by paying per request with x402 and a crypto wallet."
 "og:title": X402
 "og:description": Access Venice without an API key using wallet authentication.
 ---

--- a/guides/media/article-narration.mdx
+++ b/guides/media/article-narration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Narrating Articles with Text-to-Speech"
 sidebarTitle: "Article Narration"
-description: "Turn any web article into a narrated audio file with Venice text-to-speech, covering voice selection, the 4096-character limit, gapless audio joining, and streaming."
+description: "Turn any web article into a narrated audio file with Venice text-to-speech."
 "og:title": "Narrating Articles with Text-to-Speech | Venice API Docs"
 "og:description": "Chunk long text, synthesize it with Venice text-to-speech, and join the audio into one narrated file."
 ---

--- a/guides/media/image-editing.mdx
+++ b/guides/media/image-editing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Image Editing"
-description: "Edit, inpaint, composite layered inputs, and remove backgrounds from images using Venice's synchronous image edit, multi-edit, and background-remove APIs."
+description: "Edit, inpaint, composite, and remove backgrounds from images with the Venice image APIs."
 'og:title': "Image Editing | Venice API Docs"
 'og:description': "Learn how to edit images with Venice using prompt-based inpainting, layered multi-edit inputs, and background removal."
 ---

--- a/guides/media/image-generation.mdx
+++ b/guides/media/image-generation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Image Generation"
-description: "Generate images from text prompts with Venice's native image API or the OpenAI-compatible images endpoint, with style controls and binary or base64 output."
+description: "Generate images from text prompts with Venice's native or OpenAI-compatible image API."
 'og:title': "Image Generation | Venice API Docs"
 'og:description': "Learn how to generate images with Venice using text prompts, model-specific options, and binary or base64 responses."
 ---

--- a/guides/media/image-upscaling.mdx
+++ b/guides/media/image-upscaling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Image Upscaling"
-description: "Enhance and upscale images with Venice's synchronous /image/upscale API, sending base64-encoded input and receiving higher-resolution binary image output."
+description: "Enhance and upscale images with Venice's synchronous /image/upscale endpoint."
 'og:title': "Image Upscaling | Venice API Docs"
 'og:description': "Learn how to enhance and upscale images with the Venice API."
 ---

--- a/guides/media/music-and-sound-effects.mdx
+++ b/guides/media/music-and-sound-effects.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Music & Sound Effects"
-description: "Generate music and sound effects with Venice's asynchronous audio API: choose a model, quote the cost, queue a job, and download the completed audio."
+description: "Generate music and sound effects with Venice's asynchronous audio API."
 "og:title": "Music & Sound Effects | Venice API Docs"
 "og:description": "Learn how to generate music and sound effects with the Venice API."
 ---

--- a/guides/media/prompt-enhancement.mdx
+++ b/guides/media/prompt-enhancement.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Prompt Enhancement"
-description: "Automatically rewrite image generation and edit prompts with Venice's enhance_prompt parameter to add clarifying visual detail and improve output quality."
+description: "Rewrite image prompts automatically with Venice's enhance_prompt parameter."
 'og:title': "Prompt Enhancement | Venice API Docs"
 'og:description': "Learn how to use the enhance_prompt parameter on Venice's image generation and editing APIs to expand short prompts into richer, more detailed descriptions."
 ---

--- a/guides/media/reference-to-video.mdx
+++ b/guides/media/reference-to-video.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Reference to Video"
-description: "Generate consistent AI videos with character elements, scene references, and multi-shot control on the Venice API using Kling O3 and Grok Imagine R2V models."
+description: "Generate consistent AI videos with character elements and scene references."
 'og:title': "Reference to Video Guide | Venice API Docs"
 'og:description': "Create consistent AI videos with character elements, scene references, and multi-shot control using Kling O3 and Grok Imagine R2V"
 ---

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Seedance 2.0 & 2.5"
-description: "Generate, edit, extend, and stitch videos with Seedance 2.0 and 2.5 on Venice using text, image, and reference-to-video workflows."
+description: "Generate, edit, extend, and stitch videos with Seedance 2.0 and 2.5 on Venice."
 'og:title': "Seedance 2.0 & 2.5 Guide | Venice API Docs"
 'og:description': "Generate, edit, extend and stitch videos with Seedance 2.0 and 2.5 via the Venice API. Workflow patterns, public API media policy, multimodal limits, pricing, and worked examples."
 ---

--- a/guides/media/seedance-face-consent.mdx
+++ b/guides/media/seedance-face-consent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Seedance Face-Media Consent"
-description: "Submit face-bearing media to Seedance 2.0 on Venice: the two-call attestation flow, the consent object, the needs_consent response, dedupe, and revocation."
+description: "Submit face-bearing media to Seedance 2.0 with the two-call attestation flow."
 'og:title': "Seedance Face-Media Consent | Venice API Docs"
 'og:description': "Submit face-bearing media to Seedance 2.0 via the Venice API: the needs_consent response, the single attestation object, dedupe, and revocation."
 ---

--- a/guides/media/speech-to-text.mdx
+++ b/guides/media/speech-to-text.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Speech-to-Text"
-description: "Transcribe audio files into text with Venice speech-to-text models using the OpenAI-compatible /audio/transcriptions endpoint and multipart uploads."
+description: "Transcribe audio to text with Venice speech-to-text models and /audio/transcriptions."
 'og:title': "Speech-to-Text | Venice API Docs"
 'og:description': "Learn how to transcribe audio files with the Venice API."
 ---

--- a/guides/media/text-to-speech.mdx
+++ b/guides/media/text-to-speech.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Text-to-Speech"
-description: "Generate spoken audio from text with Venice text-to-speech models, choose a model-specific voice, and save the binary response from the /audio/speech endpoint."
+description: "Generate spoken audio from text with Venice text-to-speech models and /audio/speech."
 'og:title': "Text-to-Speech | Venice API Docs"
 'og:description': "Learn how to convert text to speech with the Venice API."
 ---

--- a/guides/media/video-generation.mdx
+++ b/guides/media/video-generation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Video Generation
-description: Generate videos from text prompts or images on Venice's async queue API — submit a job, poll for status, and download the finished video.
+description: "Generate videos from text or images on Venice's async queue API."
 "og:title": "Video Generation | Venice API Docs"
 "og:description": "Learn how to generate videos from text prompts or images using Venice's async video generation API."
 ---

--- a/guides/media/video-upscaling.mdx
+++ b/guides/media/video-upscaling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Video Upscaling"
-description: "Enhance video resolution and quality on the Venice API using the Topaz Video Upscale model — submit a source clip, pick a scale, and retrieve the result."
+description: "Enhance video resolution and quality with the Topaz Video Upscale model on Venice."
 'og:title': "Video Upscaling Guide | Venice API Docs"
 'og:description': "Enhance video resolution and quality using the Topaz Video Upscale model via the Venice API"
 ---

--- a/guides/media/voice-cloning.mdx
+++ b/guides/media/voice-cloning.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Voice Cloning"
-description: "Clone a voice from a short reference audio sample using Chatterbox HD, save the returned voice handle, and generate speech via the Venice Audio API."
+description: "Clone a voice from a short audio sample with Chatterbox HD and generate speech with it."
 'og:title': "Voice Cloning Guide | Venice API Docs"
 'og:description': "Learn how to upload a reference voice sample and use the returned voice handle with Venice text-to-speech."
 ---

--- a/guides/projects/overview.mdx
+++ b/guides/projects/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Demos & Projects"
 sidebarTitle: "Overview"
-description: "End-to-end demo projects built on the Venice API — LLM gateways, agents, and sample apps with runnable code you can read and adapt for your own builds."
+description: "End-to-end demo projects built on the Venice API, with runnable code you can adapt."
 "og:title": "Demos | Venice API Docs"
 ---
 

--- a/guides/projects/private-rag-bot.mdx
+++ b/guides/projects/private-rag-bot.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Building a Private RAG Bot"
-description: "Build a private RAG bot using Venice embeddings, Qdrant vector search, FastEmbed re-ranking, and Venice chat completions for grounded, citable answers."
+description: "Build a private RAG bot with Venice embeddings, Qdrant, and grounded, citable answers."
 slug: private-rag-bot-venice-qdrant-reranking
 "og:title": "Building a Private RAG Bot with Venice, Qdrant, and Re-ranking"
 "og:description": "A practical guide to building a modern private RAG bot with Venice embeddings, Qdrant vector search, FastEmbed re-ranking, and Venice chat completions."

--- a/guides/projects/private-research-agent.mdx
+++ b/guides/projects/private-research-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Building a Private Research Agent"
-description: "Build a Python research agent on Venice that plans searches, reads web sources via the scrape API, extracts evidence, and writes cited Markdown reports."
+description: "Build a research agent on Venice that plans searches and writes cited Markdown reports."
 slug: private-research-agent-venice
 "og:title": "Building a Private Research Agent with Venice AI"
 "og:description": "A practical guide to building a Python research agent that plans searches, reads web sources with Venice's scrape API, extracts evidence, and writes cited Markdown reports."

--- a/guides/projects/rust-llm-gateway.mdx
+++ b/guides/projects/rust-llm-gateway.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Building a Rust LLM Gateway"
-description: "Build an OpenAI-compatible Rust LLM gateway on top of Venice with Axum, Postgres, SQLx, bearer-token auth, streaming responses, rate limits, and OpenTelemetry."
+description: "Build an OpenAI-compatible Rust LLM gateway on Venice with Axum, Postgres, and streaming."
 slug: rust-llm-gateway-venice
 "og:title": "Building a Rust LLM Gateway with Venice AI"
 "og:description": "A practical guide to building an OpenAI-compatible Rust LLM gateway with Axum, Postgres, SQLx, streaming responses, rate limits, and OpenTelemetry."

--- a/guides/projects/security-code-reviewer.mdx
+++ b/guides/projects/security-code-reviewer.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Building a Codebase Security Reviewer"
-description: "Build a Python security agent on Venice that finds atomic vulnerabilities and chains them into exploit paths using an AST repo map and Pydantic guardrails."
+description: "Build a security agent on Venice that finds vulnerabilities and chains them into exploits."
 slug: security-code-reviewer-venice
 "og:title": "Building a Codebase Security Reviewer with Venice AI"
 "og:description": "A practical guide to building a Python security agent that finds atomic vulnerabilities and chains them into exploit paths using Venice AI, an AST repo map, and Pydantic guardrails."

--- a/guides/tools/cited-web-answers.mdx
+++ b/guides/tools/cited-web-answers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cited Answers with Web Search"
 sidebarTitle: "Cited Answers"
-description: "Combine Venice Web Search, Web Scrape, and chat completions into a script that answers a question with a brief where every claim links back to a source."
+description: "Answer a question with a brief where every claim links back to a source you fetched."
 "og:title": "Cited Answers with Web Search | Venice API Docs"
 "og:description": "Chain Venice Web Search and Web Scrape into a chat completion that produces a cited research brief."
 ---

--- a/guides/tools/document-processing.mdx
+++ b/guides/tools/document-processing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Document Processing"
-description: "Extract text and token counts from documents with the Venice Text Parser API, then reuse the output in prompts, embeddings, and data pipelines."
+description: "Extract text and token counts from documents with the Venice Text Parser API."
 "og:title": "Document Processing | Venice API Docs"
 "og:description": "Extract reusable text from PDFs, Office documents, spreadsheets, and text files with Venice."
 ---

--- a/guides/tools/web-retrieval.mdx
+++ b/guides/tools/web-retrieval.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Search and Scraping"
 sidebarTitle: "Web Search and Scraping"
-description: "Find current sources with Venice Web Search and extract selected pages as Markdown with Venice Web Scrape."
+description: "Find current sources with Venice Web Search and extract pages as Markdown with Web Scrape."
 "og:title": "Web Search and Scraping | Venice API Docs"
 "og:description": "Search the web and scrape public pages into model-ready Markdown with Venice."
 ---

--- a/models/embeddings.mdx
+++ b/models/embeddings.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Embedding Models"
-description: "Venice embedding models for semantic search, RAG retrieval, and clustering, including pricing, dimensions, and OpenAI-compatible /embeddings usage."
+description: "Venice embedding models with pricing, dimensions, and OpenAI-compatible usage."
 "og:title": "Embedding Models | Venice API Docs"
 ---
 

--- a/models/image.mdx
+++ b/models/image.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Image Models"
-description: "Venice image models for text-to-image generation, image editing, background removal, and upscaling, with model IDs, pricing, and supported parameters."
+description: "Venice image models for generation, editing, background removal, and upscaling."
 "og:title": "Image Models | Venice API Docs"
 ---
 

--- a/models/music.mdx
+++ b/models/music.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Music & Sound Effects Models"
-description: "Venice music and audio models for AI-generated songs, instrumental tracks, and sound effects synthesis, with model IDs, pricing, and prompt guidance."
+description: "Venice music and audio models for songs, instrumental tracks, and sound effects."
 "og:title": "Music & Sound Effects Models | Venice API Docs"
 ---
 

--- a/models/overview.mdx
+++ b/models/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "All Models"
 sidebarTitle: "All Models"
-description: "Catalog of all models available on the Venice API across text, image, video, audio, embeddings, and speech, with capabilities, pricing, and model IDs."
+description: "Every model on the Venice API across text, image, video, audio, and embeddings."
 "og:title": "All Models | Venice API Docs"
 mode: "wide"
 ---

--- a/models/speech-to-text.mdx
+++ b/models/speech-to-text.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Speech-to-Text Models"
-description: "Venice speech-to-text models for transcribing audio to text with multilingual support, timestamps, and an OpenAI-compatible /audio/transcriptions endpoint."
+description: "Venice speech-to-text models with multilingual support, timestamps, and pricing."
 "og:title": "Speech-to-Text Models | Venice API Docs"
 ---
 

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Text-to-Speech Models"
-description: "Venice text-to-speech models with multilingual voices, voice selection, and streaming audio output via the OpenAI-compatible /audio/speech endpoint."
+description: "Venice text-to-speech models with multilingual voices and streaming audio output."
 "og:title": "Text-to-Speech Models | Venice API Docs"
 ---
 

--- a/models/text.mdx
+++ b/models/text.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Text Models"
-description: "Venice chat, reasoning, and code-generation text models with context lengths, pricing, traits, and OpenAI-compatible /chat/completions usage examples."
+description: "Venice chat, reasoning, and code models with context lengths, pricing, and traits."
 "og:title": "Text Models | Venice API Docs"
 ---
 

--- a/models/video.mdx
+++ b/models/video.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Video Models"
-description: "Venice video models for text-to-video, image-to-video, reference-to-video, and Topaz upscaling, with model IDs, pricing, and supported resolutions."
+description: "Venice video models for text-to-video, image-to-video, and Topaz upscaling."
 "og:title": "Video Models | Venice API Docs"
 ---
 

--- a/overview/about-venice.mdx
+++ b/overview/about-venice.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Venice API"
-description: "Venice API documentation with guides, quickstarts, and the full API reference for building private, unrestricted text, image, audio, and video apps."
+description: "Guides, quickstarts, and the full API reference for building private AI apps on Venice."
 "og:title": "Venice API Docs"
 "og:description": "Private, unrestricted access to all the leading AI models across text, image, video, and audio. OpenAI-compatible, behind one API key."
 mode: "wide"

--- a/overview/beta-models.mdx
+++ b/overview/beta-models.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Beta Models"
-description: "Preview new Venice models in beta — try upcoming chat, image, video, and audio models for evaluation before they reach general availability on the API."
+description: "Preview upcoming Venice chat, image, video, and audio models before general availability."
 "og:title": "Beta Models | Venice API Docs"
 ---
 

--- a/overview/deprecations.mdx
+++ b/overview/deprecations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deprecations"
-description: "Venice API model lifecycle policy, deprecation timelines, and the list of retired or sunset models so you can plan upgrades before models are removed."
+description: "Venice model lifecycle policy, deprecation timelines, and the list of retired models."
 "og:title": "Deprecations | Venice API Docs"
 ---
 

--- a/overview/privacy.mdx
+++ b/overview/privacy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Privacy
-description: "How Venice handles prompts, responses, and metadata, plus the privacy modes available: anonymized, private, Trusted Execution, and end-to-end encrypted."
+description: "How Venice handles prompts and metadata, plus the four privacy modes available."
 "og:title": "Privacy | Venice API Docs"
 "og:description": "Understand Venice privacy modes: anonymized, private, TEE, and E2EE."
 ---

--- a/overview/vvv-diem.mdx
+++ b/overview/vvv-diem.mdx
@@ -1,6 +1,6 @@
 ---
 title: VVV & DIEM
-description: "Fund Venice API inference with staked DIEM tokens — $1 per day of compute per token — minted from staked VVV or acquired on Base with no per-request billing."
+description: "Fund Venice inference with staked DIEM tokens, worth $1 of compute per day each."
 "og:title": "VVV & DIEM | Venice API Docs"
 "og:description": "Use VVV and DIEM to fund Venice API inference with a daily allowance that refreshes every epoch."
 ---


### PR DESCRIPTION
## Summary

Follow-up to #439, which enabled Mintlify's per-page OG card generation. Now that descriptions are actually rendered into an image, their length matters in a way it did not before.

Mintlify draws the `description` frontmatter into the card and clips it to two lines. **All 80 pages that set a description were over that budget**, so every card showed a sentence cut mid-clause:

> Turn any web article into a narrated audio file with Venice text-to-speech, covering voice selection, t…

This rewrites all 80 to fit the card completely.

| | before | after |
|---|---|---|
| longest | 165 chars | 90 chars |
| median | 148 chars | 82 chars |
| cards clipped | 80 of 80 | 0 of 80 |

## Why shorten rather than reorder

`description` does triple duty: page subtitle, `<meta name="description">`, and now the card. There is no way to feed the card separately, so the three have to be served by one string. Shortening wins on all three counts:

- **Card.** The only way to avoid the ellipsis, since the clip is a hard two-line limit.
- **Search.** Google truncates around 120 characters on mobile, so a 148-char median was already being cut. Meta description is not a ranking factor, and a complete sentence tends to beat a clipped keyword list on click-through.
- **Page.** A 165-character subtitle under the H1 was long to begin with.

Social **post text is unchanged** — that comes from the separate `og:description` field, which 125 pages already set and this PR does not touch.

## On the budget being 90, not 105

The limit is glyph-width dependent, not a character count. A 105-char lowercase string fits, while a 102-char caps-heavy one clips. I rendered real cards through the generator to find the safe point rather than guessing, and verified the worst case:

```
Search & RAG
Web Search and Scraping
Find current sources with Venice Web Search and
extract pages as Markdown with Web Scrape.
```

That is the longest remaining description (90 chars, caps-heavy) rendering in full with no ellipsis.

## Out of scope

The 48 API reference endpoint pages take their card text from `swagger.yaml`, not frontmatter, and clip at 160 characters. Fixing those means editing spec descriptions that are also shown in full in the reference UI, which is a separate tradeoff.

## Supersedes #440

That PR removed em dashes from 11 descriptions. All 11 are rewritten here, so it can be closed.

## Test plan

- [x] All 80 descriptions ≤ 90 characters, complete sentences, no em dashes
- [x] Frontmatter parses as valid YAML in all 80 files; only the `description` line changed
- [x] Longest and most caps-heavy descriptions verified against rendered cards
- [ ] Spot-check the preview deploy
