### PR TITLE
docs: restructure the demos page into Learn

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -183,11 +183,11 @@
             ]
           },
           {
-            "tab": "Demos",
+            "tab": "Learn",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "Demos",
+                "group": "Learn",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [
@@ -516,11 +516,11 @@
             ]
           },
           {
-            "tab": "Demos",
+            "tab": "Aprender",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "Demos",
+                "group": "Aprender",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [
@@ -848,11 +848,11 @@
             ]
           },
           {
-            "tab": "العروض",
+            "tab": "تعلّم",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "العروض",
+                "group": "تعلّم",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [
@@ -1180,11 +1180,11 @@
             ]
           },
           {
-            "tab": "Demo",
+            "tab": "Impara",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "Demo",
+                "group": "Impara",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [
@@ -1512,11 +1512,11 @@
             ]
           },
           {
-            "tab": "Demos",
+            "tab": "Lernen",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "Demos",
+                "group": "Lernen",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [
@@ -1844,11 +1844,11 @@
             ]
           },
           {
-            "tab": "Demos",
+            "tab": "Aprender",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "Demos",
+                "group": "Aprender",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [
@@ -2176,11 +2176,11 @@
             ]
           },
           {
-            "tab": "Démos",
+            "tab": "Apprendre",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "Démos",
+                "group": "Apprendre",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [
@@ -2508,11 +2508,11 @@
             ]
           },
           {
-            "tab": "演示",
+            "tab": "学习",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "演示",
+                "group": "学习",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [
@@ -2840,11 +2840,11 @@
             ]
           },
           {
-            "tab": "데모",
+            "tab": "학습",
             "icon": "layout-grid",
             "pages": [
               {
-                "group": "데모",
+                "group": "학습",
                 "icon": "layout-grid",
                 "expanded": true,
                 "pages": [

--- a/guides/projects/overview.mdx
+++ b/guides/projects/overview.mdx
@@ -1,15 +1,52 @@
 ---
-title: "Demos & Projects"
+title: "Learn"
 sidebarTitle: "Overview"
-description: "End-to-end demo projects built on the Venice API, with runnable code you can adapt."
-"og:title": "Demos | Venice API Docs"
+description: "Projects and notebooks built on the Venice API, with runnable code you can adapt."
+"og:title": "Learn | Venice API Docs"
 ---
+
+Each one is complete working code rather than a fragment that assumes the interesting parts. The badge tells you what you are getting into: a **Notebook** runs in the browser with nothing to install, while a **Repo** needs a clone and a few minutes of setup.
+
+<div className="venice-learn-featured">
+  <div className="venice-learn-eyebrow">Start here</div>
+  <div className="venice-demo-card venice-demo-card-wide">
+    <div className="venice-demo-card-head">
+      <span className="venice-demo-icon"><Icon icon="headphones" /></span>
+      <span className="venice-demo-badges">
+        <span className="venice-demo-type">Notebook</span>
+        <span className="venice-demo-lang">Python</span>
+        <span className="venice-demo-meta">9 min</span>
+      </span>
+    </div>
+    <h3 className="venice-demo-title">Audio Research Notebook</h3>
+    <p className="venice-demo-desc">Add your sources, ask questions that cite them, then generate a two-host audio overview you can listen to. Chains scraping, document parsing, embeddings, chat, and speech into one pipeline.</p>
+    <div className="venice-demo-tags">
+      <span className="venice-demo-tag">Scrape</span>
+      <span className="venice-demo-tag">Text Parser</span>
+      <span className="venice-demo-tag">Embeddings</span>
+      <span className="venice-demo-tag">Text-to-Speech</span>
+    </div>
+    <div className="venice-demo-actions">
+      <a className="venice-demo-link" href="/guides/projects/audio-research-notebook">Read the guide <span className="venice-demo-arrow">→</span></a>
+      <a className="venice-demo-repo" href="https://colab.research.google.com/github/veniceai/api-docs/blob/main/notebooks/audio-research-notebook.ipynb" target="_blank" rel="noopener noreferrer"><Icon icon="notebook" size={14} /> Run in Colab</a>
+    </div>
+    <div className="venice-demo-byline">Sabrina Aquino · Aug 2026</div>
+  </div>
+</div>
+
+## Retrieval and research
+
+Getting your own material into a model, and getting answers back that point at where they came from.
 
 <div className="venice-demo-grid">
   <div className="venice-demo-card">
     <div className="venice-demo-card-head">
       <span className="venice-demo-icon"><Icon icon="database" /></span>
-      <span className="venice-demo-lang">Python</span>
+      <span className="venice-demo-badges">
+        <span className="venice-demo-type">Repo</span>
+        <span className="venice-demo-lang">Python</span>
+        <span className="venice-demo-meta">9 min</span>
+      </span>
     </div>
     <h3 className="venice-demo-title">Private RAG Bot</h3>
     <p className="venice-demo-desc">Grounded, citable answers from your own documents with re-ranked retrieval.</p>
@@ -28,7 +65,11 @@ description: "End-to-end demo projects built on the Venice API, with runnable co
   <div className="venice-demo-card">
     <div className="venice-demo-card-head">
       <span className="venice-demo-icon"><Icon icon="robot" /></span>
-      <span className="venice-demo-lang">Python</span>
+      <span className="venice-demo-badges">
+        <span className="venice-demo-type">Repo</span>
+        <span className="venice-demo-lang">Python</span>
+        <span className="venice-demo-meta">18 min</span>
+      </span>
     </div>
     <h3 className="venice-demo-title">Private Research Agent</h3>
     <p className="venice-demo-desc">Plans searches, reads web sources, and writes cited Markdown briefings.</p>
@@ -43,11 +84,21 @@ description: "End-to-end demo projects built on the Venice API, with runnable co
     </div>
     <div className="venice-demo-byline">Joshua Mo · May 2026</div>
   </div>
+</div>
 
+## Agents and infrastructure
+
+Running Venice behind something else: an agent that acts on its own, or a service that fronts the API for your own users.
+
+<div className="venice-demo-grid">
   <div className="venice-demo-card">
     <div className="venice-demo-card-head">
       <span className="venice-demo-icon"><Icon icon="shield" /></span>
-      <span className="venice-demo-lang">Python</span>
+      <span className="venice-demo-badges">
+        <span className="venice-demo-type">Repo</span>
+        <span className="venice-demo-lang">Python</span>
+        <span className="venice-demo-meta">24 min</span>
+      </span>
     </div>
     <h3 className="venice-demo-title">Codebase Security Reviewer</h3>
     <p className="venice-demo-desc">Finds atomic vulnerabilities and chains them into exploit paths.</p>
@@ -66,7 +117,11 @@ description: "End-to-end demo projects built on the Venice API, with runnable co
   <div className="venice-demo-card">
     <div className="venice-demo-card-head">
       <span className="venice-demo-icon"><Icon icon="server" /></span>
-      <span className="venice-demo-lang">Rust</span>
+      <span className="venice-demo-badges">
+        <span className="venice-demo-type">Repo</span>
+        <span className="venice-demo-lang">Rust</span>
+        <span className="venice-demo-meta">18 min</span>
+      </span>
     </div>
     <h3 className="venice-demo-title">Rust LLM Gateway</h3>
     <p className="venice-demo-desc">An OpenAI-compatible gateway with auth, rate limits, streaming, and telemetry.</p>
@@ -82,24 +137,17 @@ description: "End-to-end demo projects built on the Venice API, with runnable co
     </div>
     <div className="venice-demo-byline">Joshua Mo · Jul 2026</div>
   </div>
-
-  <div className="venice-demo-card">
-    <div className="venice-demo-card-head">
-      <span className="venice-demo-icon"><Icon icon="headphones" /></span>
-      <span className="venice-demo-lang">Python</span>
-    </div>
-    <h3 className="venice-demo-title">Audio Research Notebook</h3>
-    <p className="venice-demo-desc">Cited answers from your sources, plus a two-host audio overview you can listen to.</p>
-    <div className="venice-demo-tags">
-      <span className="venice-demo-tag">Scrape</span>
-      <span className="venice-demo-tag">Text Parser</span>
-      <span className="venice-demo-tag">Embeddings</span>
-      <span className="venice-demo-tag">Text-to-Speech</span>
-    </div>
-    <div className="venice-demo-actions">
-      <a className="venice-demo-link" href="/guides/projects/audio-research-notebook">Read the guide <span className="venice-demo-arrow">→</span></a>
-      <a className="venice-demo-repo" href="https://colab.research.google.com/github/veniceai/api-docs/blob/main/notebooks/audio-research-notebook.ipynb" target="_blank" rel="noopener noreferrer"><Icon icon="notebook" size={14} /> Colab</a>
-    </div>
-    <div className="venice-demo-byline">Sabrina Aquino · Aug 2026</div>
-  </div>
 </div>
+
+## Shorter walkthroughs
+
+Single-capability guides that take under half an hour, for when a full project is more than you need.
+
+<CardGroup cols={2}>
+  <Card title="Cited Answers with Web Search" icon="search" href="/guides/tools/cited-web-answers">
+    Answer a question with a brief where every claim links back to a source.
+  </Card>
+  <Card title="Narrating Articles with Text-to-Speech" icon="microphone" href="/guides/media/article-narration">
+    Turn any web article into a single narrated audio file.
+  </Card>
+</CardGroup>

--- a/guides/projects/overview.mdx
+++ b/guides/projects/overview.mdx
@@ -5,149 +5,121 @@ description: "Projects and notebooks built on the Venice API, with runnable code
 "og:title": "Learn | Venice API Docs"
 ---
 
-Each one is complete working code rather than a fragment that assumes the interesting parts. The badge tells you what you are getting into: a **Notebook** runs in the browser with nothing to install, while a **Repo** needs a clone and a few minutes of setup.
+Each one is complete working code rather than a fragment that assumes the interesting parts. The badge tells you what you are getting into: a **Notebook** runs in the browser with nothing to install, a **Repo** needs a clone and a few minutes of setup, and a **Walkthrough** is a single capability you can read end to end.
 
-<div className="venice-learn-featured">
-  <div className="venice-learn-eyebrow">Start here</div>
-  <div className="venice-demo-card venice-demo-card-wide">
-    <div className="venice-demo-card-head">
-      <span className="venice-demo-icon"><Icon icon="headphones" /></span>
-      <span className="venice-demo-badges">
-        <span className="venice-demo-type">Notebook</span>
-        <span className="venice-demo-lang">Python</span>
-        <span className="venice-demo-meta">9 min</span>
+<div className="venice-learn">
+  <input type="radio" name="venice-learn-cat" id="lc-all" className="venice-learn-radio" defaultChecked />
+  <input type="radio" name="venice-learn-cat" id="lc-retrieval" className="venice-learn-radio" />
+  <input type="radio" name="venice-learn-cat" id="lc-audio" className="venice-learn-radio" />
+  <input type="radio" name="venice-learn-cat" id="lc-agents" className="venice-learn-radio" />
+
+  <div className="venice-learn-chips">
+    <label htmlFor="lc-all">All</label>
+    <label htmlFor="lc-retrieval">Retrieval</label>
+    <label htmlFor="lc-audio">Audio</label>
+    <label htmlFor="lc-agents">Agents</label>
+  </div>
+
+  <div className="venice-learn-row">
+    <a className="venice-learn-card" data-cat="audio" href="/guides/projects/audio-research-notebook">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="headphones" /></span>
+        <span className="venice-learn-type">Notebook</span>
       </span>
-    </div>
-    <h3 className="venice-demo-title">Audio Research Notebook</h3>
-    <p className="venice-demo-desc">Add your sources, ask questions that cite them, then generate a two-host audio overview you can listen to. Chains scraping, document parsing, embeddings, chat, and speech into one pipeline.</p>
-    <div className="venice-demo-tags">
-      <span className="venice-demo-tag">Scrape</span>
-      <span className="venice-demo-tag">Text Parser</span>
-      <span className="venice-demo-tag">Embeddings</span>
-      <span className="venice-demo-tag">Text-to-Speech</span>
-    </div>
-    <div className="venice-demo-actions">
-      <a className="venice-demo-link" href="/guides/projects/audio-research-notebook">Read the guide <span className="venice-demo-arrow">→</span></a>
-      <a className="venice-demo-repo" href="https://colab.research.google.com/github/veniceai/api-docs/blob/main/notebooks/audio-research-notebook.ipynb" target="_blank" rel="noopener noreferrer"><Icon icon="notebook" size={14} /> Run in Colab</a>
-    </div>
-    <div className="venice-demo-byline">Sabrina Aquino · Aug 2026</div>
+      <span className="venice-learn-title">Audio Research Notebook</span>
+      <span className="venice-learn-desc">Add your sources, ask questions that cite them, then generate a two-host audio overview.</span>
+    </a>
+
+    <a className="venice-learn-card" data-cat="retrieval" href="/guides/projects/private-rag-bot">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="database" /></span>
+        <span className="venice-learn-type">Repo</span>
+      </span>
+      <span className="venice-learn-title">Private RAG Bot</span>
+      <span className="venice-learn-desc">Grounded, citable answers from your own documents with re-ranked retrieval.</span>
+    </a>
+
+    <a className="venice-learn-card" data-cat="retrieval" href="/guides/projects/private-research-agent">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="robot" /></span>
+        <span className="venice-learn-type">Repo</span>
+      </span>
+      <span className="venice-learn-title">Private Research Agent</span>
+      <span className="venice-learn-desc">Plans searches, reads web sources, and writes cited Markdown briefings.</span>
+    </a>
+
+    <a className="venice-learn-card" data-cat="agents" href="/guides/projects/security-code-reviewer">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="shield" /></span>
+        <span className="venice-learn-type">Repo</span>
+      </span>
+      <span className="venice-learn-title">Codebase Security Reviewer</span>
+      <span className="venice-learn-desc">Finds atomic vulnerabilities and chains them into exploit paths.</span>
+    </a>
+
+    <a className="venice-learn-card" data-cat="agents" href="/guides/projects/rust-llm-gateway">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="server" /></span>
+        <span className="venice-learn-type">Repo</span>
+      </span>
+      <span className="venice-learn-title">Rust LLM Gateway</span>
+      <span className="venice-learn-desc">An OpenAI-compatible gateway with auth, rate limits, streaming, and telemetry.</span>
+    </a>
+
+    <a className="venice-learn-card" data-cat="retrieval" href="/guides/tools/cited-web-answers">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="search" /></span>
+        <span className="venice-learn-type">Walkthrough</span>
+      </span>
+      <span className="venice-learn-title">Cited Answers with Web Search</span>
+      <span className="venice-learn-desc">Answer a question with a brief where every claim links back to a source.</span>
+    </a>
+
+    <a className="venice-learn-card" data-cat="audio" href="/guides/media/article-narration">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="microphone" /></span>
+        <span className="venice-learn-type">Walkthrough</span>
+      </span>
+      <span className="venice-learn-title">Narrating Articles with Text-to-Speech</span>
+      <span className="venice-learn-desc">Turn any web article into a single narrated audio file.</span>
+    </a>
   </div>
 </div>
 
-## Retrieval and research
+## Keep learning
 
-Getting your own material into a model, and getting answers back that point at where they came from.
-
-<div className="venice-demo-grid">
-  <div className="venice-demo-card">
-    <div className="venice-demo-card-head">
-      <span className="venice-demo-icon"><Icon icon="database" /></span>
-      <span className="venice-demo-badges">
-        <span className="venice-demo-type">Repo</span>
-        <span className="venice-demo-lang">Python</span>
-        <span className="venice-demo-meta">9 min</span>
+<div className="venice-learn">
+  <div className="venice-learn-row">
+    <a className="venice-learn-card" href="/api-reference/api-spec">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="code" /></span>
       </span>
-    </div>
-    <h3 className="venice-demo-title">Private RAG Bot</h3>
-    <p className="venice-demo-desc">Grounded, citable answers from your own documents with re-ranked retrieval.</p>
-    <div className="venice-demo-tags">
-      <span className="venice-demo-tag">Qdrant</span>
-      <span className="venice-demo-tag">FastEmbed</span>
-      <span className="venice-demo-tag">Re-ranking</span>
-    </div>
-    <div className="venice-demo-actions">
-      <a className="venice-demo-link" href="/guides/projects/private-rag-bot">Read the guide <span className="venice-demo-arrow">→</span></a>
-      <a className="venice-demo-repo" href="https://github.com/joshua-mo-143/venice-rag-bot-demo" target="_blank" rel="noopener noreferrer"><Icon icon="brand-github" size={14} /> GitHub</a>
-    </div>
-    <div className="venice-demo-byline">Joshua Mo · Apr 2026</div>
-  </div>
+      <span className="venice-learn-title">API Reference</span>
+      <span className="venice-learn-desc">Every endpoint, with request and response shapes you can try in the browser.</span>
+    </a>
 
-  <div className="venice-demo-card">
-    <div className="venice-demo-card-head">
-      <span className="venice-demo-icon"><Icon icon="robot" /></span>
-      <span className="venice-demo-badges">
-        <span className="venice-demo-type">Repo</span>
-        <span className="venice-demo-lang">Python</span>
-        <span className="venice-demo-meta">18 min</span>
+    <a className="venice-learn-card" href="/guides/tools/web-retrieval">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="book" /></span>
       </span>
-    </div>
-    <h3 className="venice-demo-title">Private Research Agent</h3>
-    <p className="venice-demo-desc">Plans searches, reads web sources, and writes cited Markdown briefings.</p>
-    <div className="venice-demo-tags">
-      <span className="venice-demo-tag">Scrape API</span>
-      <span className="venice-demo-tag">Planner</span>
-      <span className="venice-demo-tag">Cited reports</span>
-    </div>
-    <div className="venice-demo-actions">
-      <a className="venice-demo-link" href="/guides/projects/private-research-agent">Read the guide <span className="venice-demo-arrow">→</span></a>
-      <a className="venice-demo-repo" href="https://github.com/joshua-mo-143/venice-research-agent-demo" target="_blank" rel="noopener noreferrer"><Icon icon="brand-github" size={14} /> GitHub</a>
-    </div>
-    <div className="venice-demo-byline">Joshua Mo · May 2026</div>
+      <span className="venice-learn-title">Feature guides</span>
+      <span className="venice-learn-desc">One capability at a time: search, speech, vision, embeddings, and the rest.</span>
+    </a>
+
+    <a className="venice-learn-card" href="https://github.com/veniceai/api-docs/tree/main/notebooks" target="_blank" rel="noopener noreferrer">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="notebook" /></span>
+      </span>
+      <span className="venice-learn-title">Notebooks</span>
+      <span className="venice-learn-desc">Sources for every Colab above, generated from these pages so they cannot drift.</span>
+    </a>
+
+    <a className="venice-learn-card" href="https://featurebase.venice.ai/changelog" target="_blank" rel="noopener noreferrer">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="sparkles" /></span>
+      </span>
+      <span className="venice-learn-title">Changelog</span>
+      <span className="venice-learn-desc">New models, endpoints, and behaviour changes as they ship.</span>
+    </a>
   </div>
 </div>
-
-## Agents and infrastructure
-
-Running Venice behind something else: an agent that acts on its own, or a service that fronts the API for your own users.
-
-<div className="venice-demo-grid">
-  <div className="venice-demo-card">
-    <div className="venice-demo-card-head">
-      <span className="venice-demo-icon"><Icon icon="shield" /></span>
-      <span className="venice-demo-badges">
-        <span className="venice-demo-type">Repo</span>
-        <span className="venice-demo-lang">Python</span>
-        <span className="venice-demo-meta">24 min</span>
-      </span>
-    </div>
-    <h3 className="venice-demo-title">Codebase Security Reviewer</h3>
-    <p className="venice-demo-desc">Finds atomic vulnerabilities and chains them into exploit paths.</p>
-    <div className="venice-demo-tags">
-      <span className="venice-demo-tag">AST repo map</span>
-      <span className="venice-demo-tag">Pydantic</span>
-      <span className="venice-demo-tag">Two-agent</span>
-    </div>
-    <div className="venice-demo-actions">
-      <a className="venice-demo-link" href="/guides/projects/security-code-reviewer">Read the guide <span className="venice-demo-arrow">→</span></a>
-      <a className="venice-demo-repo" href="https://github.com/joshua-mo-143/venice-security-agent-demo" target="_blank" rel="noopener noreferrer"><Icon icon="brand-github" size={14} /> GitHub</a>
-    </div>
-    <div className="venice-demo-byline">Joshua Mo · Jun 2026</div>
-  </div>
-
-  <div className="venice-demo-card">
-    <div className="venice-demo-card-head">
-      <span className="venice-demo-icon"><Icon icon="server" /></span>
-      <span className="venice-demo-badges">
-        <span className="venice-demo-type">Repo</span>
-        <span className="venice-demo-lang">Rust</span>
-        <span className="venice-demo-meta">18 min</span>
-      </span>
-    </div>
-    <h3 className="venice-demo-title">Rust LLM Gateway</h3>
-    <p className="venice-demo-desc">An OpenAI-compatible gateway with auth, rate limits, streaming, and telemetry.</p>
-    <div className="venice-demo-tags">
-      <span className="venice-demo-tag">Axum</span>
-      <span className="venice-demo-tag">Postgres</span>
-      <span className="venice-demo-tag">SQLx</span>
-      <span className="venice-demo-tag">OpenTelemetry</span>
-    </div>
-    <div className="venice-demo-actions">
-      <a className="venice-demo-link" href="/guides/projects/rust-llm-gateway">Read the guide <span className="venice-demo-arrow">→</span></a>
-      <a className="venice-demo-repo" href="https://github.com/joshua-mo-143/venice-llm-gateway-demo" target="_blank" rel="noopener noreferrer"><Icon icon="brand-github" size={14} /> GitHub</a>
-    </div>
-    <div className="venice-demo-byline">Joshua Mo · Jul 2026</div>
-  </div>
-</div>
-
-## Shorter walkthroughs
-
-Single-capability guides that take under half an hour, for when a full project is more than you need.
-
-<CardGroup cols={2}>
-  <Card title="Cited Answers with Web Search" icon="search" href="/guides/tools/cited-web-answers">
-    Answer a question with a brief where every claim links back to a source.
-  </Card>
-  <Card title="Narrating Articles with Text-to-Speech" icon="microphone" href="/guides/media/article-narration">
-    Turn any web article into a single narrated audio file.
-  </Card>
-</CardGroup>

--- a/guides/projects/overview.mdx
+++ b/guides/projects/overview.mdx
@@ -1,11 +1,9 @@
 ---
 title: "Learn"
 sidebarTitle: "Overview"
-description: "Projects and notebooks built on the Venice API, with runnable code you can adapt."
+description: "Complete, runnable projects built on the Venice API, from short walkthroughs to full repositories."
 "og:title": "Learn | Venice API Docs"
 ---
-
-Each one is complete working code rather than a fragment that assumes the interesting parts. The badge tells you what you are getting into: a **Notebook** runs in the browser with nothing to install, a **Repo** needs a clone and a few minutes of setup, and a **Walkthrough** is a single capability you can read end to end.
 
 <div className="venice-learn">
   <input type="radio" name="venice-learn-cat" id="lc-all" className="venice-learn-radio" defaultChecked />
@@ -24,102 +22,77 @@ Each one is complete working code rather than a fragment that assumes the intere
     <a className="venice-learn-card" data-cat="audio" href="/guides/projects/audio-research-notebook">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="headphones" /></span>
-        <span className="venice-learn-type">Notebook</span>
+        <span className="venice-learn-title">Audio Research Notebook</span>
       </span>
-      <span className="venice-learn-title">Audio Research Notebook</span>
       <span className="venice-learn-desc">Add your sources, ask questions that cite them, then generate a two-host audio overview.</span>
+      <span className="venice-learn-meta">Notebook · Python · 9 min</span>
     </a>
 
     <a className="venice-learn-card" data-cat="retrieval" href="/guides/projects/private-rag-bot">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="database" /></span>
-        <span className="venice-learn-type">Repo</span>
+        <span className="venice-learn-title">Private RAG Bot</span>
       </span>
-      <span className="venice-learn-title">Private RAG Bot</span>
       <span className="venice-learn-desc">Grounded, citable answers from your own documents with re-ranked retrieval.</span>
+      <span className="venice-learn-meta">Repo · Python · 9 min</span>
     </a>
 
     <a className="venice-learn-card" data-cat="retrieval" href="/guides/projects/private-research-agent">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="robot" /></span>
-        <span className="venice-learn-type">Repo</span>
+        <span className="venice-learn-title">Private Research Agent</span>
       </span>
-      <span className="venice-learn-title">Private Research Agent</span>
       <span className="venice-learn-desc">Plans searches, reads web sources, and writes cited Markdown briefings.</span>
+      <span className="venice-learn-meta">Repo · Python · 18 min</span>
     </a>
 
     <a className="venice-learn-card" data-cat="agents" href="/guides/projects/security-code-reviewer">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="shield" /></span>
-        <span className="venice-learn-type">Repo</span>
+        <span className="venice-learn-title">Codebase Security Reviewer</span>
       </span>
-      <span className="venice-learn-title">Codebase Security Reviewer</span>
       <span className="venice-learn-desc">Finds atomic vulnerabilities and chains them into exploit paths.</span>
+      <span className="venice-learn-meta">Repo · Python · 24 min</span>
     </a>
 
     <a className="venice-learn-card" data-cat="agents" href="/guides/projects/rust-llm-gateway">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="server" /></span>
-        <span className="venice-learn-type">Repo</span>
+        <span className="venice-learn-title">Rust LLM Gateway</span>
       </span>
-      <span className="venice-learn-title">Rust LLM Gateway</span>
       <span className="venice-learn-desc">An OpenAI-compatible gateway with auth, rate limits, streaming, and telemetry.</span>
+      <span className="venice-learn-meta">Repo · Rust · 18 min</span>
     </a>
 
     <a className="venice-learn-card" data-cat="retrieval" href="/guides/tools/cited-web-answers">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="search" /></span>
-        <span className="venice-learn-type">Walkthrough</span>
+        <span className="venice-learn-title">Cited Answers with Web Search</span>
       </span>
-      <span className="venice-learn-title">Cited Answers with Web Search</span>
       <span className="venice-learn-desc">Answer a question with a brief where every claim links back to a source.</span>
+      <span className="venice-learn-meta">Walkthrough · Python · 7 min</span>
     </a>
 
     <a className="venice-learn-card" data-cat="audio" href="/guides/media/article-narration">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="microphone" /></span>
-        <span className="venice-learn-type">Walkthrough</span>
+        <span className="venice-learn-title">Narrating Articles with Text-to-Speech</span>
       </span>
-      <span className="venice-learn-title">Narrating Articles with Text-to-Speech</span>
       <span className="venice-learn-desc">Turn any web article into a single narrated audio file.</span>
+      <span className="venice-learn-meta">Walkthrough · Python · 9 min</span>
     </a>
   </div>
+
+  <p className="venice-learn-legend">A <strong>Notebook</strong> runs in the browser with nothing to install. A <strong>Repo</strong> needs a clone and a few minutes of setup. A <strong>Walkthrough</strong> is one capability you can read end to end.</p>
 </div>
 
 ## Keep learning
 
 <div className="venice-learn">
-  <div className="venice-learn-row">
-    <a className="venice-learn-card" href="/api-reference/api-spec">
-      <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="code" /></span>
-      </span>
-      <span className="venice-learn-title">API Reference</span>
-      <span className="venice-learn-desc">Every endpoint, with request and response shapes you can try in the browser.</span>
-    </a>
-
-    <a className="venice-learn-card" href="/guides/tools/web-retrieval">
-      <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="book" /></span>
-      </span>
-      <span className="venice-learn-title">Feature guides</span>
-      <span className="venice-learn-desc">One capability at a time: search, speech, vision, embeddings, and the rest.</span>
-    </a>
-
-    <a className="venice-learn-card" href="https://github.com/veniceai/api-docs/tree/main/notebooks" target="_blank" rel="noopener noreferrer">
-      <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="notebook" /></span>
-      </span>
-      <span className="venice-learn-title">Notebooks</span>
-      <span className="venice-learn-desc">Sources for every Colab above, generated from these pages so they cannot drift.</span>
-    </a>
-
-    <a className="venice-learn-card" href="https://featurebase.venice.ai/changelog" target="_blank" rel="noopener noreferrer">
-      <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="history" /></span>
-      </span>
-      <span className="venice-learn-title">Changelog</span>
-      <span className="venice-learn-desc">New models, endpoints, and behaviour changes as they ship.</span>
-    </a>
+  <div className="venice-learn-links">
+    <a href="/api-reference/api-spec">API reference <span className="venice-learn-arrow">→</span></a>
+    <a href="/guides/tools/web-retrieval">Feature guides <span className="venice-learn-arrow">→</span></a>
+    <a href="https://github.com/veniceai/api-docs/tree/main/notebooks" target="_blank" rel="noopener noreferrer">Notebook sources <span className="venice-learn-arrow">→</span></a>
+    <a href="https://featurebase.venice.ai/changelog" target="_blank" rel="noopener noreferrer">Changelog <span className="venice-learn-arrow">→</span></a>
   </div>
 </div>

--- a/guides/projects/overview.mdx
+++ b/guides/projects/overview.mdx
@@ -116,7 +116,7 @@ Each one is complete working code rather than a fragment that assumes the intere
 
     <a className="venice-learn-card" href="https://featurebase.venice.ai/changelog" target="_blank" rel="noopener noreferrer">
       <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="sparkles" /></span>
+        <span className="venice-learn-icon"><Icon icon="history" /></span>
       </span>
       <span className="venice-learn-title">Changelog</span>
       <span className="venice-learn-desc">New models, endpoints, and behaviour changes as they ship.</span>

--- a/guides/projects/overview.mdx
+++ b/guides/projects/overview.mdx
@@ -6,93 +6,99 @@ description: "Complete, runnable projects built on the Venice API, from short wa
 ---
 
 <div className="venice-learn">
-  <input type="radio" name="venice-learn-cat" id="lc-all" className="venice-learn-radio" defaultChecked />
-  <input type="radio" name="venice-learn-cat" id="lc-retrieval" className="venice-learn-radio" />
-  <input type="radio" name="venice-learn-cat" id="lc-audio" className="venice-learn-radio" />
-  <input type="radio" name="venice-learn-cat" id="lc-agents" className="venice-learn-radio" />
 
-  <div className="venice-learn-chips">
-    <label htmlFor="lc-all">All</label>
-    <label htmlFor="lc-retrieval">Retrieval</label>
-    <label htmlFor="lc-audio">Audio</label>
-    <label htmlFor="lc-agents">Agents</label>
-  </div>
+<div className="venice-learn-section">
+
+## Walkthroughs
+
+<p className="venice-learn-lede">One capability, start to finish. Read the page, or open the notebook and run it.</p>
 
   <div className="venice-learn-row">
-    <a className="venice-learn-card" data-cat="audio" href="/guides/projects/audio-research-notebook">
+    <a className="venice-learn-card" href="/guides/projects/audio-research-notebook">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="headphones" /></span>
         <span className="venice-learn-title">Audio Research Notebook</span>
       </span>
       <span className="venice-learn-desc">Add your sources, ask questions that cite them, then generate a two-host audio overview.</span>
-      <span className="venice-learn-meta">Notebook · Python · 9 min</span>
+      <span className="venice-learn-meta">Python · 9 min</span>
     </a>
-
-    <a className="venice-learn-card" data-cat="retrieval" href="/guides/projects/private-rag-bot">
-      <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="database" /></span>
-        <span className="venice-learn-title">Private RAG Bot</span>
-      </span>
-      <span className="venice-learn-desc">Grounded, citable answers from your own documents with re-ranked retrieval.</span>
-      <span className="venice-learn-meta">Repo · Python · 9 min</span>
-    </a>
-
-    <a className="venice-learn-card" data-cat="retrieval" href="/guides/projects/private-research-agent">
-      <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="robot" /></span>
-        <span className="venice-learn-title">Private Research Agent</span>
-      </span>
-      <span className="venice-learn-desc">Plans searches, reads web sources, and writes cited Markdown briefings.</span>
-      <span className="venice-learn-meta">Repo · Python · 18 min</span>
-    </a>
-
-    <a className="venice-learn-card" data-cat="agents" href="/guides/projects/security-code-reviewer">
-      <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="shield" /></span>
-        <span className="venice-learn-title">Codebase Security Reviewer</span>
-      </span>
-      <span className="venice-learn-desc">Finds atomic vulnerabilities and chains them into exploit paths.</span>
-      <span className="venice-learn-meta">Repo · Python · 24 min</span>
-    </a>
-
-    <a className="venice-learn-card" data-cat="agents" href="/guides/projects/rust-llm-gateway">
-      <span className="venice-learn-card-head">
-        <span className="venice-learn-icon"><Icon icon="server" /></span>
-        <span className="venice-learn-title">Rust LLM Gateway</span>
-      </span>
-      <span className="venice-learn-desc">An OpenAI-compatible gateway with auth, rate limits, streaming, and telemetry.</span>
-      <span className="venice-learn-meta">Repo · Rust · 18 min</span>
-    </a>
-
-    <a className="venice-learn-card" data-cat="retrieval" href="/guides/tools/cited-web-answers">
+    <a className="venice-learn-card" href="/guides/tools/cited-web-answers">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="search" /></span>
         <span className="venice-learn-title">Cited Answers with Web Search</span>
       </span>
       <span className="venice-learn-desc">Answer a question with a brief where every claim links back to a source.</span>
-      <span className="venice-learn-meta">Walkthrough · Python · 7 min</span>
+      <span className="venice-learn-meta">Python · 7 min</span>
     </a>
-
-    <a className="venice-learn-card" data-cat="audio" href="/guides/media/article-narration">
+    <a className="venice-learn-card" href="/guides/media/article-narration">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="microphone" /></span>
         <span className="venice-learn-title">Narrating Articles with Text-to-Speech</span>
       </span>
       <span className="venice-learn-desc">Turn any web article into a single narrated audio file.</span>
-      <span className="venice-learn-meta">Walkthrough · Python · 9 min</span>
+      <span className="venice-learn-meta">Python · 9 min</span>
     </a>
   </div>
 
-  <p className="venice-learn-legend">A <strong>Notebook</strong> runs in the browser with nothing to install. A <strong>Repo</strong> needs a clone and a few minutes of setup. A <strong>Walkthrough</strong> is one capability you can read end to end.</p>
 </div>
+
+
+<div className="venice-learn-section">
+
+## Projects
+
+<p className="venice-learn-lede">Clone a repository and build the whole thing.</p>
+
+  <div className="venice-learn-row">
+    <a className="venice-learn-card" href="/guides/projects/rust-llm-gateway">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="server" /></span>
+        <span className="venice-learn-title">Rust LLM Gateway</span>
+      </span>
+      <span className="venice-learn-desc">An OpenAI-compatible gateway with auth, rate limits, streaming, and telemetry.</span>
+      <span className="venice-learn-meta">Rust · 18 min</span>
+    </a>
+    <a className="venice-learn-card" href="/guides/projects/security-code-reviewer">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="shield" /></span>
+        <span className="venice-learn-title">Codebase Security Reviewer</span>
+      </span>
+      <span className="venice-learn-desc">Finds atomic vulnerabilities and chains them into exploit paths.</span>
+      <span className="venice-learn-meta">Python · 24 min</span>
+    </a>
+    <a className="venice-learn-card" href="/guides/projects/private-research-agent">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="robot" /></span>
+        <span className="venice-learn-title">Private Research Agent</span>
+      </span>
+      <span className="venice-learn-desc">Plans searches, reads web sources, and writes cited Markdown briefings.</span>
+      <span className="venice-learn-meta">Python · 18 min</span>
+    </a>
+    <a className="venice-learn-card" href="/guides/projects/private-rag-bot">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="database" /></span>
+        <span className="venice-learn-title">Private RAG Bot</span>
+      </span>
+      <span className="venice-learn-desc">Grounded, citable answers from your own documents with re-ranked retrieval.</span>
+      <span className="venice-learn-meta">Python · 9 min</span>
+    </a>
+  </div>
+
+</div>
+
+</div>
+
+<div className="venice-learn">
+<div className="venice-learn-section">
 
 ## Keep learning
 
-<div className="venice-learn">
   <div className="venice-learn-links">
     <a href="/api-reference/api-spec">API reference <span className="venice-learn-arrow">→</span></a>
     <a href="/guides/tools/web-retrieval">Feature guides <span className="venice-learn-arrow">→</span></a>
     <a href="https://github.com/veniceai/api-docs/tree/main/notebooks" target="_blank" rel="noopener noreferrer">Notebook sources <span className="venice-learn-arrow">→</span></a>
     <a href="https://featurebase.venice.ai/changelog" target="_blank" rel="noopener noreferrer">Changelog <span className="venice-learn-arrow">→</span></a>
   </div>
+
+</div>
 </div>

--- a/style.css
+++ b/style.css
@@ -3249,7 +3249,7 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   --learn-accent: #125DA3;
   --learn-tint: rgba(18,93,163,0.08);
   --learn-edge: rgba(18,93,163,0.42);
-  --learn-shadow: rgba(0,0,0,0.08);
+  --learn-line: rgba(128,128,128,0.2);
 }
 
 .dark .venice-learn,
@@ -3257,7 +3257,6 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   --learn-accent: #6ba7e0;
   --learn-tint: rgba(96,165,250,0.1);
   --learn-edge: rgba(96,165,250,0.42);
-  --learn-shadow: rgba(0,0,0,0.35);
 }
 
 /* The chips are labels driving hidden radios, which is what lets the filtering
@@ -3278,10 +3277,12 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   margin: 22px 0 2px;
 }
 
+/* 8px matches the radius Venice uses on buttons. A full pill would be the
+   generic filter-chip shape rather than ours. */
 .venice-learn-chips label {
-  padding: 5px 13px;
-  border: 1px solid rgba(128,128,128,0.25);
-  border-radius: 999px;
+  padding: 5px 12px;
+  border: 1px solid var(--learn-line);
+  border-radius: 8px;
   font-size: 13px;
   line-height: 1.45;
   opacity: 0.7;
@@ -3361,55 +3362,59 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   background: rgba(128,128,128,0.5);
 }
 
-/* The whole card is the link, so there is no separate "read more" affordance
-   to slim away. Prose styles would otherwise colour and underline it. */
+/* The whole card is the link. Two things fight us here: prose styles colour
+   and underline it, and the theme repaints the bottom border with the primary
+   colour for every .link, which read as a stray blue rule under each card --
+   hence the explicit border-bottom colour rather than the shorthand alone.
+
+   12px is the radius Venice uses on cards. The card is outlined, with no
+   shadow: Venice's own cards are elevated or outlined, never both, and a
+   hairline plus a wide diffuse shadow commits to neither. */
 .venice-learn-card {
   display: flex;
   flex-direction: column;
-  gap: 9px;
+  gap: 8px;
   padding: 16px;
-  border: 1px solid rgba(128,128,128,0.2);
-  border-radius: 14px;
+  border: 1px solid var(--learn-line);
+  border-bottom-color: var(--learn-line) !important;
+  border-radius: 12px;
   background: rgba(128,128,128,0.03);
   scroll-snap-align: start;
   color: inherit !important;
   text-decoration: none !important;
-  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  transition: border-color 0.15s ease, background 0.15s ease;
 }
 
 .venice-learn-card:hover {
   border-color: var(--learn-edge);
+  border-bottom-color: var(--learn-edge) !important;
   background: var(--learn-tint);
-  transform: translateY(-2px);
-  box-shadow: 0 10px 30px var(--learn-shadow);
 }
 
 .venice-learn-card-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 10px;
 }
 
+/* Bare, the way icons are used throughout the Venice app. Setting it in a
+   tinted rounded square is the stock feature-card treatment and belongs to
+   no brand in particular. Mintlify paints icons as a mask, so the size has
+   to be set on the svg rather than the wrapper. */
 .venice-learn-icon {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 10px;
-  color: var(--learn-accent);
-  background: var(--learn-tint);
+}
+
+.venice-learn-icon svg {
+  width: 19px;
+  height: 19px;
 }
 
 .venice-learn-type {
-  padding: 3px 9px;
-  border: 1px solid rgba(128,128,128,0.25);
-  border-radius: 999px;
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  opacity: 0.7;
+  font-size: 12px;
+  opacity: 0.5;
 }
 
 .venice-learn-title {

--- a/style.css
+++ b/style.css
@@ -3189,9 +3189,73 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   opacity: 0.45;
 }
 
+/* Card metadata strip: artifact type, language, and effort. Grouped so the
+   head stays a two-part row (icon on the left, all metadata on the right)
+   however many badges a card carries. */
+.venice-demo-badges {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Artifact type is the one badge worth emphasizing: it tells the reader
+   whether they are cloning a repo or opening a notebook that needs nothing. */
+.venice-demo-type {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 4px 9px;
+  border-radius: 999px;
+  color: #125DA3;
+  background: rgba(18,93,163,0.1);
+}
+
+.dark .venice-demo-type,
+[data-theme="dark"] .venice-demo-type {
+  color: #6ba7e0;
+  background: rgba(96,165,250,0.14);
+}
+
+.venice-demo-meta {
+  font-size: 12px;
+  opacity: 0.5;
+  white-space: nowrap;
+}
+
+/* Featured slot: one full-width card above the tracks. The eyebrow explains
+   why this card is out of the grid without adding a heading to the page TOC. */
+.venice-learn-featured {
+  margin: 24px 0;
+}
+
+.venice-learn-eyebrow {
+  margin-bottom: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.45;
+}
+
+.venice-demo-card-wide .venice-demo-title {
+  font-size: 18px !important;
+}
+
+.venice-demo-card-wide .venice-demo-desc {
+  max-width: 60ch;
+}
+
 @media (max-width: 768px) {
   .venice-demo-grid {
     grid-template-columns: 1fr;
+  }
+
+  /* The metadata strip is the first thing to overflow on a phone, since it
+     sits opposite the icon in a fixed-height row. Drop the language chip
+     rather than letting the head wrap. */
+  .venice-demo-lang {
+    display: none;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2976,10 +2976,9 @@
   }
 
   /* With both side columns gone this page can be wider than the 820px prose
-     default. 1100px is three 320px cards and their gaps, plus enough left over
-     that a fourth card shows at the edge -- which is what tells you the track
-     scrolls. Going wider than that only strands whitespace to the right of the
-     short tracks, since scrolling, not width, is what absorbs new demos. */
+     default. 1100px fits three cards and leaves a fourth showing at the edge,
+     which is what tells you the row scrolls. Going wider only strands
+     whitespace, since scrolling rather than width absorbs new entries. */
   html[data-current-path="/guides/projects/overview"] #content-area {
     max-width: min(1100px, calc(100vw - 6rem)) !important;
     margin-left: auto !important;
@@ -2993,8 +2992,8 @@
     display: none !important;
   }
 
-  /* Hide the tab-name eyebrow above the page title -- redundant on the landing
-     page, where it repeats the title verbatim. Add padding above the
+  /* Hide the "Demos" eyebrow above the page title -- redundant on the landing
+     page since the title now reads "Demos & Projects". Add padding above the
      header to reclaim the vertical space the eyebrow (h-5 + 0.625rem gap) left
      behind, so the title sits at roughly the same offset as other pages. */
   html[data-current-path="/guides/projects/overview"] #header .eyebrow {
@@ -3029,55 +3028,11 @@ html[data-current-path="/guides/projects/overview"] #pagination {
 }
 
 /* ===== Demos landing page: rich project cards ===== */
-/* Each track is one horizontal row that scrolls.
-
-   Cards are a fixed 320px rather than stretching to fill, so one is the same
-   size in every track no matter how full that track is, and a short track
-   stays a short row instead of inflating two cards into billboards. Adding
-   demos lengthens the row until it overflows and scrolls.
-
-   The horizontal padding is reclaimed by the negative margin so cards still
-   line up with the prose, while the container keeps room for the hover lift
-   and its shadow -- `overflow-x` makes the vertical axis clip too. */
 .venice-demo-grid {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: 320px;
-  justify-content: start;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
-  margin: 16px -8px 8px;
-  padding: 8px 8px 22px;
-  overflow-x: auto;
-  overscroll-behavior-x: contain;
-  scroll-snap-type: x proximity;
-  scroll-padding-left: 8px;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(128,128,128,0.35) transparent;
-}
-
-/* Two syntaxes on purpose, not redundancy. Chrome 121+ and Firefox honour the
-   standard `scrollbar-width` / `scrollbar-color` above and ignore these rules;
-   older Safari only understands these. Without them that Safari falls back to
-   a chunky default bar, which does not fit the 22px of padding below the row. */
-.venice-demo-grid::-webkit-scrollbar {
-  height: 8px;
-}
-
-.venice-demo-grid::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.venice-demo-grid::-webkit-scrollbar-thumb {
-  border-radius: 4px;
-  background: rgba(128,128,128,0.3);
-}
-
-.venice-demo-grid::-webkit-scrollbar-thumb:hover {
-  background: rgba(128,128,128,0.5);
-}
-
-.venice-demo-grid > .venice-demo-card {
-  scroll-snap-align: start;
+  margin: 24px 0;
 }
 
 .venice-demo-card {
@@ -3239,80 +3194,9 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   opacity: 0.45;
 }
 
-/* Card metadata strip: artifact type, language, and effort. Grouped so the
-   head stays a two-part row (icon on the left, all metadata on the right)
-   however many badges a card carries. */
-.venice-demo-badges {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-/* Artifact type is the one badge worth emphasizing: it tells the reader
-   whether they are cloning a repo or opening a notebook that needs nothing. */
-.venice-demo-type {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  padding: 4px 9px;
-  border-radius: 999px;
-  color: #125DA3;
-  background: rgba(18,93,163,0.1);
-}
-
-.dark .venice-demo-type,
-[data-theme="dark"] .venice-demo-type {
-  color: #6ba7e0;
-  background: rgba(96,165,250,0.14);
-}
-
-.venice-demo-meta {
-  font-size: 12px;
-  opacity: 0.5;
-  white-space: nowrap;
-}
-
-/* Featured slot: one card above the tracks, sized to two card widths plus the
-   gap so it leads without stretching into a banner and still aligns with the
-   grid below. The eyebrow explains why this card is out of the grid without
-   adding a heading to the page TOC. */
-.venice-learn-featured {
-  margin: 24px 0;
-  max-width: 656px;
-}
-
-.venice-learn-eyebrow {
-  margin-bottom: 8px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  opacity: 0.45;
-}
-
-.venice-demo-card-wide .venice-demo-title {
-  font-size: 18px !important;
-}
-
-.venice-demo-card-wide .venice-demo-desc {
-  max-width: 60ch;
-}
-
 @media (max-width: 768px) {
-  /* One card at a time with the next one peeking, which is the affordance
-     that tells a thumb the row swipes. Snap firmly here rather than by
-     proximity so a swipe always settles on a card. */
   .venice-demo-grid {
-    grid-auto-columns: minmax(0, 86%);
-    scroll-snap-type: x mandatory;
-  }
-
-  /* The metadata strip is the first thing to overflow on a phone, since it
-     sits opposite the icon in a fixed-height row. Drop the language chip
-     rather than letting the head wrap. */
-  .venice-demo-lang {
-    display: none;
+    grid-template-columns: 1fr;
   }
 }
 
@@ -3351,5 +3235,202 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   [data-theme="dark"] header a.link.bg-gray-950\/\[0\.03\] {
     background-color: rgba(96, 165, 250, 0.16) !important;
     color: #6ba7e0 !important;
+  }
+}
+
+/* ===== Learn page: category chips over one scrolling row =====
+   Deliberately separate from the .venice-demo-* card styles above, which the
+   eight translated copies of this page still use. Those pages keep the old
+   two-column grid; only the English page uses what follows. */
+
+/* One accent pair for the whole component, so the dark theme is a single
+   override instead of a duplicate of every rule below. */
+.venice-learn {
+  --learn-accent: #125DA3;
+  --learn-tint: rgba(18,93,163,0.08);
+  --learn-edge: rgba(18,93,163,0.42);
+  --learn-shadow: rgba(0,0,0,0.08);
+}
+
+.dark .venice-learn,
+[data-theme="dark"] .venice-learn {
+  --learn-accent: #6ba7e0;
+  --learn-tint: rgba(96,165,250,0.1);
+  --learn-edge: rgba(96,165,250,0.42);
+  --learn-shadow: rgba(0,0,0,0.35);
+}
+
+/* The chips are labels driving hidden radios, which is what lets the filtering
+   work with no JavaScript. The radios have to precede both the chip row and
+   the card row, since a checked one reaches them with the sibling combinator. */
+.venice-learn-radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.venice-learn-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 22px 0 2px;
+}
+
+.venice-learn-chips label {
+  padding: 5px 13px;
+  border: 1px solid rgba(128,128,128,0.25);
+  border-radius: 999px;
+  font-size: 13px;
+  line-height: 1.45;
+  opacity: 0.7;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, opacity 0.15s ease;
+}
+
+.venice-learn-chips label:hover {
+  border-color: var(--learn-edge);
+  opacity: 1;
+}
+
+#lc-all:checked ~ .venice-learn-chips label[for="lc-all"],
+#lc-retrieval:checked ~ .venice-learn-chips label[for="lc-retrieval"],
+#lc-audio:checked ~ .venice-learn-chips label[for="lc-audio"],
+#lc-agents:checked ~ .venice-learn-chips label[for="lc-agents"] {
+  border-color: var(--learn-edge);
+  background: var(--learn-tint);
+  color: var(--learn-accent);
+  opacity: 1;
+}
+
+/* The radios stay focusable, so arrow keys move between chips. Without this
+   the focus ring would land on an invisible input and appear to vanish. */
+#lc-all:focus-visible ~ .venice-learn-chips label[for="lc-all"],
+#lc-retrieval:focus-visible ~ .venice-learn-chips label[for="lc-retrieval"],
+#lc-audio:focus-visible ~ .venice-learn-chips label[for="lc-audio"],
+#lc-agents:focus-visible ~ .venice-learn-chips label[for="lc-agents"] {
+  outline: 2px solid var(--learn-accent);
+  outline-offset: 2px;
+}
+
+/* Hide whatever the checked chip does not name. "All" names nothing, so it
+   matches no rule here and everything stays visible. */
+#lc-retrieval:checked ~ .venice-learn-row > .venice-learn-card:not([data-cat="retrieval"]),
+#lc-audio:checked ~ .venice-learn-row > .venice-learn-card:not([data-cat="audio"]),
+#lc-agents:checked ~ .venice-learn-row > .venice-learn-card:not([data-cat="agents"]) {
+  display: none;
+}
+
+/* Fixed-width cards in a row that scrolls once they outgrow it. The horizontal
+   padding is given back by the negative margin so cards still line up with the
+   prose, while the container keeps room for the hover lift and its shadow --
+   setting overflow-x makes the vertical axis clip too. */
+.venice-learn-row {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 300px;
+  justify-content: start;
+  gap: 14px;
+  margin: 14px -8px 8px;
+  padding: 8px 8px 20px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x proximity;
+  scroll-padding-left: 8px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(128,128,128,0.35) transparent;
+}
+
+/* Two syntaxes on purpose. Chrome 121+ and Firefox honour the standard
+   properties above and ignore these; older Safari only understands these. */
+.venice-learn-row::-webkit-scrollbar {
+  height: 8px;
+}
+
+.venice-learn-row::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.venice-learn-row::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background: rgba(128,128,128,0.3);
+}
+
+.venice-learn-row::-webkit-scrollbar-thumb:hover {
+  background: rgba(128,128,128,0.5);
+}
+
+/* The whole card is the link, so there is no separate "read more" affordance
+   to slim away. Prose styles would otherwise colour and underline it. */
+.venice-learn-card {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 16px;
+  border: 1px solid rgba(128,128,128,0.2);
+  border-radius: 14px;
+  background: rgba(128,128,128,0.03);
+  scroll-snap-align: start;
+  color: inherit !important;
+  text-decoration: none !important;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.venice-learn-card:hover {
+  border-color: var(--learn-edge);
+  background: var(--learn-tint);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px var(--learn-shadow);
+}
+
+.venice-learn-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.venice-learn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  color: var(--learn-accent);
+  background: var(--learn-tint);
+}
+
+.venice-learn-type {
+  padding: 3px 9px;
+  border: 1px solid rgba(128,128,128,0.25);
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.venice-learn-title {
+  display: block;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.venice-learn-desc {
+  display: block;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.68;
+}
+
+@media (max-width: 768px) {
+  /* One card at a time with the next peeking, which is the affordance that
+     tells a thumb the row swipes. Snap firmly so a swipe settles on a card. */
+  .venice-learn-row {
+    grid-auto-columns: minmax(0, 86%);
+    scroll-snap-type: x mandatory;
   }
 }

--- a/style.css
+++ b/style.css
@@ -3259,81 +3259,44 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   --learn-edge: rgba(96,165,250,0.42);
 }
 
-/* The chips are labels driving hidden radios, which is what lets the filtering
-   work with no JavaScript. The radios have to precede both the chip row and
-   the card row, since a checked one reaches them with the sibling combinator. */
-.venice-learn-radio {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
-  pointer-events: none;
+/* Each section is one row, so the heading has to sit tighter to its own cards
+   than to the section above it. Mintlify's default h2 margins space them
+   evenly, which leaves the heading floating between two rows. */
+.venice-learn-section {
+  margin-top: 40px;
 }
 
-.venice-learn-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 0 0 4px;
+.venice-learn-section:first-of-type {
+  margin-top: 28px;
 }
 
-/* 8px matches the radius Venice uses on buttons. A full pill would be the
-   generic filter-chip shape rather than ours. */
-.venice-learn-chips label {
-  padding: 5px 12px;
-  border: 1px solid var(--learn-line);
-  border-radius: 8px;
-  font-size: 13px;
-  line-height: 1.45;
-  opacity: 0.7;
-  cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease, opacity 0.15s ease;
+.venice-learn-section h2 {
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.4;
 }
 
-.venice-learn-chips label:hover {
-  border-color: var(--learn-edge);
-  opacity: 1;
-}
-
-#lc-all:checked ~ .venice-learn-chips label[for="lc-all"],
-#lc-retrieval:checked ~ .venice-learn-chips label[for="lc-retrieval"],
-#lc-audio:checked ~ .venice-learn-chips label[for="lc-audio"],
-#lc-agents:checked ~ .venice-learn-chips label[for="lc-agents"] {
-  border-color: var(--learn-edge);
-  background: var(--learn-tint);
-  color: var(--learn-accent);
-  opacity: 1;
-}
-
-/* The radios stay focusable, so arrow keys move between chips. Without this
-   the focus ring would land on an invisible input and appear to vanish. */
-#lc-all:focus-visible ~ .venice-learn-chips label[for="lc-all"],
-#lc-retrieval:focus-visible ~ .venice-learn-chips label[for="lc-retrieval"],
-#lc-audio:focus-visible ~ .venice-learn-chips label[for="lc-audio"],
-#lc-agents:focus-visible ~ .venice-learn-chips label[for="lc-agents"] {
-  outline: 2px solid var(--learn-accent);
-  outline-offset: 2px;
-}
-
-/* Hide whatever the checked chip does not name. "All" names nothing, so it
-   matches no rule here and everything stays visible. */
-#lc-retrieval:checked ~ .venice-learn-row > .venice-learn-card:not([data-cat="retrieval"]),
-#lc-audio:checked ~ .venice-learn-row > .venice-learn-card:not([data-cat="audio"]),
-#lc-agents:checked ~ .venice-learn-row > .venice-learn-card:not([data-cat="agents"]) {
-  display: none;
+.venice-learn-lede {
+  margin: 4px 0 0;
+  font-size: 13.5px;
+  line-height: 1.6;
+  opacity: 0.55;
 }
 
 /* Fixed-width cards in a row that scrolls once they outgrow it. The horizontal
    padding is given back by the negative margin so cards still line up with the
-   prose, while the container keeps room for the hover lift and its shadow --
-   setting overflow-x makes the vertical axis clip too. */
+   prose; setting overflow-x makes the vertical axis clip too, so the row needs
+   that padding to keep the card outlines off the clip edge. */
 .venice-learn-row {
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: 300px;
   justify-content: start;
   gap: 12px;
-  margin: 16px -8px 0;
+  margin: 12px -8px 0;
   padding: 8px;
   overflow-x: auto;
   overscroll-behavior-x: contain;
@@ -3431,20 +3394,6 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   padding-top: 4px;
   font-size: 12px;
   opacity: 0.5;
-}
-
-/* A caption for the badges, so it has to sit under the descriptions it
-   explains. At body size it was the heaviest text on the page. */
-.venice-learn-legend {
-  margin: 14px 0 0;
-  font-size: 13px;
-  line-height: 1.6;
-  opacity: 0.55;
-}
-
-.venice-learn-legend strong {
-  font-weight: 600;
-  opacity: 0.85;
 }
 
 /* Secondary links. Boxing these identically to the demos gave the page two

--- a/style.css
+++ b/style.css
@@ -3274,7 +3274,7 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin: 22px 0 2px;
+  margin: 0 0 4px;
 }
 
 /* 8px matches the radius Venice uses on buttons. A full pill would be the
@@ -3332,34 +3332,28 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   grid-auto-flow: column;
   grid-auto-columns: 300px;
   justify-content: start;
-  gap: 14px;
-  margin: 14px -8px 8px;
-  padding: 8px 8px 20px;
+  gap: 12px;
+  margin: 16px -8px 0;
+  padding: 8px;
   overflow-x: auto;
   overscroll-behavior-x: contain;
   scroll-snap-type: x proximity;
   scroll-padding-left: 8px;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(128,128,128,0.35) transparent;
+
+  /* The card at the boundary gets cut mid-word otherwise, which reads as a
+     clipping bug rather than as more content. Masking the trailing edge is
+     what makes it look like a row that continues. The mask box is the padding
+     box, so the fade stays put instead of scrolling with the cards. */
+  mask-image: linear-gradient(to right, #000 calc(100% - 64px), transparent);
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 64px), transparent);
+
+  /* No scrollbar: it drew a rule under the row, and the faded edge plus the
+     partial card already say the row scrolls. */
+  scrollbar-width: none;
 }
 
