### PR TITLE
Put model catalogs in the markdown export

### DIFF
--- a/api-reference/endpoint/models/list.mdx
+++ b/api-reference/endpoint/models/list.mdx
@@ -5,6 +5,10 @@ openapi: 'GET /models'
 "og:description": "Documentation covering Venice's model list API."
 ---
 
+This is the live catalog. If you can make HTTP requests, call this endpoint for current model IDs instead of relying on the snapshot tables on `/models`. No API key is required.
+
+`GET https://api.venice.ai/api/v1/models?type=text`
+
 ## Quality-Tier Pricing
 
 For image models that accept the optional `quality` parameter (currently `gpt-image-2` and `gpt-image-2-edit`), the response exposes a per-quality price matrix under `model_spec.pricing.quality`. Each top-level key is a resolution tier (`1K`, `2K`, `4K`) and each nested key is a quality level (`low`, `medium`, `high`) carrying its own `usd` and `diem` price:

--- a/api-reference/endpoint/models/traits.mdx
+++ b/api-reference/endpoint/models/traits.mdx
@@ -10,12 +10,21 @@ For additional examples, please see this [Postman Collection](https://www.postma
 
 ## Current text trait mappings
 
-These mappings are refreshed automatically from the public API.
+These mappings are refreshed automatically from the public API. If you can make HTTP requests, call this endpoint for the current mapping — no API key is required:
+
+`GET https://api.venice.ai/api/v1/models/traits?type=text`
 
 <div id="traits-list-placeholder"></div>
 
 <Visibility for="agents">
 {/* AUTO-GENERATED:API-TRAITS:START */}
+
+These mappings are a snapshot, refreshed about hourly.
+If you can make HTTP requests, fetch the live mappings instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models/traits?type=text`
+
+Use the snapshot below only when you cannot call the API.
 
 - `default` → currently routes to `zai-org-glm-5-2`
 - `function_calling_default` → currently routes to `zai-org-glm-5-2`

--- a/models/embeddings.mdx
+++ b/models/embeddings.mdx
@@ -4,12 +4,10 @@ description: "Venice embedding models with pricing, dimensions, and OpenAI-compa
 "og:title": "Embedding Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="embedding">Loading models...</div>
-
-<Visibility for="agents">
+<div id="model-search-placeholder" data-filter="embedding">
 {/* AUTO-GENERATED:MODELS:START */}
 
-This is the current model catalog, not a dynamic widget. Use the `id` value as the `model` parameter in API requests. 9 models currently available.
+Use the `id` value as the `model` parameter in API requests. 9 models currently available.
 
 | Model | ID | Input (per 1M tokens) | Privacy |
 |---|---|---|---|
@@ -24,7 +22,7 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 | Text Embedding 3 Small | `text-embedding-3-small` | $0.03 | Anonymized |
 
 {/* AUTO-GENERATED:MODELS:END */}
-</Visibility>
+</div>
 
 ---
 

--- a/models/embeddings.mdx
+++ b/models/embeddings.mdx
@@ -7,6 +7,13 @@ description: "Venice embedding models with pricing, dimensions, and OpenAI-compa
 <div id="model-search-placeholder" data-filter="embedding">
 {/* AUTO-GENERATED:MODELS:START */}
 
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=embedding`
+
+Use the snapshot below only when you cannot call the API.
+
 Use the `id` value as the `model` parameter in API requests. 9 models currently available.
 
 | Model | ID | Input (per 1M tokens) | Privacy |

--- a/models/image.mdx
+++ b/models/image.mdx
@@ -7,6 +7,15 @@ description: "Venice image models for generation, editing, background removal, a
 <div id="model-search-placeholder" data-filter="image">
 {/* AUTO-GENERATED:MODELS:START */}
 
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=image`
+`GET https://api.venice.ai/api/v1/models?type=upscale`
+`GET https://api.venice.ai/api/v1/models?type=inpaint`
+
+Use the snapshot below only when you cannot call the API.
+
 Use the `id` value as the `model` parameter in API requests. 60 models currently available.
 
 #### Generation

--- a/models/image.mdx
+++ b/models/image.mdx
@@ -4,12 +4,10 @@ description: "Venice image models for generation, editing, background removal, a
 "og:title": "Image Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="image">Loading models...</div>
-
-<Visibility for="agents">
+<div id="model-search-placeholder" data-filter="image">
 {/* AUTO-GENERATED:MODELS:START */}
 
-This is the current model catalog, not a dynamic widget. Use the `id` value as the `model` parameter in API requests. 60 models currently available.
+Use the `id` value as the `model` parameter in API requests. 60 models currently available.
 
 #### Generation
 
@@ -87,7 +85,7 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 | Wan 2.7 Pro Edit | `wan-2-7-pro-edit` | $0.09 | Anonymized |
 
 {/* AUTO-GENERATED:MODELS:END */}
-</Visibility>
+</div>
 
 ---
 

--- a/models/music.mdx
+++ b/models/music.mdx
@@ -7,6 +7,13 @@ description: "Venice music and audio models for songs, instrumental tracks, and 
 <div id="model-search-placeholder" data-filter="music">
 {/* AUTO-GENERATED:MODELS:START */}
 
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=music`
+
+Use the snapshot below only when you cannot call the API.
+
 Use the `id` value as the `model` parameter in API requests. 14 models currently available.
 
 | Model | ID | Pricing | Privacy |

--- a/models/music.mdx
+++ b/models/music.mdx
@@ -4,12 +4,10 @@ description: "Venice music and audio models for songs, instrumental tracks, and 
 "og:title": "Music & Sound Effects Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="music">Loading models...</div>
-
-<Visibility for="agents">
+<div id="model-search-placeholder" data-filter="music">
 {/* AUTO-GENERATED:MODELS:START */}
 
-This is the current model catalog, not a dynamic widget. Use the `id` value as the `model` parameter in API requests. 14 models currently available.
+Use the `id` value as the `model` parameter in API requests. 14 models currently available.
 
 | Model | ID | Pricing | Privacy |
 |---|---|---|---|
@@ -29,7 +27,7 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 | Stable Audio 2.5 | `stable-audio-25` | $0.19 / generation | Anonymized |
 
 {/* AUTO-GENERATED:MODELS:END */}
-</Visibility>
+</div>
 
 ## Model Categories
 

--- a/models/overview.mdx
+++ b/models/overview.mdx
@@ -9,6 +9,13 @@ mode: "wide"
 <div id="model-search-placeholder">
 {/* AUTO-GENERATED:MODELS:START */}
 
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=all`
+
+Use the snapshot below only when you cannot call the API.
+
 Use the `id` value as the `model` parameter in API requests. 321 models currently available.
 
 ### Text (110)

--- a/models/overview.mdx
+++ b/models/overview.mdx
@@ -6,12 +6,10 @@ description: "Every model on the Venice API across text, image, video, audio, an
 mode: "wide"
 ---
 
-<div id="model-search-placeholder">Loading models...</div>
-
-<Visibility for="agents">
+<div id="model-search-placeholder">
 {/* AUTO-GENERATED:MODELS:START */}
 
-This is the current model catalog, not a dynamic widget. Use the `id` value as the `model` parameter in API requests. 321 models currently available.
+Use the `id` value as the `model` parameter in API requests. 321 models currently available.
 
 ### Text (110)
 
@@ -382,4 +380,4 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 | Text Embedding 3 Small | `text-embedding-3-small` | $0.03 | Anonymized |
 
 {/* AUTO-GENERATED:MODELS:END */}
-</Visibility>
+</div>

--- a/models/speech-to-text.mdx
+++ b/models/speech-to-text.mdx
@@ -7,6 +7,13 @@ description: "Venice speech-to-text models with multilingual support, timestamps
 <div id="model-search-placeholder" data-filter="asr">
 {/* AUTO-GENERATED:MODELS:START */}
 
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=asr`
+
+Use the snapshot below only when you cannot call the API.
+
 Use the `id` value as the `model` parameter in API requests. 5 models currently available.
 
 | Model | ID | Per audio second | Privacy |

--- a/models/speech-to-text.mdx
+++ b/models/speech-to-text.mdx
@@ -4,12 +4,10 @@ description: "Venice speech-to-text models with multilingual support, timestamps
 "og:title": "Speech-to-Text Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="asr">Loading models...</div>
-
-<Visibility for="agents">
+<div id="model-search-placeholder" data-filter="asr">
 {/* AUTO-GENERATED:MODELS:START */}
 
-This is the current model catalog, not a dynamic widget. Use the `id` value as the `model` parameter in API requests. 5 models currently available.
+Use the `id` value as the `model` parameter in API requests. 5 models currently available.
 
 | Model | ID | Per audio second | Privacy |
 |---|---|---|---|
@@ -20,7 +18,7 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 | xAI Speech to Text v1 | `stt-xai-v1` | $0.0000 | Anonymized |
 
 {/* AUTO-GENERATED:MODELS:END */}
-</Visibility>
+</div>
 
 ---
 

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -7,6 +7,13 @@ description: "Venice text-to-speech models with multilingual voices and streamin
 <div id="model-search-placeholder" data-filter="tts">
 {/* AUTO-GENERATED:MODELS:START */}
 
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=tts`
+
+Use the snapshot below only when you cannot call the API.
+
 Use the `id` value as the `model` parameter in API requests. 11 models currently available.
 
 | Model | ID | Per 1M characters | Voices | Privacy |
@@ -35,6 +42,15 @@ of the `model` you selected. Pick a model below to browse its voices.
 
 <div id="tts-voice-picker-placeholder">
 {/* AUTO-GENERATED:VOICES:START */}
+
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=tts`
+
+Use the snapshot below only when you cannot call the API.
+
+Voice IDs are listed on each TTS model as `model_spec.voices`.
 
 #### Chatterbox HD (Resemble AI) (`tts-chatterbox-hd`)
 

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -4,12 +4,10 @@ description: "Venice text-to-speech models with multilingual voices and streamin
 "og:title": "Text-to-Speech Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="tts">Loading models...</div>
-
-<Visibility for="agents">
+<div id="model-search-placeholder" data-filter="tts">
 {/* AUTO-GENERATED:MODELS:START */}
 
-This is the current model catalog, not a dynamic widget. Use the `id` value as the `model` parameter in API requests. 11 models currently available.
+Use the `id` value as the `model` parameter in API requests. 11 models currently available.
 
 | Model | ID | Per 1M characters | Voices | Privacy |
 |---|---|---|---|---|
@@ -26,7 +24,7 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 | xAI TTS v1 | `tts-xai-v1` | $18.75 | 26 | Anonymized |
 
 {/* AUTO-GENERATED:MODELS:END */}
-</Visibility>
+</div>
 
 ---
 
@@ -35,9 +33,7 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 Voices are **model-specific**. The `voice` you pass must come from the catalog
 of the `model` you selected. Pick a model below to browse its voices.
 
-<div id="tts-voice-picker-placeholder">Loading voices...</div>
-
-<Visibility for="agents">
+<div id="tts-voice-picker-placeholder">
 {/* AUTO-GENERATED:VOICES:START */}
 
 #### Chatterbox HD (Resemble AI) (`tts-chatterbox-hd`)
@@ -303,7 +299,7 @@ of the `model` you selected. Pick a model below to browse its voices.
 | `zenith` |
 
 {/* AUTO-GENERATED:VOICES:END */}
-</Visibility>
+</div>
 
 <Note>
 Voice IDs are case-sensitive and **only valid for the matching `model`**. Pass

--- a/models/text.mdx
+++ b/models/text.mdx
@@ -7,6 +7,13 @@ description: "Venice chat, reasoning, and code models with context lengths, pric
 <div id="model-search-placeholder" data-filter="text">
 {/* AUTO-GENERATED:MODELS:START */}
 
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=text`
+
+Use the snapshot below only when you cannot call the API.
+
 Use the `id` value as the `model` parameter in API requests. 110 models currently available.
 
 | Model | ID | Input | Output | Context | Privacy | Capabilities |

--- a/models/text.mdx
+++ b/models/text.mdx
@@ -4,12 +4,10 @@ description: "Venice chat, reasoning, and code models with context lengths, pric
 "og:title": "Text Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="text">Loading models...</div>
-
-<Visibility for="agents">
+<div id="model-search-placeholder" data-filter="text">
 {/* AUTO-GENERATED:MODELS:START */}
 
-This is the current model catalog, not a dynamic widget. Use the `id` value as the `model` parameter in API requests. 110 models currently available.
+Use the `id` value as the `model` parameter in API requests. 110 models currently available.
 
 | Model | ID | Input | Output | Context | Privacy | Capabilities |
 |---|---|---|---|---|---|---|
@@ -125,7 +123,7 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 | Venice Uncensored 1.2 | `venice-uncensored-1-2` | $0.20 | $0.90 | 128K | Private | Function calling, Vision, Uncensored |
 
 {/* AUTO-GENERATED:MODELS:END */}
-</Visibility>
+</div>
 
 ---
 

--- a/models/video.mdx
+++ b/models/video.mdx
@@ -7,6 +7,13 @@ description: "Venice video models for text-to-video, image-to-video, and Topaz u
 <div id="model-search-placeholder" data-filter="video">
 {/* AUTO-GENERATED:MODELS:START */}
 
+This table is a snapshot of the public catalog, refreshed about hourly.
+If you can make HTTP requests, fetch the live list instead — no API key required:
+
+`GET https://api.venice.ai/api/v1/models?type=video`
+
+Use the snapshot below only when you cannot call the API.
+
 Use the `id` value as the `model` parameter in API requests. 112 models currently available.
 
 | Model | ID | Type | Pricing | Privacy |

--- a/models/video.mdx
+++ b/models/video.mdx
@@ -4,12 +4,10 @@ description: "Venice video models for text-to-video, image-to-video, and Topaz u
 "og:title": "Video Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="video">Loading models...</div>
-
-<Visibility for="agents">
+<div id="model-search-placeholder" data-filter="video">
 {/* AUTO-GENERATED:MODELS:START */}
 
-This is the current model catalog, not a dynamic widget. Use the `id` value as the `model` parameter in API requests. 112 models currently available.
+Use the `id` value as the `model` parameter in API requests. 112 models currently available.
 
 | Model | ID | Type | Pricing | Privacy |
 |---|---|---|---|---|
@@ -127,7 +125,7 @@ This is the current model catalog, not a dynamic widget. Use the `id` value as t
 | Wan 2.7 Reference | `wan-2-7-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
 
 {/* AUTO-GENERATED:MODELS:END */}
-</Visibility>
+</div>
 
 ## Model Types
 

--- a/scripts/generate-deprecations-static.js
+++ b/scripts/generate-deprecations-static.js
@@ -31,6 +31,7 @@ const DEPRECATIONS_START = '{/* AUTO-GENERATED:DEPRECATIONS:START */}';
 const DEPRECATIONS_END = '{/* AUTO-GENERATED:DEPRECATIONS:END */}';
 const API_TRAITS_START = '{/* AUTO-GENERATED:API-TRAITS:START */}';
 const API_TRAITS_END = '{/* AUTO-GENERATED:API-TRAITS:END */}';
+const TRAITS_API_URL = 'https://api.venice.ai/api/v1/models/traits?type=text';
 
 function readJson(filePath) {
   if (!fs.existsSync(filePath)) {
@@ -58,6 +59,17 @@ function tableCell(value) {
   return String(value).replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
 }
 
+function renderLiveTraitsNote() {
+  return [
+    'These mappings are a snapshot, refreshed about hourly.',
+    'If you can make HTTP requests, fetch the live mappings instead — no API key required:',
+    '',
+    `\`GET ${TRAITS_API_URL}\``,
+    '',
+    'Use the snapshot below only when you cannot call the API.'
+  ].join('\n');
+}
+
 function renderTraitsList(traits) {
   const entries = sortTraits(traits);
   if (entries.length === 0) return 'No text model traits are currently available.';
@@ -65,6 +77,10 @@ function renderTraitsList(traits) {
   return entries
     .map(([trait, modelId]) => `- ${inlineCode(trait)} → currently routes to ${inlineCode(modelId)}`)
     .join('\n');
+}
+
+function renderTraitsListForAgents(traits) {
+  return `${renderLiveTraitsNote()}\n\n${renderTraitsList(traits)}`;
 }
 
 function getModelRemovalDate(model) {
@@ -209,7 +225,7 @@ function updateTraitsApiPage(page, traits) {
     id: 'traits-list-placeholder',
     startMarker: API_TRAITS_START,
     endMarker: API_TRAITS_END,
-    content: renderTraitsList(traits)
+    content: renderTraitsListForAgents(traits)
   });
 }
 

