### PR TITLE
docs: add the audio research notebook demo

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -195,7 +195,8 @@
                   "guides/projects/private-rag-bot",
                   "guides/projects/private-research-agent",
                   "guides/projects/security-code-reviewer",
-                  "guides/projects/rust-llm-gateway"
+                  "guides/projects/rust-llm-gateway",
+                  "guides/projects/audio-research-notebook"
                 ]
               }
             ]

--- a/guides/projects/audio-research-notebook.mdx
+++ b/guides/projects/audio-research-notebook.mdx
@@ -1,0 +1,399 @@
+---
+title: "Building an Audio Research Notebook"
+description: "Turn your sources into cited answers and a two-host audio overview with Venice."
+slug: audio-research-notebook-venice
+"og:title": "Building an Audio Research Notebook with Venice"
+"og:description": "A NotebookLM-style notebook on Venice. Ingest URLs and PDFs, ask questions that cite their sources, and generate a two-host audio overview."
+---
+import { AuthorByline } from "/snippets/authorByline.jsx";
+
+<AuthorByline name="Sabrina Aquino" date="20 August 2026"/>
+
+Tools like NotebookLM changed what people expect from a pile of research. You add sources, you ask questions and get answers that point back at the material, and then you generate a conversation between two hosts that you can listen to on a walk.
+
+This guide builds that, in about two hundred lines of Python, on five Venice endpoints. Nothing is stored outside your machine except the requests themselves, and Venice does not retain those.
+
+<Card title="Run this notebook in Google Colab" icon="notebook" href="https://colab.research.google.com/github/veniceai/api-docs/blob/main/notebooks/audio-research-notebook.ipynb">
+  Every step below as an executable notebook, with the overview playing inline. Nothing to install.
+</Card>
+
+## How It Works
+
+Five endpoints, each doing one job:
+
+| Step | Endpoint | Why |
+| --- | --- | --- |
+| Read a web page | `/augment/scrape` | Returns Markdown, not HTML you have to clean |
+| Read a PDF or document | `/augment/text-parser` | One multipart upload, text back |
+| Index the text | `/embeddings` | Lets you retrieve by meaning rather than keyword |
+| Answer questions | `/chat/completions` | Grounded in retrieved passages, with citations |
+| Speak the overview | `/audio/speech` | Two voices, one per host |
+
+The retrieval here is deliberately plain: vectors in a Python list, cosine similarity in a loop. That is the right amount of machinery for a few dozen sources and it keeps the moving parts visible. When you outgrow it, [Building a Private RAG Bot](/guides/projects/private-rag-bot) covers the same pipeline with a real vector database and a re-ranking pass.
+
+## Setting Up
+
+One dependency, and a key from [the API settings page](/guides/getting-started/generating-api-key).
+
+```bash
+pip install requests
+export VENICE_API_KEY="your-key-here"
+```
+
+Create `notebook.py` and start with the imports and configuration. The two lists at the bottom are the whole state of the notebook: `sources` records what you added, and `chunks` holds the searchable pieces.
+
+```python
+import io
+import json
+import os
+import re
+import wave
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import requests
+
+BASE_URL = "https://api.venice.ai/api/v1"
+HEADERS = {"Authorization": f"Bearer {os.environ['VENICE_API_KEY']}"}
+
+EMBED_MODEL = "text-embedding-bge-m3"
+TTS_MODEL = "tts-xai-v1"
+HOSTS = {"Ana": "luna", "Marco": "orion"}
+
+sources = []
+chunks = []
+```
+
+`HOSTS` maps a host name to a voice. Both voices come from `tts-xai-v1`, and that matters: voices belong to models, and sending a voice from one family to a model from another is the most common first mistake with the speech endpoint.
+
+## Choosing a Model That Will Not Go Stale
+
+Hardcoding a chat model into a project guarantees the project ages. Venice publishes which model currently holds each role through `/models/traits`, so you can ask for the current default instead of naming one.
+
+```python
+def default_text_model():
+    response = requests.get(
+        f"{BASE_URL}/models/traits", headers=HEADERS, params={"type": "text"}, timeout=60
+    )
+    response.raise_for_status()
+    return response.json()["data"]["default"]
+
+
+CHAT_MODEL = default_text_model()
+
+
+def chat(messages, **options):
+    response = requests.post(
+        f"{BASE_URL}/chat/completions",
+        headers=HEADERS,
+        json={"model": CHAT_MODEL, "messages": messages, **options},
+        timeout=300,
+    )
+    response.raise_for_status()
+    return response.json()["choices"][0]["message"]["content"]
+```
+
+Other traits are available if this notebook is not the shape you want. `most_intelligent` buys you a stronger model for the reasoning-heavy summarization, and `default_reasoning` gives you one that thinks in the open. See [Models](/models/overview) for the full list.
+
+## Adding Sources
+
+A source is either a URL or a file on disk, and Venice has an endpoint for each. Both return plain text, which is the point: the rest of the notebook does not care where a source came from.
+
+```python
+def read_url(url):
+    response = requests.post(
+        f"{BASE_URL}/augment/scrape", headers=HEADERS, json={"url": url}, timeout=180
+    )
+    response.raise_for_status()
+    return response.json()["content"]
+
+
+def read_file(path):
+    with open(path, "rb") as handle:
+        response = requests.post(
+            f"{BASE_URL}/augment/text-parser",
+            headers=HEADERS,
+            files={"file": (Path(path).name, handle)},
+            timeout=180,
+        )
+    response.raise_for_status()
+    return response.json()["text"]
+```
+
+`/augment/scrape` returns Markdown rather than raw HTML, so there is no boilerplate stripping to write. `/augment/text-parser` accepts PDF, Word, Excel, and plain text up to 25 MB, and reports a token count alongside the text. [Document Processing](/guides/tools/document-processing) covers its options in full.
+
+## Chunking and Embedding
+
+Embedding a whole document produces one vector that is an average of everything it says, which is too blunt to retrieve a specific claim. Splitting it produces vectors that each mean something.
+
+Split on paragraph boundaries rather than a fixed character count. A chunk that stops mid-sentence retrieves badly, because the embedding is of a fragment.
+
+```python
+def split(text, limit=1200):
+    """Pack paragraphs into chunks without cutting one in half."""
+    packed, current = [], ""
+    for para in re.split(r"\n\s*\n", text):
+        para = para.strip()
+        if not para:
+            continue
+        if current and len(current) + len(para) + 2 > limit:
+            packed.append(current)
+            current = para
+        else:
+            current = f"{current}\n\n{para}" if current else para
+    if current:
+        packed.append(current)
+    return packed
+
+
+def embed(texts):
+    vectors = []
+    for start in range(0, len(texts), 64):
+        response = requests.post(
+            f"{BASE_URL}/embeddings",
+            headers=HEADERS,
+            json={"model": EMBED_MODEL, "input": texts[start : start + 64]},
+            timeout=180,
+        )
+        response.raise_for_status()
+        vectors.extend(row["embedding"] for row in response.json()["data"])
+    return vectors
+```
+
+`embed` batches because the endpoint takes a list, and one request for sixty-four chunks is far cheaper in wall time than sixty-four requests. `text-embedding-bge-m3` returns 1024 dimensions and handles multilingual sources well.
+
+Adding a source is now read, split, embed, and record. The magnitude of each vector gets stored alongside it, because it never changes and recomputing it inside the similarity loop is wasted work.
+
+```python
+def add_source(title, ref):
+    text = read_url(ref) if ref.startswith("http") else read_file(ref)
+    number = len(sources) + 1
+    sources.append({"number": number, "title": title, "ref": ref})
+
+    pieces = split(text)
+    for piece, vector in zip(pieces, embed(pieces)):
+        magnitude = sum(x * x for x in vector) ** 0.5
+        chunks.append(
+            {"source": number, "title": title, "text": piece,
+             "vector": vector, "magnitude": magnitude}
+        )
+    print(f"[{number}] {title}: {len(text)} characters, {len(pieces)} chunks")
+```
+
+The `number` is what makes citation possible later. Every chunk remembers which source it came from, so an answer can point back at it.
+
+## Retrieving the Right Passages
+
+Cosine similarity between the question vector and every chunk vector, sorted, top k. For a few thousand chunks this runs faster than the network call that produced the question vector.
+
+```python
+def retrieve(question, k=6):
+    query = embed([question])[0]
+    query_magnitude = sum(x * x for x in query) ** 0.5
+
+    def similarity(chunk):
+        dot = sum(a * b for a, b in zip(query, chunk["vector"]))
+        return dot / (query_magnitude * chunk["magnitude"])
+
+    return sorted(chunks, key=similarity, reverse=True)[:k]
+```
+
+## Answering with Citations
+
+The difference between a grounded answer and a confident guess is entirely in the prompt. Two instructions do the work: answer only from the notes, and say so when the notes fall short. Without the second one a model will quietly fill the gap from memory, which is the failure mode you are trying to design out.
+
+Numbering the notes in the prompt gives the model a citation vocabulary. It writes `[2]`, and you can resolve that back to a source.
+
+```python
+def ask(question, k=6):
+    hits = retrieve(question, k)
+    notes = "\n\n".join(f"[{h['source']}] {h['title']}\n{h['text']}" for h in hits)
+    answer = chat(
+        [
+            {"role": "system", "content": (
+                "Answer only from the numbered notes. Cite every claim with the bracket number "
+                "of the note it came from. If the notes do not answer the question, say so "
+                "instead of filling the gap.")},
+            {"role": "user", "content": f"Notes:\n\n{notes}\n\nQuestion: {question}"},
+        ],
+        temperature=0.2,
+    )
+    cited = sorted({int(n) for n in re.findall(r"\[(\d+)\]", answer)})
+    return answer, [s for s in sources if s["number"] in cited]
+```
+
+Parsing the brackets back out is worth the one line. It tells you which sources actually carried the answer, which is how you notice that a source you thought was central never gets cited.
+
+## Writing the Overview Script
+
+Here is where the notebook stops being a search box. A summary is something you read; an overview is something you listen to, and the two want different prose. Dialogue works better in audio because the turn-taking does the pacing for you, and a question from one host is a natural way to introduce the next idea.
+
+Three constraints matter, and all three come from the audio rather than the text:
+
+- **No markdown, no URLs.** A speech model reads `https://docs.venice.ai` one character at a time.
+- **Spell out abbreviations.** *T E E* the first time, not *tee*.
+- **Vary turn length.** Evenly sized turns sound like two people reading a list at each other.
+
+Asking for JSON with a schema is what makes the result renderable. Free-form text would need parsing, and speaker labels are exactly the thing a model gets creative about. The `enum` on `speaker` means every turn maps to a voice you have.
+
+```python
+DIALOGUE_SCHEMA = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "dialogue",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["turns"],
+            "properties": {
+                "turns": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["speaker", "text"],
+                        "properties": {
+                            "speaker": {"type": "string", "enum": list(HOSTS)},
+                            "text": {"type": "string"},
+                        },
+                    },
+                }
+            },
+        },
+    },
+}
+
+
+def write_script(turns=16):
+    """Ask a chat model for a two-host dialogue grounded in the sources."""
+    spread = chunks[:: max(1, len(chunks) // 12)][:12]
+    notes = "\n\n".join(f"{c['title']}\n{c['text']}" for c in spread)
+    hosts = " and ".join(HOSTS)
+    raw = chat(
+        [
+            {"role": "system", "content": (
+                f"You write podcast dialogue for two hosts, {hosts}. Ground every statement in "
+                "the supplied notes. Write for the ear: no markdown, no URLs, no bracket "
+                "citations, no stage directions. Spell out abbreviations the first time they "
+                "appear. Vary the length of turns. Open with a hook and close with a takeaway.")},
+            {"role": "user", "content": f"Notes:\n\n{notes}\n\nWrite about {turns} turns."},
+        ],
+        temperature=0.7,
+        response_format=DIALOGUE_SCHEMA,
+    )
+    return json.loads(raw)["turns"]
+```
+
+The overview covers the sources broadly rather than answering one question, so `spread` samples chunks across the whole collection instead of retrieving by similarity. Taking every nth chunk is crude and works well: it reaches the end of long documents, which taking the first twelve never would.
+
+Treat the turn count as a hint rather than an instruction. Asking for sixteen has produced anywhere from sixteen to twenty-eight here, depending on how much the sources have to say. If you need a hard ceiling, truncate `turns` before rendering rather than arguing with the prompt.
+
+## Rendering Two Voices into One Track
+
+Each turn becomes one speech request, with the voice chosen by who is speaking.
+
+```python
+def speak(turn):
+    response = requests.post(
+        f"{BASE_URL}/audio/speech",
+        headers=HEADERS,
+        json={"model": TTS_MODEL, "voice": HOSTS[turn["speaker"]],
+              "input": turn["text"], "response_format": "wav"},
+        timeout=300,
+    )
+    response.raise_for_status()
+    with wave.open(io.BytesIO(response.content)) as clip:
+        return clip.getparams(), clip.readframes(clip.getnframes())
+```
+
+Reading the frames out of each clip, rather than saving twenty files and stitching them afterwards, is what keeps the join clean. Concatenating encoded audio such as MP3 does not work reliably, because every file carries its own headers. Decoded frames are just samples, so joining them is appending bytes.
+
+Two details make the result sound intentional. The header for the output comes from the first clip rather than from constants, so the sample rate is always right for whichever model you chose. And a quarter second of silence between turns gives the ear a beat to register that the speaker changed. Without it the hosts talk over each other's endings.
+
+```python
+def audio_overview(turns, path="overview.wav", pause_seconds=0.25):
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        rendered = list(pool.map(speak, turns))
+
+    params = rendered[0][0]
+    silence = b"\x00" * int(params.framerate * params.sampwidth * params.nchannels * pause_seconds)
+    with wave.open(path, "wb") as out:
+        out.setnchannels(params.nchannels)
+        out.setsampwidth(params.sampwidth)
+        out.setframerate(params.framerate)
+        for position, (_, frames) in enumerate(rendered):
+            if position:
+                out.writeframes(silence)
+            out.writeframes(frames)
+    return path
+```
+
+`pool.map` preserves input order, so the turns come back in the order they were written no matter which finishes first. Four workers is a deliberate ceiling rather than a maximum: more concurrency will start returning 429s on lower tiers, and the job is already dominated by the longest single turn.
+
+## Running It
+
+```python
+if __name__ == "__main__":
+    add_source("Venice Privacy", "https://docs.venice.ai/overview/privacy")
+    add_source("TEE and E2EE Models", "https://docs.venice.ai/guides/features/tee-e2ee-models")
+    add_source("VVV and DIEM", "https://docs.venice.ai/overview/vvv-diem")
+
+    answer, cited = ask("How does Venice keep my prompts private, and what do I give up?")
+    print(answer)
+    print("\nSources:", ", ".join(f"[{s['number']}] {s['title']}" for s in cited))
+
+    turns = write_script()
+    print(f"\nWriting {len(turns)} turns to overview.wav")
+    audio_overview(turns)
+```
+
+```bash
+python notebook.py
+```
+
+```
+[1] Venice Privacy: 7507 characters, 7 chunks
+[2] TEE and E2EE Models: 43859 characters, 40 chunks
+[3] VVV and DIEM: 9609 characters, 11 chunks
+
+Venice's privacy architecture is built around a proxy foundation. All requests pass
+through Venice over HTTPS and are relayed to the model provider without Venice storing
+your prompt or response content [1]. On top of that proxy, each model offers one of four
+progressively stronger privacy modes [1]...
+
+Sources: [1] Venice Privacy
+
+Writing 23 turns to overview.wav
+```
+
+Ingesting and answering takes a few seconds. The audio is the slow part, and it varies with load: about six minutes of speech takes anywhere from half a minute to three minutes to render.
+
+## Making It Yours
+
+**The sources are the whole game.** Everything downstream is bounded by what you put in. Scraped pages bring their navigation and footers along, which is harmless for answering but shows up in an overview as a host earnestly discussing a documentation index. If that happens, drop chunks below a length threshold or filter obvious furniture before embedding.
+
+**Swap the voices.** `HOSTS` is two entries in a dictionary. `tts-xai-v1` ships twenty-six voices, and other families have their own; `GET /models?type=tts` lists `voices` per model. Two voices that contrast clearly are easier to follow than two that are merely different.
+
+**Clone your own.** [Voice Cloning](/guides/media/voice-cloning) turns a short sample into a voice handle you can drop straight into `HOSTS`.
+
+**Add a third participant.** Nothing in the pipeline assumes two speakers except the schema `enum`. Adding an interviewer who only asks questions changes the feel considerably.
+
+**Keep the script.** Writing `turns` to a JSON file next to the audio costs two lines and saves a re-render every time you want to tweak one sentence.
+
+## Where to Go Next
+
+<CardGroup cols={2}>
+  <Card title="Private RAG Bot" icon="database" href="/guides/projects/private-rag-bot">
+    The same retrieval pipeline with a real vector database and re-ranking.
+  </Card>
+  <Card title="Cited Answers with Web Search" icon="search" href="/guides/tools/cited-web-answers">
+    Find the sources automatically instead of naming them yourself.
+  </Card>
+  <Card title="Text-to-Speech" icon="microphone" href="/guides/media/text-to-speech">
+    Reference for the speech endpoint, its voices, and streaming.
+  </Card>
+  <Card title="Document Processing" icon="file-text" href="/guides/tools/document-processing">
+    Everything the text parser accepts, and what it returns.
+  </Card>
+</CardGroup>