-/* Two syntaxes on purpose. Chrome 121+ and Firefox honour the standard
-   properties above and ignore these; older Safari only understands these. */
 .venice-learn-row::-webkit-scrollbar {
-  height: 8px;
-}
-
-.venice-learn-row::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.venice-learn-row::-webkit-scrollbar-thumb {
-  border-radius: 4px;
-  background: rgba(128,128,128,0.3);
-}
-
-.venice-learn-row::-webkit-scrollbar-thumb:hover {
-  background: rgba(128,128,128,0.5);
+  display: none;
 }
 
 /* The whole card is the link. Two things fight us here: prose styles colour
@@ -3374,7 +3368,7 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 16px;
+  padding: 16px 16px 14px;
   border: 1px solid var(--learn-line);
   border-bottom-color: var(--learn-line) !important;
   border-radius: 12px;
@@ -3391,11 +3385,13 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   background: var(--learn-tint);
 }
 
+/* Icon leads the title on one line, which is how the Venice app builds a list
+   row. Holding it apart from the title on its own line left the two ends of
+   that row unrelated, with a gap that changed width per card. */
 .venice-learn-card-head {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  align-items: flex-start;
+  gap: 9px;
 }
 
 /* Bare, the way icons are used throughout the Venice app. Setting it in a
@@ -3404,38 +3400,95 @@ html[data-current-path="/guides/projects/overview"] #pagination {
    to be set on the svg rather than the wrapper. */
 .venice-learn-icon {
   display: inline-flex;
-  align-items: center;
+  flex-shrink: 0;
+  padding-top: 1px;
 }
 
 .venice-learn-icon svg {
-  width: 19px;
-  height: 19px;
-}
-
-.venice-learn-type {
-  font-size: 12px;
-  opacity: 0.5;
+  width: 17px;
+  height: 17px;
 }
 
 .venice-learn-title {
-  display: block;
   font-size: 15px;
   font-weight: 600;
-  line-height: 1.35;
+  line-height: 1.4;
 }
 
 .venice-learn-desc {
   display: block;
   font-size: 13px;
-  line-height: 1.5;
-  opacity: 0.68;
+  line-height: 1.55;
+  opacity: 0.6;
+}
+
+/* Pushed to the bottom of the card. Because grid stretches every card in a
+   row to the tallest, this lines the meta up across all of them instead of
+   letting it float wherever the description happens to end. */
+.venice-learn-meta {
+  display: block;
+  margin-top: auto;
+  padding-top: 4px;
+  font-size: 12px;
+  opacity: 0.5;
+}
+
+/* A caption for the badges, so it has to sit under the descriptions it
+   explains. At body size it was the heaviest text on the page. */
+.venice-learn-legend {
+  margin: 14px 0 0;
+  font-size: 13px;
+  line-height: 1.6;
+  opacity: 0.55;
+}
+
+.venice-learn-legend strong {
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+/* Secondary links. Boxing these identically to the demos gave the page two
+   rows of equal weight and no hierarchy, so these are plain links. */
+.venice-learn-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 28px;
+  margin: 4px 0 8px;
+}
+
+.venice-learn-links a {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 14px;
+  color: inherit !important;
+  text-decoration: none !important;
+  border-bottom-color: transparent !important;
+  opacity: 0.75;
+  transition: opacity 0.15s ease, color 0.15s ease;
+}
+
+.venice-learn-links a:hover {
+  color: var(--learn-accent) !important;
+  opacity: 1;
+}
+
+.venice-learn-links .venice-learn-arrow {
+  font-size: 12px;
+  opacity: 0.5;
 }
 
 @media (max-width: 768px) {
   /* One card at a time with the next peeking, which is the affordance that
-     tells a thumb the row swipes. Snap firmly so a swipe settles on a card. */
+     tells a thumb the row swipes. Snap firmly so a swipe settles on a card.
+
+     A definite length, not a percentage: the row already overflows its
+     container, so a track with a zero minimum collapses to the width of the
+     longest word instead of resolving against the container. */
   .venice-learn-row {
-    grid-auto-columns: minmax(0, 86%);
+    grid-auto-columns: min(86vw, 320px);
     scroll-snap-type: x mandatory;
+    mask-image: linear-gradient(to right, #000 calc(100% - 36px), transparent);
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 36px), transparent);
   }
 }

