### PR TITLE
Document Seedance bitrate_mode for 2.0 and 2.5

### DIFF
--- a/api-reference/endpoint/video/queue.mdx
+++ b/api-reference/endpoint/video/queue.mdx
@@ -11,7 +11,7 @@ Private models also return a `download_url` for the finished video. It is a shor
 
 ### Seedance 2.0 & 2.5
 
-For `seedance-2-0-*-basic` and `seedance-2-5-*-basic` models (text-to-video, image-to-video, reference-to-video, plus the Seedance 2.0 `-fast-*` variants), see the [Seedance 2.0 & 2.5 Guide](/guides/media/seedance-2-0) for the four-workflow model (Reference / Edit / Extend / Stitch), source-matched `aspect_ratio` / `duration` values, family-specific multimodal limits, public API media policy, and pricing details.
+For `seedance-2-0-*-basic` and `seedance-2-5-*-basic` models (text-to-video, image-to-video, reference-to-video, plus the Seedance 2.0 `-fast-*` variants), see the [Seedance 2.0 & 2.5 Guide](/guides/media/seedance-2-0) for the four-workflow model (Reference / Edit / Extend / Stitch), source-matched `aspect_ratio` / `duration` values, user-settable `bitrate_mode`, family-specific multimodal limits, public API media policy, and pricing details.
 
 ### Public Seedance media policy
 

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -7,7 +7,7 @@ description: "Generate, edit, extend, and stitch videos with Seedance 2.0 and 2.
 
 Seedance is a flagship multimodal video family on Venice for text-, image-, and reference-driven video generation. **Seedance 2.0** (plus Fast) and **Seedance 2.5** share the same R2V prompt-routing model: a single reference-to-video endpoint handles **four distinct workflows** (Reference, Edit, Extend, Stitch) — the workflow is inferred from the **shape of your prompt**.
 
-This guide covers variants, the four workflows, **public API media policy**, **family-specific multimodal limits**, pricing, and `curl` examples.
+This guide covers variants, the four workflows, **public API media policy**, **family-specific multimodal limits**, output bitrate, pricing, and `curl` examples.
 
 <Warning>
 **Person-bearing media is not supported on the public Seedance API.** Public `*-basic` models do not use consent attestation (`consents.seedance` / `needs_consent`). Such inputs may be rejected upstream as a content-policy or provider error. Use the Venice app or Studio for the full Seedance feature set.
@@ -30,6 +30,17 @@ This guide covers variants, the four workflows, **public API media policy**, **f
 All variants are async. Submit via `POST /api/v1/video/queue`, then poll `POST /api/v1/video/retrieve` until the response body is `video/mp4`. See [Video Generation](/guides/media/video-generation) for the general queue flow.
 
 Pass `resolution` as one of: `480p`, `720p`, `1080p`, or `4k` (lowercase). Seedance **2.0** (non-Fast) accepts all four; **2.0 Fast** and **2.5** accept `480p` / `720p` only. Discover live model IDs and capabilities with `GET /models?type=video` — do not hardcode availability.
+
+## Output bitrate
+
+You can set the output encode bitrate on every public Seedance **2.0** (including Fast) and **2.5** model. Pass `bitrate_mode` on `/video/queue` yourself — Venice does not pick this automatically.
+
+| Value | Behavior |
+|---|---|
+| `standard` | Default bitrate. Same as omitting the field. |
+| `high` | Higher-quality, larger-file encode. |
+
+This is a queue-only encoding option: it does not change price or token cost, and `/video/quote` does not accept `bitrate_mode`. Other video families (Wan, Kling, LTX, and so on) do not support this field.
 
 ## The "one model, four workflows" model
 
@@ -202,6 +213,7 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 |---|---|---|
 | Output duration | 4–15 s | 4–30 s (default 10) |
 | Output resolutions | 480p / 720p / 1080p / **4k** (Fast: 480p / 720p only) | 480p / 720p only |
+| Output bitrate (`bitrate_mode`) | `standard` (default) or `high` | `standard` (default) or `high` |
 | R2V reference images | 1–9 | 1–30 |
 | Max R2V reference image bytes | (shared request limits) | ≤ 30 MB per image |
 | R2V reference videos | ≤ 3 | ≤ 10 |
@@ -289,7 +301,8 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
     "prompt": "Ultra-detailed aerial glide over a sunlit alpine lake, crystal water, distant peaks, cinematic color grade.",
     "duration": "5s",
     "aspect_ratio": "16:9",
-    "resolution": "4k"
+    "resolution": "4k",
+    "bitrate_mode": "high"
   }'
 ```
 
@@ -304,7 +317,8 @@ curl -X POST https://api.venice.ai/api/v1/video/queue \
     "prompt": "A slow aerial push over misty mountains at sunrise, clouds parting, soft orchestral ambience, cinematic widescreen framing.",
     "duration": "20s",
     "aspect_ratio": "16:9",
-    "resolution": "720p"
+    "resolution": "720p",
+    "bitrate_mode": "high"
   }'
 ```
 

--- a/guides/media/video-generation.mdx
+++ b/guides/media/video-generation.mdx
@@ -260,6 +260,7 @@ await fetch(`${BASE_URL}/video/complete`, {
 | `resolution` | string | No | `"720p"` | `"480p"`, `"720p"`, or `"1080p"` |
 | `aspect_ratio` | string | Conditional | - | Model-dependent. Required for models that expose aspect-ratio options; omit for models that do not support aspect-ratio selection |
 | `audio` | boolean | Conditional | `true` (when supported) | Only valid for models with `supportsAudioConfig: true`; omit for models without audio config support |
+| `bitrate_mode` | string | No | `"standard"` | Seedance 2.0 / 2.5 only. `"standard"` or `"high"`. `high` requests a higher-quality, larger-file encode. Does not change price. Omit for other families |
 | `image_url` | string | Only for image-to-video | - | URL or base64 data URL of source image |
 | `audio_url` | string | Conditional | - | URL or base64 data URL of reference audio for models that support audio input |
 


### PR DESCRIPTION
## Summary
- Document user-settable `bitrate_mode` (`standard` | `high`) on Seedance 2.0 (including Fast) and Seedance 2.5 `/video/queue` requests.
- Call it out in the Seedance guide, the video generation parameter table, and the queue endpoint pointer.
- Leave `swagger.yaml` unchanged; that spec is updated from outerface.

## Test plan
- [x] Confirm the Seedance 2.0 & 2.5 guide has an Output bitrate section and a family-comparison row
- [x] Confirm `/video/queue` examples for 2.0 4K T2V and 2.5 longer T2V include `"bitrate_mode": "high"`
- [x] Confirm the video-generation queue table lists `bitrate_mode` as Seedance-only and the quote table does not
- [ ] After outerface ships the OpenAPI field, confirm swagger sync matches this docs wording


Made with [Cursor](https://cursor.com)