--- a/guides/projects/overview.mdx
+++ b/guides/projects/overview.mdx
@@ -82,4 +82,24 @@ description: "End-to-end demo projects built on the Venice API, with runnable co
     </div>
     <div className="venice-demo-byline">Joshua Mo · Jul 2026</div>
   </div>
+
+  <div className="venice-demo-card">
+    <div className="venice-demo-card-head">
+      <span className="venice-demo-icon"><Icon icon="headphones" /></span>
+      <span className="venice-demo-lang">Python</span>
+    </div>
+    <h3 className="venice-demo-title">Audio Research Notebook</h3>
+    <p className="venice-demo-desc">Cited answers from your sources, plus a two-host audio overview you can listen to.</p>
+    <div className="venice-demo-tags">
+      <span className="venice-demo-tag">Scrape</span>
+      <span className="venice-demo-tag">Text Parser</span>
+      <span className="venice-demo-tag">Embeddings</span>
+      <span className="venice-demo-tag">Text-to-Speech</span>
+    </div>
+    <div className="venice-demo-actions">
+      <a className="venice-demo-link" href="/guides/projects/audio-research-notebook">Read the guide <span className="venice-demo-arrow">→</span></a>
+      <a className="venice-demo-repo" href="https://colab.research.google.com/github/veniceai/api-docs/blob/main/notebooks/audio-research-notebook.ipynb" target="_blank" rel="noopener noreferrer"><Icon icon="notebook" size={14} /> Colab</a>
+    </div>
+    <div className="venice-demo-byline">Sabrina Aquino · Aug 2026</div>
+  </div>
 </div>