--- a/style.css
+++ b/style.css
@@ -2975,12 +2975,13 @@
     padding-left: 0 !important;
   }
 
-  /* With both side columns gone this page has the whole viewport to work with,
-     so it gets a wider column than the 820px prose default. The card tracks
-     below are horizontal scrollers, and the extra width is what decides how
-     many cards land in view before one has to scroll. */
+  /* With both side columns gone this page can be wider than the 820px prose
+     default. 1100px is three 320px cards and their gaps, plus enough left over
+     that a fourth card shows at the edge -- which is what tells you the track
+     scrolls. Going wider than that only strands whitespace to the right of the
+     short tracks, since scrolling, not width, is what absorbs new demos. */
   html[data-current-path="/guides/projects/overview"] #content-area {
-    max-width: min(1240px, calc(100vw - 6rem)) !important;
+    max-width: min(1100px, calc(100vw - 6rem)) !important;
     margin-left: auto !important;
     margin-right: auto !important;
   }
@@ -3030,11 +3031,10 @@ html[data-current-path="/guides/projects/overview"] #pagination {
 /* ===== Demos landing page: rich project cards ===== */
 /* Each track is one horizontal row that scrolls.
 
-   `minmax(320px, 1fr)` is what makes a track work at both ends of its life.
-   The fr share wins while a track is short, so its cards spread to fill the
-   row and line up with the featured card above. As demos are added the share
-   shrinks until it hits the 320px floor, at which point the row overflows and
-   becomes a scroller. Self-correcting, with no breakpoint to retune.
+   Cards are a fixed 320px rather than stretching to fill, so one is the same
+   size in every track no matter how full that track is, and a short track
+   stays a short row instead of inflating two cards into billboards. Adding
+   demos lengthens the row until it overflows and scrolls.
 
    The horizontal padding is reclaimed by the negative margin so cards still
    line up with the prose, while the container keeps room for the hover lift
@@ -3042,7 +3042,8 @@ html[data-current-path="/guides/projects/overview"] #pagination {
 .venice-demo-grid {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(320px, 1fr);
+  grid-auto-columns: 320px;
+  justify-content: start;
   gap: 16px;
   margin: 16px -8px 8px;
   padding: 8px 8px 22px;
@@ -3077,14 +3078,6 @@ html[data-current-path="/guides/projects/overview"] #pagination {
 
 .venice-demo-grid > .venice-demo-card {
   scroll-snap-align: start;
-}
-
-/* A track holding one card would otherwise stretch the full row and read as a
-   second featured item. Hold it to the width it will have once a sibling
-   arrives, so a card is the same size in every track regardless of how full
-   that track happens to be. */
-.venice-demo-grid > .venice-demo-card:only-child {
-  max-width: calc(50% - 8px);
 }
 
 .venice-demo-card {
@@ -3280,10 +3273,13 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   white-space: nowrap;
 }
 