--- a/scripts/generate-models-static.js
+++ b/scripts/generate-models-static.js
@@ -19,6 +19,7 @@ const VOICES_START = '{/* AUTO-GENERATED:VOICES:START */}';
 const VOICES_END = '{/* AUTO-GENERATED:VOICES:END */}';
 
 const PRIVATE_TYPES = new Set(['upscale']);
+const MODELS_API_URL = 'https://api.venice.ai/api/v1/models';
 
 function readModels() {
   if (!fs.existsSync(SNAPSHOT_PATH)) {
@@ -167,9 +168,23 @@ function getVideoType(modelId) {
   return 'Text to Video';
 }
 
-function renderCatalogIntro(count) {
+function renderLiveCatalogNote(types) {
+  const urls = (!types || types.length === 0)
+    ? [`GET ${MODELS_API_URL}?type=all`]
+    : types.map(type => `GET ${MODELS_API_URL}?type=${type}`);
+  return [
+    'This table is a snapshot of the public catalog, refreshed about hourly.',
+    'If you can make HTTP requests, fetch the live list instead — no API key required:',
+    '',
+    ...urls.map(url => `\`${url}\``),
+    '',
+    'Use the snapshot below only when you cannot call the API.'
+  ].join('\n');
+}
+
+function renderCatalogIntro(count, types) {
   const noun = count === 1 ? 'model' : 'models';
-  return `Use the \`id\` value as the \`model\` parameter in API requests. ${count} ${noun} currently available.`;
+  return `${renderLiveCatalogNote(types)}\n\nUse the \`id\` value as the \`model\` parameter in API requests. ${count} ${noun} currently available.`;
 }
 
 function renderTextTable(models) {
@@ -230,7 +245,7 @@ function renderVoiceTables(models) {
   const ttsModels = liveModels(models, m => m.type === 'tts');
   if (ttsModels.length === 0) return 'No voices available.';
 
-  return ttsModels.map(model => {
+  const tables = ttsModels.map(model => {
     const voices = model.model_spec?.voices || [];
     const table = markdownTable(
       ['Voice ID'],
@@ -238,6 +253,8 @@ function renderVoiceTables(models) {
     );
     return `#### ${tableCell(getModelName(model))} (${inlineCode(model.id)})\n\n${table}`;
   }).join('\n\n');
+
+  return `${renderLiveCatalogNote(['tts'])}\n\nVoice IDs are listed on each TTS model as \`model_spec.voices\`.\n\n${tables}`;
 }
 
 function renderAsrTable(models) {
@@ -347,8 +364,8 @@ function updatePage(relativePath, id, startMarker, endMarker, content) {
   );
 }
 
-function withIntro(count, table) {
-  return `${renderCatalogIntro(count)}\n\n${table}`;
+function withIntro(count, table, types) {
+  return `${renderCatalogIntro(count, types)}\n\n${table}`;
 }
 
 function main() {
@@ -367,7 +384,7 @@ function main() {
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'text').length, renderTextTable(models))
+    withIntro(live.filter(m => m.type === 'text').length, renderTextTable(models), ['text'])
   );
   updatePage(
     'models/image.mdx',
@@ -376,7 +393,8 @@ function main() {
     MODELS_END,
     withIntro(
       live.filter(m => m.type === 'image' || m.type === 'upscale' || m.type === 'inpaint').length,
-      renderImageTables(models)
+      renderImageTables(models),
+      ['image', 'upscale', 'inpaint']
     )
   );
   updatePage(
@@ -384,14 +402,14 @@ function main() {
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'video').length, renderVideoTable(models))
+    withIntro(live.filter(m => m.type === 'video').length, renderVideoTable(models), ['video'])
   );
   updatePage(
     'models/text-to-speech.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'tts').length, renderTtsTable(models))
+    withIntro(live.filter(m => m.type === 'tts').length, renderTtsTable(models), ['tts'])
   );
   updatePage(
     'models/text-to-speech.mdx',
@@ -405,21 +423,21 @@ function main() {
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'asr').length, renderAsrTable(models))
+    withIntro(live.filter(m => m.type === 'asr').length, renderAsrTable(models), ['asr'])
   );
   updatePage(
     'models/music.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'music').length, renderMusicTable(models))
+    withIntro(live.filter(m => m.type === 'music').length, renderMusicTable(models), ['music'])
   );
   updatePage(
     'models/embeddings.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'embedding').length, renderEmbeddingTable(models))
+    withIntro(live.filter(m => m.type === 'embedding').length, renderEmbeddingTable(models), ['embedding'])
   );
 }
 

--- a/scripts/generate-models-static.js
+++ b/scripts/generate-models-static.js
@@ -169,7 +169,7 @@ function getVideoType(modelId) {
 
 function renderCatalogIntro(count) {
   const noun = count === 1 ? 'model' : 'models';
-  return `This is the current model catalog, not a dynamic widget. Use the \`id\` value as the \`model\` parameter in API requests. ${count} ${noun} currently available.`;
+  return `Use the \`id\` value as the \`model\` parameter in API requests. ${count} ${noun} currently available.`;
 }
 
 function renderTextTable(models) {
@@ -289,23 +289,21 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-// Humans get a JS mount point. Agents get top-level markdown: Mintlify's
-// assistant indexes the .md export and often drops markdown nested in <div>s.
-function upsertVisibilityBlock(page, { id, startMarker, endMarker, content, humanFallback }) {
+// Mintlify's .md export keeps markdown tables inside a plain placeholder
+// <div> (same pattern as overview/pricing.mdx). Visibility-for-agents
+// dropped the model catalogs on the published export.
+function upsertCatalogBlock(page, { id, startMarker, endMarker, content }) {
   const attrMatch = page.match(new RegExp(`<div id="${escapeRegExp(id)}"([^>]*)>`));
   const attrs = attrMatch ? attrMatch[1] : '';
-  const inner = humanFallback ?? '';
 
   const block = [
-    `<div id="${id}"${attrs}>${inner}</div>`,
-    '',
-    `<Visibility for="agents">`,
+    `<div id="${id}"${attrs}>`,
     startMarker,
     '',
     content,
     '',
     endMarker,
-    `</Visibility>`
+    `</div>`
   ].join('\n');
 
   const wrappedPattern = new RegExp(
@@ -340,12 +338,12 @@ function writeIfChanged(filePath, content) {
   console.log(`Updated ${path.relative(ROOT, filePath)}`);
 }
 
-function updatePage(relativePath, id, startMarker, endMarker, content, humanFallback) {
+function updatePage(relativePath, id, startMarker, endMarker, content) {
   const filePath = path.join(ROOT, relativePath);
   const page = fs.readFileSync(filePath, 'utf-8');
   writeIfChanged(
     filePath,
-    upsertVisibilityBlock(page, { id, startMarker, endMarker, content, humanFallback })
+    upsertCatalogBlock(page, { id, startMarker, endMarker, content })
   );
 }
 
@@ -362,16 +360,14 @@ function main() {
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    renderOverviewTables(models),
-    'Loading models...'
+    renderOverviewTables(models)
   );
   updatePage(
     'models/text.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'text').length, renderTextTable(models)),
-    'Loading models...'
+    withIntro(live.filter(m => m.type === 'text').length, renderTextTable(models))
   );
   updatePage(
     'models/image.mdx',
@@ -381,56 +377,49 @@ function main() {
     withIntro(
       live.filter(m => m.type === 'image' || m.type === 'upscale' || m.type === 'inpaint').length,
       renderImageTables(models)
-    ),
-    'Loading models...'
+    )
   );
   updatePage(
     'models/video.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'video').length, renderVideoTable(models)),
-    'Loading models...'
+    withIntro(live.filter(m => m.type === 'video').length, renderVideoTable(models))
   );
   updatePage(
     'models/text-to-speech.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'tts').length, renderTtsTable(models)),
-    'Loading models...'
+    withIntro(live.filter(m => m.type === 'tts').length, renderTtsTable(models))
   );
   updatePage(
     'models/text-to-speech.mdx',
     'tts-voice-picker-placeholder',
     VOICES_START,
     VOICES_END,
-    renderVoiceTables(models),
-    'Loading voices...'
+    renderVoiceTables(models)
   );
   updatePage(
     'models/speech-to-text.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'asr').length, renderAsrTable(models)),
-    'Loading models...'
+    withIntro(live.filter(m => m.type === 'asr').length, renderAsrTable(models))
   );
   updatePage(
     'models/music.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'music').length, renderMusicTable(models)),
-    'Loading models...'
+    withIntro(live.filter(m => m.type === 'music').length, renderMusicTable(models))
   );
   updatePage(
     'models/embeddings.mdx',
     'model-search-placeholder',
     MODELS_START,
     MODELS_END,
-    withIntro(live.filter(m => m.type === 'embedding').length, renderEmbeddingTable(models)),
-    'Loading models...'
+    withIntro(live.filter(m => m.type === 'embedding').length, renderEmbeddingTable(models))
   );
 }
 


### PR DESCRIPTION
## Summary
- The previous change put catalogs in `<Visibility for="agents">`, which Mintlify dropped from the published `.md` export. Production `https://docs.venice.ai/models/text.md` still showed `Loading models...`.
- Move the snapshot tables into the same placeholder `<div>` pattern as `overview/pricing.mdx`, which already exports tables to Markdown. The JS browser still replaces that div for humans.
- Point tool-using agents at the live `GET /models` and `GET /models/traits` endpoints. The snapshot stays for Mintlify's in-docs assistant, which cannot call the API.

## Test plan
- [ ] After merge, `curl -sL https://docs.venice.ai/models/text.md` includes `claude-fable-5` and does not stop at `Loading models...`.
- [ ] Local `mintlify dev` still mounts the interactive browser on `/models/text`.
- [ ] Production assistant on `/models/text` answers with real model IDs.
- [ ] `https://docs.venice.ai/models/text.md` tells agents that can make HTTP requests to call `GET https://api.venice.ai/api/v1/models?type=text`.