--- a/llms.txt
+++ b/llms.txt
@@ -148,6 +148,7 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Building a Private Research Agent](https://docs.venice.ai/guides/projects/private-research-agent): Python research agent that plans searches, reads sources with Venice's scrape API, extracts evidence, and writes cited Markdown reports
 - [Building a Codebase Security Reviewer](https://docs.venice.ai/guides/projects/security-code-reviewer): Python security agent that finds vulnerabilities and chains them into exploit paths using Venice, an AST repo map, and Pydantic guardrails
 - [Building a Rust LLM Gateway](https://docs.venice.ai/guides/projects/rust-llm-gateway): OpenAI-compatible Rust gateway with Axum, Postgres-backed API keys, fixed-window rate limits, streaming responses, and OpenTelemetry
+- [Building an Audio Research Notebook](https://docs.venice.ai/guides/projects/audio-research-notebook): NotebookLM-style notebook that ingests URLs and documents with Venice scrape and text parser, answers questions with citations over embeddings, and renders a two-host audio overview with text-to-speech
 
 ## Key Features
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -5,6 +5,7 @@ Colab notebooks that accompany the tutorial pages.
 | Notebook | Tutorial |
 |---|---|
 | [`article-narration.ipynb`](article-narration.ipynb) | [Narrating Articles with Text-to-Speech](../guides/media/article-narration.mdx) |
+| [`audio-research-notebook.ipynb`](audio-research-notebook.ipynb) | [Building an Audio Research Notebook](../guides/projects/audio-research-notebook.mdx) |
 
 ## These are generated
 

--- a/notebooks/audio-research-notebook.ipynb
+++ b/notebooks/audio-research-notebook.ipynb
@@ -1,0 +1,525 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# An Audio Research Notebook on Venice\n",
+    "\n",
+    "Add sources, ask questions that cite them, then generate a two-host audio overview and play it back here.\n",
+    "\n",
+    "This notebook accompanies [Building an Audio Research Notebook](https://docs.venice.ai/guides/projects/audio-research-notebook), which explains the reasoning behind each step. Run the cells in order.\n",
+    "\n",
+    "You need a Venice API key from [venice.ai/settings/api](https://docs.venice.ai/guides/getting-started/generating-api-key). A full run scrapes three pages, embeds them, makes two chat completions, and synthesizes about six minutes of speech, so it consumes a small amount of credit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Store the key with the key icon in the Colab sidebar, as a secret named `VENICE_API_KEY`, so it is not saved into the notebook when you share it. If no secret is set you will be prompted for it, and the value stays in memory.\n",
+    "\n",
+    "Run this cell first. The configuration cell below reads the key as it is imported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%pip install -q requests\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "\n",
+    "def load_api_key() -> str:\n",
+    "    try:\n",
+    "        from google.colab import userdata\n",
+    "\n",
+    "        return userdata.get('VENICE_API_KEY')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    if os.environ.get('VENICE_API_KEY'):\n",
+    "        return os.environ['VENICE_API_KEY']\n",
+    "    from getpass import getpass\n",
+    "\n",
+    "    return getpass('Venice API key: ')\n",
+    "\n",
+    "\n",
+    "os.environ['VENICE_API_KEY'] = load_api_key()\n",
+    "print('Key loaded.')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "`HOSTS` maps a host name to a voice. Both voices belong to `tts-xai-v1`, and that matters: voices belong to models, and sending a voice from one family to a model from another is the most common first mistake with the speech endpoint.\n",
+    "\n",
+    "`sources` and `chunks` are the entire state of the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import io\n",
+    "import json\n",
+    "import os\n",
+    "import re\n",
+    "import wave\n",
+    "from concurrent.futures import ThreadPoolExecutor\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "BASE_URL = \"https://api.venice.ai/api/v1\"\n",
+    "HEADERS = {\"Authorization\": f\"Bearer {os.environ['VENICE_API_KEY']}\"}\n",
+    "\n",
+    "EMBED_MODEL = \"text-embedding-bge-m3\"\n",
+    "TTS_MODEL = \"tts-xai-v1\"\n",
+    "HOSTS = {\"Ana\": \"luna\", \"Marco\": \"orion\"}\n",
+    "\n",
+    "sources = []\n",
+    "chunks = []"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick the current model\n",
+    "\n",
+    "Hardcoding a chat model guarantees the project ages. `/models/traits` reports which model currently holds each role, so this asks for the current default instead of naming one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def default_text_model():\n",
+    "    response = requests.get(\n",
+    "        f\"{BASE_URL}/models/traits\", headers=HEADERS, params={\"type\": \"text\"}, timeout=60\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()[\"data\"][\"default\"]\n",
+    "\n",
+    "\n",
+    "CHAT_MODEL = default_text_model()\n",
+    "\n",
+    "\n",
+    "def chat(messages, **options):\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/chat/completions\",\n",
+    "        headers=HEADERS,\n",
+    "        json={\"model\": CHAT_MODEL, \"messages\": messages, **options},\n",
+    "        timeout=300,\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()[\"choices\"][0][\"message\"][\"content\"]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "print('Using', CHAT_MODEL)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add sources\n",
+    "\n",
+    "A source is a URL or a file on disk, and Venice has an endpoint for each. Both return plain text, so nothing downstream cares which one you used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def read_url(url):\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/augment/scrape\", headers=HEADERS, json={\"url\": url}, timeout=180\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()[\"content\"]\n",
+    "\n",
+    "\n",
+    "def read_file(path):\n",
+    "    with open(path, \"rb\") as handle:\n",
+    "        response = requests.post(\n",
+    "            f\"{BASE_URL}/augment/text-parser\",\n",
+    "            headers=HEADERS,\n",
+    "            files={\"file\": (Path(path).name, handle)},\n",
+    "            timeout=180,\n",
+    "        )\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()[\"text\"]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chunk and embed\n",
+    "\n",
+    "Embedding a whole document produces one vector that averages everything it says, which is too blunt to retrieve a specific claim. Splitting on paragraph boundaries produces vectors that each mean something."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def split(text, limit=1200):\n",
+    "    \"\"\"Pack paragraphs into chunks without cutting one in half.\"\"\"\n",
+    "    packed, current = [], \"\"\n",
+    "    for para in re.split(r\"\\n\\s*\\n\", text):\n",
+    "        para = para.strip()\n",
+    "        if not para:\n",
+    "            continue\n",
+    "        if current and len(current) + len(para) + 2 > limit:\n",
+    "            packed.append(current)\n",
+    "            current = para\n",
+    "        else:\n",
+    "            current = f\"{current}\\n\\n{para}\" if current else para\n",
+    "    if current:\n",
+    "        packed.append(current)\n",
+    "    return packed\n",
+    "\n",
+    "\n",
+    "def embed(texts):\n",
+    "    vectors = []\n",
+    "    for start in range(0, len(texts), 64):\n",
+    "        response = requests.post(\n",
+    "            f\"{BASE_URL}/embeddings\",\n",
+    "            headers=HEADERS,\n",
+    "            json={\"model\": EMBED_MODEL, \"input\": texts[start : start + 64]},\n",
+    "            timeout=180,\n",
+    "        )\n",
+    "        response.raise_for_status()\n",
+    "        vectors.extend(row[\"embedding\"] for row in response.json()[\"data\"])\n",
+    "    return vectors"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def add_source(title, ref):\n",
+    "    text = read_url(ref) if ref.startswith(\"http\") else read_file(ref)\n",
+    "    number = len(sources) + 1\n",
+    "    sources.append({\"number\": number, \"title\": title, \"ref\": ref})\n",
+    "\n",
+    "    pieces = split(text)\n",
+    "    for piece, vector in zip(pieces, embed(pieces)):\n",
+    "        magnitude = sum(x * x for x in vector) ** 0.5\n",
+    "        chunks.append(\n",
+    "            {\"source\": number, \"title\": title, \"text\": piece,\n",
+    "             \"vector\": vector, \"magnitude\": magnitude}\n",
+    "        )\n",
+    "    print(f\"[{number}] {title}: {len(text)} characters, {len(pieces)} chunks\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now add some sources. These three Venice pages cover overlapping ground, which makes the citations in the next section more interesting. Swap in your own URLs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "add_source('Venice Privacy', 'https://docs.venice.ai/overview/privacy')\n",
+    "add_source('TEE and E2EE Models', 'https://docs.venice.ai/guides/features/tee-e2ee-models')\n",
+    "add_source('VVV and DIEM', 'https://docs.venice.ai/overview/vvv-diem')\n",
+    "\n",
+    "print(f'{len(chunks)} chunks from {len(sources)} sources')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Optional: add a PDF from your machine\n",
+    "\n",
+    "This cell waits for you to choose a file, so skip it if you only want web sources. The text parser accepts PDF, Word, Excel, and plain text up to 25 MB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "try:\n",
+    "    from google.colab import files\n",
+    "\n",
+    "    for name in files.upload():\n",
+    "        add_source(name, name)\n",
+    "except ImportError:\n",
+    "    print('Not running in Colab, skipping the upload.')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ask a question\n",
+    "\n",
+    "Two instructions do the work of grounding: answer only from the notes, and say so when the notes fall short. Without the second one a model quietly fills the gap from memory, which is the failure mode you are designing out.\n",
+    "\n",
+    "Numbering the notes gives the model a citation vocabulary, and parsing the brackets back out tells you which sources actually carried the answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def retrieve(question, k=6):\n",
+    "    query = embed([question])[0]\n",
+    "    query_magnitude = sum(x * x for x in query) ** 0.5\n",
+    "\n",
+    "    def similarity(chunk):\n",
+    "        dot = sum(a * b for a, b in zip(query, chunk[\"vector\"]))\n",
+    "        return dot / (query_magnitude * chunk[\"magnitude\"])\n",
+    "\n",
+    "    return sorted(chunks, key=similarity, reverse=True)[:k]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def ask(question, k=6):\n",
+    "    hits = retrieve(question, k)\n",
+    "    notes = \"\\n\\n\".join(f\"[{h['source']}] {h['title']}\\n{h['text']}\" for h in hits)\n",
+    "    answer = chat(\n",
+    "        [\n",
+    "            {\"role\": \"system\", \"content\": (\n",
+    "                \"Answer only from the numbered notes. Cite every claim with the bracket number \"\n",
+    "                \"of the note it came from. If the notes do not answer the question, say so \"\n",
+    "                \"instead of filling the gap.\")},\n",
+    "            {\"role\": \"user\", \"content\": f\"Notes:\\n\\n{notes}\\n\\nQuestion: {question}\"},\n",
+    "        ],\n",
+    "        temperature=0.2,\n",
+    "    )\n",
+    "    cited = sorted({int(n) for n in re.findall(r\"\\[(\\d+)\\]\", answer)})\n",
+    "    return answer, [s for s in sources if s[\"number\"] in cited]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "answer, cited = ask('How does Venice keep my prompts private, and what do I give up?')\n",
+    "\n",
+    "display(Markdown(answer))\n",
+    "print('Sources:', ', '.join(f\"[{s['number']}] {s['title']}\" for s in cited))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write the overview script\n",
+    "\n",
+    "A summary is something you read; an overview is something you listen to. Dialogue works better in audio because the turn-taking does the pacing, and a question from one host introduces the next idea naturally.\n",
+    "\n",
+    "Asking for JSON with a schema is what makes the result renderable: the `enum` on `speaker` guarantees every turn maps to a voice you have."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "DIALOGUE_SCHEMA = {\n",
+    "    \"type\": \"json_schema\",\n",
+    "    \"json_schema\": {\n",
+    "        \"name\": \"dialogue\",\n",
+    "        \"strict\": True,\n",
+    "        \"schema\": {\n",
+    "            \"type\": \"object\",\n",
+    "            \"additionalProperties\": False,\n",
+    "            \"required\": [\"turns\"],\n",
+    "            \"properties\": {\n",
+    "                \"turns\": {\n",
+    "                    \"type\": \"array\",\n",
+    "                    \"items\": {\n",
+    "                        \"type\": \"object\",\n",
+    "                        \"additionalProperties\": False,\n",
+    "                        \"required\": [\"speaker\", \"text\"],\n",
+    "                        \"properties\": {\n",
+    "                            \"speaker\": {\"type\": \"string\", \"enum\": list(HOSTS)},\n",
+    "                            \"text\": {\"type\": \"string\"},\n",
+    "                        },\n",
+    "                    },\n",
+    "                }\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def write_script(turns=16):\n",
+    "    \"\"\"Ask a chat model for a two-host dialogue grounded in the sources.\"\"\"\n",
+    "    spread = chunks[:: max(1, len(chunks) // 12)][:12]\n",
+    "    notes = \"\\n\\n\".join(f\"{c['title']}\\n{c['text']}\" for c in spread)\n",
+    "    hosts = \" and \".join(HOSTS)\n",
+    "    raw = chat(\n",
+    "        [\n",
+    "            {\"role\": \"system\", \"content\": (\n",
+    "                f\"You write podcast dialogue for two hosts, {hosts}. Ground every statement in \"\n",
+    "                \"the supplied notes. Write for the ear: no markdown, no URLs, no bracket \"\n",
+    "                \"citations, no stage directions. Spell out abbreviations the first time they \"\n",
+    "                \"appear. Vary the length of turns. Open with a hook and close with a takeaway.\")},\n",
+    "            {\"role\": \"user\", \"content\": f\"Notes:\\n\\n{notes}\\n\\nWrite about {turns} turns.\"},\n",
+    "        ],\n",
+    "        temperature=0.7,\n",
+    "        response_format=DIALOGUE_SCHEMA,\n",
+    "    )\n",
+    "    return json.loads(raw)[\"turns\"]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "turns = write_script(16)\n",
+    "\n",
+    "print(f'{len(turns)} turns\\n')\n",
+    "for turn in turns[:4]:\n",
+    "    print(f\"{turn['speaker']}: {turn['text']}\\n\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Render it\n",
+    "\n",
+    "Each turn is one speech request, with the voice chosen by who is speaking. Reading the frames out of each clip rather than saving files and stitching them afterwards is what keeps the join clean, because concatenating encoded audio such as MP3 does not work reliably.\n",
+    "\n",
+    "The output header comes from the first clip rather than from constants, so the sample rate is right for whichever model you chose, and a quarter second of silence between turns gives the ear a beat to register that the speaker changed.\n",
+    "\n",
+    "Rendering six minutes of speech takes somewhere between half a minute and three minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def speak(turn):\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/audio/speech\",\n",
+    "        headers=HEADERS,\n",
+    "        json={\"model\": TTS_MODEL, \"voice\": HOSTS[turn[\"speaker\"]],\n",
+    "              \"input\": turn[\"text\"], \"response_format\": \"wav\"},\n",
+    "        timeout=300,\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    with wave.open(io.BytesIO(response.content)) as clip:\n",
+    "        return clip.getparams(), clip.readframes(clip.getnframes())"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def audio_overview(turns, path=\"overview.wav\", pause_seconds=0.25):\n",
+    "    with ThreadPoolExecutor(max_workers=4) as pool:\n",
+    "        rendered = list(pool.map(speak, turns))\n",
+    "\n",
+    "    params = rendered[0][0]\n",
+    "    silence = b\"\\x00\" * int(params.framerate * params.sampwidth * params.nchannels * pause_seconds)\n",
+    "    with wave.open(path, \"wb\") as out:\n",
+    "        out.setnchannels(params.nchannels)\n",
+    "        out.setsampwidth(params.sampwidth)\n",
+    "        out.setframerate(params.framerate)\n",
+    "        for position, (_, frames) in enumerate(rendered):\n",
+    "            if position:\n",
+    "                out.writeframes(silence)\n",
+    "            out.writeframes(frames)\n",
+    "    return path"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from IPython.display import Audio\n",
+    "\n",
+    "audio_overview(turns, 'overview.wav')\n",
+    "\n",
+    "Audio('overview.wav')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- [Building a Private RAG Bot](https://docs.venice.ai/guides/projects/private-rag-bot), the same retrieval pipeline with a real vector database and re-ranking\n",
+    "- [Cited Answers with Web Search](https://docs.venice.ai/guides/tools/cited-web-answers), find the sources automatically instead of naming them\n",
+    "- [Voice Cloning](https://docs.venice.ai/guides/media/voice-cloning), host the overview in your own voice\n",
+    "- [Document Processing](https://docs.venice.ai/guides/tools/document-processing), everything the text parser accepts and what it returns"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/build.py
+++ b/notebooks/build.py
@@ -302,7 +302,200 @@ NARRATION = [
     ),
 ]
 
-BUILDS = [(NARRATION_PAGE, "notebooks/article-narration.ipynb", NARRATION)]
+# --------------------------------------------------------------------------
+# notebooks/audio-research-notebook.ipynb
+# --------------------------------------------------------------------------
+
+RESEARCH_PAGE = "guides/projects/audio-research-notebook.mdx"
+
+RESEARCH = [
+    md(
+        "# An Audio Research Notebook on Venice\n"
+        "\n"
+        "Add sources, ask questions that cite them, then generate a two-host audio overview "
+        "and play it back here.\n"
+        "\n"
+        "This notebook accompanies "
+        f"[Building an Audio Research Notebook]({DOCS_URL}/guides/projects/audio-research-notebook), "
+        "which explains the reasoning behind each step. Run the cells in order.\n"
+        "\n"
+        "You need a Venice API key from "
+        f"[venice.ai/settings/api]({DOCS_URL}/guides/getting-started/generating-api-key). "
+        "A full run scrapes three pages, embeds them, makes two chat completions, and "
+        "synthesizes about six minutes of speech, so it consumes a small amount of credit."
+    ),
+    md(
+        "## Setup\n"
+        "\n"
+        "Store the key with the key icon in the Colab sidebar, as a secret named "
+        "`VENICE_API_KEY`, so it is not saved into the notebook when you share it. "
+        "If no secret is set you will be prompted for it, and the value stays in memory.\n"
+        "\n"
+        "Run this cell first. The configuration cell below reads the key as it is imported."
+    ),
+    extra(
+        "%pip install -q requests\n"
+        "\n"
+        "import os\n"
+        "\n"
+        "\n"
+        "def load_api_key() -> str:\n"
+        "    try:\n"
+        "        from google.colab import userdata\n"
+        "\n"
+        "        return userdata.get('VENICE_API_KEY')\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "    if os.environ.get('VENICE_API_KEY'):\n"
+        "        return os.environ['VENICE_API_KEY']\n"
+        "    from getpass import getpass\n"
+        "\n"
+        "    return getpass('Venice API key: ')\n"
+        "\n"
+        "\n"
+        "os.environ['VENICE_API_KEY'] = load_api_key()\n"
+        "print('Key loaded.')"
+    ),
+    md(
+        "## Configuration\n"
+        "\n"
+        "`HOSTS` maps a host name to a voice. Both voices belong to `tts-xai-v1`, and that "
+        "matters: voices belong to models, and sending a voice from one family to a model from "
+        "another is the most common first mistake with the speech endpoint.\n"
+        "\n"
+        "`sources` and `chunks` are the entire state of the notebook."
+    ),
+    mdx("Setting Up"),
+    md(
+        "## Pick the current model\n"
+        "\n"
+        "Hardcoding a chat model guarantees the project ages. `/models/traits` reports which "
+        "model currently holds each role, so this asks for the current default instead of "
+        "naming one."
+    ),
+    mdx("Choosing a Model That Will Not Go Stale"),
+    extra("print('Using', CHAT_MODEL)"),
+    md(
+        "## Add sources\n"
+        "\n"
+        "A source is a URL or a file on disk, and Venice has an endpoint for each. Both return "
+        "plain text, so nothing downstream cares which one you used."
+    ),
+    mdx("Adding Sources"),
+    md(
+        "## Chunk and embed\n"
+        "\n"
+        "Embedding a whole document produces one vector that averages everything it says, which "
+        "is too blunt to retrieve a specific claim. Splitting on paragraph boundaries produces "
+        "vectors that each mean something."
+    ),
+    mdx("Chunking and Embedding"),
+    mdx("Chunking and Embedding", 1),
+    md(
+        "Now add some sources. These three Venice pages cover overlapping ground, which makes "
+        "the citations in the next section more interesting. Swap in your own URLs."
+    ),
+    extra(
+        "add_source('Venice Privacy', 'https://docs.venice.ai/overview/privacy')\n"
+        "add_source('TEE and E2EE Models', 'https://docs.venice.ai/guides/features/tee-e2ee-models')\n"
+        "add_source('VVV and DIEM', 'https://docs.venice.ai/overview/vvv-diem')\n"
+        "\n"
+        "print(f'{len(chunks)} chunks from {len(sources)} sources')"
+    ),
+    md(
+        "### Optional: add a PDF from your machine\n"
+        "\n"
+        "This cell waits for you to choose a file, so skip it if you only want web sources. "
+        "The text parser accepts PDF, Word, Excel, and plain text up to 25 MB."
+    ),
+    extra(
+        "try:\n"
+        "    from google.colab import files\n"
+        "\n"
+        "    for name in files.upload():\n"
+        "        add_source(name, name)\n"
+        "except ImportError:\n"
+        "    print('Not running in Colab, skipping the upload.')"
+    ),
+    md(
+        "## Ask a question\n"
+        "\n"
+        "Two instructions do the work of grounding: answer only from the notes, and say so when "
+        "the notes fall short. Without the second one a model quietly fills the gap from memory, "
+        "which is the failure mode you are designing out.\n"
+        "\n"
+        "Numbering the notes gives the model a citation vocabulary, and parsing the brackets back "
+        "out tells you which sources actually carried the answer."
+    ),
+    mdx("Retrieving the Right Passages"),
+    mdx("Answering with Citations"),
+    extra(
+        "from IPython.display import Markdown, display\n"
+        "\n"
+        "answer, cited = ask('How does Venice keep my prompts private, and what do I give up?')\n"
+        "\n"
+        "display(Markdown(answer))\n"
+        "print('Sources:', ', '.join(f\"[{s['number']}] {s['title']}\" for s in cited))"
+    ),
+    md(
+        "## Write the overview script\n"
+        "\n"
+        "A summary is something you read; an overview is something you listen to. Dialogue works "
+        "better in audio because the turn-taking does the pacing, and a question from one host "
+        "introduces the next idea naturally.\n"
+        "\n"
+        "Asking for JSON with a schema is what makes the result renderable: the `enum` on "
+        "`speaker` guarantees every turn maps to a voice you have."
+    ),
+    mdx("Writing the Overview Script"),
+    extra(
+        "turns = write_script(16)\n"
+        "\n"
+        "print(f'{len(turns)} turns\\n')\n"
+        "for turn in turns[:4]:\n"
+        "    print(f\"{turn['speaker']}: {turn['text']}\\n\")"
+    ),
+    md(
+        "## Render it\n"
+        "\n"
+        "Each turn is one speech request, with the voice chosen by who is speaking. Reading the "
+        "frames out of each clip rather than saving files and stitching them afterwards is what "
+        "keeps the join clean, because concatenating encoded audio such as MP3 does not work "
+        "reliably.\n"
+        "\n"
+        "The output header comes from the first clip rather than from constants, so the sample "
+        "rate is right for whichever model you chose, and a quarter second of silence between "
+        "turns gives the ear a beat to register that the speaker changed.\n"
+        "\n"
+        "Rendering six minutes of speech takes somewhere between half a minute and three minutes."
+    ),
+    mdx("Rendering Two Voices into One Track"),
+    mdx("Rendering Two Voices into One Track", 1),
+    extra(
+        "from IPython.display import Audio\n"
+        "\n"
+        "audio_overview(turns, 'overview.wav')\n"
+        "\n"
+        "Audio('overview.wav')"
+    ),
+    md(
+        "## Next steps\n"
+        "\n"
+        f"- [Building a Private RAG Bot]({DOCS_URL}/guides/projects/private-rag-bot), the same "
+        "retrieval pipeline with a real vector database and re-ranking\n"
+        f"- [Cited Answers with Web Search]({DOCS_URL}/guides/tools/cited-web-answers), find the "
+        "sources automatically instead of naming them\n"
+        f"- [Voice Cloning]({DOCS_URL}/guides/media/voice-cloning), host the overview in your own "
+        "voice\n"
+        f"- [Document Processing]({DOCS_URL}/guides/tools/document-processing), everything the "
+        "text parser accepts and what it returns"
+    ),
+]
+
+BUILDS = [
+    (NARRATION_PAGE, "notebooks/article-narration.ipynb", NARRATION),
+    (RESEARCH_PAGE, "notebooks/audio-research-notebook.ipynb", RESEARCH),
+]
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

A new Demos entry: a NotebookLM-style research notebook on Venice. You add sources, ask questions that cite them, and generate a two-host audio overview you can listen to.

It is the first demo that chains five endpoints which until now only appeared separately:

| Step | Endpoint |
|---|---|
| Read a web page | `/augment/scrape` |
| Read a PDF or document | `/augment/text-parser` |
| Index the text | `/embeddings` |
| Answer with citations | `/chat/completions` |
| Speak the overview | `/audio/speech` |

The audio overview is the part worth looking at. A chat model writes a two-host dialogue constrained by a JSON schema, each turn renders with the voice belonging to its speaker, and the decoded frames are joined into one track.

## Choices worth flagging

**The chat model is not hardcoded.** It comes from `/models/traits`, so the demo picks up whatever currently holds the `default` trait instead of naming a model that ages out.

**Retrieval is a Python list and a cosine loop.** That is the right amount of machinery for a few dozen sources and it keeps the moving parts visible. The page points at [Private RAG Bot](https://docs.venice.ai/guides/projects/private-rag-bot) for anything larger, so the two demos complement rather than duplicate.

**The dialogue is schema-constrained.** Free-form text would need parsing, and speaker labels are exactly what a model gets creative about. The `enum` on `speaker` guarantees every turn maps to a voice that exists.

**Joining happens on decoded frames, not files.** Concatenating MP3 does not work reliably since every file carries its own headers. The output header is taken from the first clip rather than from constants, so the sample rate is correct whichever TTS model you pick.

## Verification

Everything here was run against the live API, not written from the spec.

- The page's Python was extracted, assembled, and diffed against the file that was actually executed: **0 differences**
- That assembled file runs end to end in **51s**, producing a 5.8 minute overview
- The generated notebook executes top to bottom under `nbclient`: **29 cells, 0 failures, 38s**
- Ingestion verified for both paths, a scraped URL and an uploaded PDF
- All 6 icons confirmed present in Tabler 3.46, after the earlier round of Font Awesome name mismatches
- 7 internal links resolve, `docs.json` parses, description is 79 chars so it fits the OG card from #443

## Notes

- English only for now. Translations follow separately, the way #438 followed the last pair of tutorials.
- Byline is set to Sabrina Aquino to match the pattern on the other demo pages. Easy to change.

## Test plan

- [x] `python notebooks/build.py --check` passes
- [x] Notebook executes with zero failing cells and no committed outputs
- [x] No API key in the diff
- [ ] Check the Colab badge resolves once merged to `main`
- [ ] Listen to a generated overview on the preview deploy