-/* Featured slot: one full-width card above the tracks. The eyebrow explains
-   why this card is out of the grid without adding a heading to the page TOC. */
+/* Featured slot: one card above the tracks, sized to two card widths plus the
+   gap so it leads without stretching into a banner and still aligns with the
+   grid below. The eyebrow explains why this card is out of the grid without
+   adding a heading to the page TOC. */
 .venice-learn-featured {
   margin: 24px 0;
+  max-width: 656px;
 }
 
 .venice-learn-eyebrow {
@@ -3310,12 +3306,6 @@ html[data-current-path="/guides/projects/overview"] #pagination {
   .venice-demo-grid {
     grid-auto-columns: minmax(0, 86%);
     scroll-snap-type: x mandatory;
-  }
-
-  /* Half a phone screen is not a card. Let a lone card take the same 86% as
-     any other on this breakpoint. */
-  .venice-demo-grid > .venice-demo-card:only-child {
-    max-width: none;
   }
 
   /* The metadata strip is the first thing to overflow on a phone, since it

--- a/style.css
+++ b/style.css
@@ -2975,7 +2975,12 @@
     padding-left: 0 !important;
   }
 
+  /* With both side columns gone this page has the whole viewport to work with,
+     so it gets a wider column than the 820px prose default. The card tracks
+     below are horizontal scrollers, and the extra width is what decides how
+     many cards land in view before one has to scroll. */
   html[data-current-path="/guides/projects/overview"] #content-area {
+    max-width: min(1240px, calc(100vw - 6rem)) !important;
     margin-left: auto !important;
     margin-right: auto !important;
   }
@@ -2987,8 +2992,8 @@
     display: none !important;
   }
 
-  /* Hide the "Demos" eyebrow above the page title -- redundant on the landing
-     page since the title now reads "Demos & Projects". Add padding above the
+  /* Hide the tab-name eyebrow above the page title -- redundant on the landing
+     page, where it repeats the title verbatim. Add padding above the
      header to reclaim the vertical space the eyebrow (h-5 + 0.625rem gap) left
      behind, so the title sits at roughly the same offset as other pages. */
   html[data-current-path="/guides/projects/overview"] #header .eyebrow {
@@ -3023,11 +3028,63 @@ html[data-current-path="/guides/projects/overview"] #pagination {
 }
 
 /* ===== Demos landing page: rich project cards ===== */
+/* Each track is one horizontal row that scrolls.
+
+   `minmax(320px, 1fr)` is what makes a track work at both ends of its life.
+   The fr share wins while a track is short, so its cards spread to fill the
+   row and line up with the featured card above. As demos are added the share
+   shrinks until it hits the 320px floor, at which point the row overflows and
+   becomes a scroller. Self-correcting, with no breakpoint to retune.
+
+   The horizontal padding is reclaimed by the negative margin so cards still
+   line up with the prose, while the container keeps room for the hover lift
+   and its shadow -- `overflow-x` makes the vertical axis clip too. */
 .venice-demo-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(320px, 1fr);
   gap: 16px;
-  margin: 24px 0;
+  margin: 16px -8px 8px;
+  padding: 8px 8px 22px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x proximity;
+  scroll-padding-left: 8px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(128,128,128,0.35) transparent;
+}
+
+/* Two syntaxes on purpose, not redundancy. Chrome 121+ and Firefox honour the
+   standard `scrollbar-width` / `scrollbar-color` above and ignore these rules;
+   older Safari only understands these. Without them that Safari falls back to
+   a chunky default bar, which does not fit the 22px of padding below the row. */
+.venice-demo-grid::-webkit-scrollbar {
+  height: 8px;
+}
+
+.venice-demo-grid::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.venice-demo-grid::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background: rgba(128,128,128,0.3);
+}
+
+.venice-demo-grid::-webkit-scrollbar-thumb:hover {
+  background: rgba(128,128,128,0.5);
+}
+
+.venice-demo-grid > .venice-demo-card {
+  scroll-snap-align: start;
+}
+
+/* A track holding one card would otherwise stretch the full row and read as a
+   second featured item. Hold it to the width it will have once a sibling
+   arrives, so a card is the same size in every track regardless of how full
+   that track happens to be. */
+.venice-demo-grid > .venice-demo-card:only-child {
+  max-width: calc(50% - 8px);
 }
 
 .venice-demo-card {
@@ -3247,8 +3304,18 @@ html[data-current-path="/guides/projects/overview"] #pagination {
 }
 
 @media (max-width: 768px) {
+  /* One card at a time with the next one peeking, which is the affordance
+     that tells a thumb the row swipes. Snap firmly here rather than by
+     proximity so a swipe always settles on a card. */
   .venice-demo-grid {
-    grid-template-columns: 1fr;
+    grid-auto-columns: minmax(0, 86%);
+    scroll-snap-type: x mandatory;
+  }
+
+  /* Half a phone screen is not a card. Let a lone card take the same 86% as
+     any other on this breakpoint. */
+  .venice-demo-grid > .venice-demo-card:only-child {
+    max-width: none;
   }
 
   /* The metadata strip is the first thing to overflow on a phone, since it


### PR DESCRIPTION
## Summary

Reshapes the demos landing page so ten more entries can land in it without it turning into a wall.

The current grid is ordered by ship date. That is exactly what stops working past a handful of items, and it is the one thing both reference pages avoid: Pinecone groups into series, Claude Academy groups into product tracks, and both put a **type** and an **effort estimate** on every card.

Three changes, borrowed directly from those two:

**Tracks instead of chronology.** Cards group by what the reader is trying to build. Two tracks today, `Retrieval and research` and `Agents and infrastructure`, with room for `Payments and privacy` when the x402 demo lands.

**A type badge on every card.** `Notebook` means it runs in the browser with nothing installed; `Repo` means a clone and some setup. This is also what gives findings posts and benchmarks a home later as `Experiment`, instead of forcing them to pretend to be projects.

**A read time on every card.** Computed per page from prose at 220 wpm plus code skimmed at 500 wpm, so the numbers are consistent rather than guessed.

Plus a featured slot above the tracks, labelled `Start here`, pointing at the notebook since it is the only entry that needs no setup at all.

## Tab renamed to Learn

`Demos` no longer describes a section that will hold experiments and walkthroughs. Renamed in all nine locales, tab and group label both:

`Learn` · `Aprender` · `تعلّم` · `Impara` · `Lernen` · `Aprender` · `Apprendre` · `学习` · `학습`

## Verification

Rendered locally rather than reasoned about:

- Desktop and the top-of-page hierarchy checked against a real render
- Caught and fixed two things only visible in the render: the opening paragraph restated the frontmatter subtitle almost word for word, and the featured card had no visible reason for sitting outside the grid
- Mobile at 430px shows the same clipping as the current production page, so this change does not regress it. That clipping is a headless artifact, not real overflow
- All 5 project pages still linked, 7 internal links resolve, every CSS class used is defined, `docs.json` parses with zero `"Demos"` left

Light mode is unverified by render, since the docs default to dark and the toggle is not drivable headlessly. The new `.venice-demo-type` badge copies the exact light/dark pattern already used by `.venice-demo-icon`.

## Notes

- **Stacked on #444.** Both touch `guides/projects/overview.mdx`, so this is based on that branch rather than `main` to avoid a conflict. Merge #444 first and the base collapses to `main`.
- Page paths are unchanged. `guides/projects/*` under a `Learn` tab is slightly off, but renaming the directory means redirects for 5 pages across 9 locales, which is not worth it right now.
- Localized overview pages still carry the old markup and title. They render fine, just without badges, and follow in the translation PR.

## Test plan

- [x] Renders correctly on a local Mintlify server
- [x] Links, CSS classes, icons, and `docs.json` all validated
- [ ] Confirm light mode on the preview deploy
- [ ] Confirm the tab label reads correctly in the RTL Arabic locale