### PR TITLE
docs: add the wallet budget agent demo

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -199,7 +199,8 @@
                   "learn/private-research-agent",
                   "learn/security-code-reviewer",
                   "learn/rust-llm-gateway",
-                  "learn/audio-research-notebook"
+                  "learn/audio-research-notebook",
+                  "learn/wallet-budget-agent"
                 ]
               }
             ]

--- a/learn.mdx
+++ b/learn.mdx
@@ -38,6 +38,14 @@ description: "Complete, runnable projects built on the Venice API, from short wa
       <span className="venice-learn-desc">Give a model three read-only tools and let it explore a database it has never seen.</span>
       <span className="venice-learn-meta">Python · 10 min</span>
     </a>
+    <a className="venice-learn-card" href="/learn/wallet-budget-agent">
+      <span className="venice-learn-card-head">
+        <span className="venice-learn-icon"><Icon icon="wallet" /></span>
+        <span className="venice-learn-title">Wallet Budget Agent</span>
+      </span>
+      <span className="venice-learn-desc">Pay per request from a USDC wallet, with no API key and a ceiling the agent enforces on itself.</span>
+      <span className="venice-learn-meta">Python · 8 min</span>
+    </a>
     <a className="venice-learn-card" href="/learn/audio-research-notebook">
       <span className="venice-learn-card-head">
         <span className="venice-learn-icon"><Icon icon="headphones" /></span>

--- a/learn/wallet-budget-agent.mdx
+++ b/learn/wallet-budget-agent.mdx
@@ -1,0 +1,358 @@
+---
+title: "Giving an Agent a Wallet and a Budget"
+description: "Pay for inference from a wallet with no API key, and cap what the agent can spend."
+slug: wallet-budget-agent-venice-x402
+"og:title": "Giving an Agent a Wallet and a Budget with Venice x402"
+"og:description": "An agent that authenticates with a wallet signature, pays per request in USDC, prints every charge, and stops at a ceiling you set."
+---
+import { AuthorByline } from "/snippets/authorByline.jsx";
+
+<AuthorByline name="Sabrina Aquino" date="21 August 2026"/>
+
+An agent with an API key can spend whatever the key can spend. That is fine when a person is watching it and awkward when nobody is. The usual fixes live outside the agent, in a dashboard or a billing alert that tells you about the problem after it happened.
+
+Venice supports a second way in. Instead of a key, the agent holds a wallet. It authenticates by signing a message, pays for each request out of a USDC balance attached to that wallet address, and every charge lands in a ledger it can read back. There is no account, no dashboard, and no key to leak. The ceiling is the balance, and you decide what to put there.
+
+This guide builds an agent that does exactly that, under a budget it enforces on itself.
+
+<Card title="Run this notebook in Google Colab" icon="notebook" href="https://colab.research.google.com/github/veniceai/api-docs/blob/main/notebooks/wallet-budget-agent.ipynb">
+  Every step below as an executable notebook. It runs without a funded wallet and stops at the payment wall, so you can see the whole flow before spending anything.
+</Card>
+
+## How It Works
+
+Four moving parts, three of which are just HTTP:
+
+| Step | Endpoint | Why |
+| --- | --- | --- |
+| Prove who you are | Any, via `SIGN-IN-WITH-X` | A signed message replaces the API key |
+| Put money in | `/x402/top-up` | Discover the rails, then settle a signed USDC transfer |
+| Check the balance | `/x402/balance/{address}` | What is left, and whether it is enough to transact |
+| Read the charges | `/x402/transactions/{address}` | Per request ledger of every debit |
+
+Inference itself is the ordinary `/chat/completions` call. The only difference is which header you send.
+
+## What It Costs to Start
+
+Two numbers matter and they are not the same number.
+
+The **minimum top-up is five dollars**. That is the smallest amount `/x402/top-up` will settle, and it is returned in the discovery response rather than hardcoded anywhere, so read it rather than trusting this page.
+
+The **minimum balance to make a call is ten cents**. A wallet holding less than that gets a `402` back from inference even though it holds money.
+
+So five dollars is the smallest wallet worth funding, and five dollars is what this guide gives the agent. Worth knowing what that buys: a short question to `qwen3-5-9b` costs about twenty seven input tokens and twenty six output tokens, which at that model's prices is roughly seven millionths of a dollar. Five dollars is on the order of three quarters of a million questions. The budget here is not a tight constraint, it is a blast radius.
+
+## Setting Up
+
+The x402 SDK does the payment signing. Do not hand-roll it: the transfer authorization is EIP-712 typed data and a reused nonce fails verification in ways that are tedious to debug.
+
+```bash
+pip install "x402[evm]" eth-account requests
+```
+
+<Note>
+  The x402 Python SDK requires Python 3.10 or newer. Colab is fine. A system Python that shipped with macOS may not be.
+</Note>
+
+Create `agent.py` with the configuration. `BUDGET_USD` is the ceiling the agent enforces on itself, set here to the whole wallet. Lower it and the agent stops before the money does, which is the only knob you are likely to change.
+
+```python
+import base64
+import json
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import requests
+from eth_account import Account
+from eth_account.messages import encode_defunct
+
+BASE_URL = "https://api.venice.ai/api/v1"
+DOMAIN = "api.venice.ai"
+CHAIN_ID = 8453          # Base mainnet
+MODEL = "qwen3-5-9b"
+BUDGET_USD = 5.00
+```
+
+## A Wallet the Agent Owns
+
+The agent needs a keypair. In production this is a wallet you funded deliberately and whose key lives in a secret manager. While you are building, generating a throwaway is the right move, because a wallet with no money cannot do anything expensive by accident.
+
+```python
+key = os.environ.get("WALLET_KEY")
+account = Account.from_key(key) if key else Account.create()
+
+print(f"wallet {account.address}")
+print("funded" if key else "disposable, cannot pay yet")
+```
+
+Keep the private key out of the notebook. In Colab, put it in Secrets and read it with `userdata.get("WALLET_KEY")`.
+
+## Signing In Instead of Authenticating
+
+There is no key to send, so each request carries a proof that the wallet owner made it. The proof is an [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) message, signed, then base64 encoded into the `SIGN-IN-WITH-X` header.
+
+The message format is exact. Venice rebuilds these bytes on its side and verifies your signature against them, so a stray blank line means a rejected signature rather than a helpful error.
+
+```python
+def siwx_header():
+    now = datetime.now(timezone.utc)
+    stamp = lambda t: t.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    issued_at, expires_at = stamp(now), stamp(now + timedelta(minutes=4))
+    nonce = secrets.token_hex(8)
+
+    message = (
+        f"{DOMAIN} wants you to sign in with your Ethereum account:\n"
+        f"{account.address}\n\nSign in to Venice AI\n\n"
+        f"URI: https://{DOMAIN}\nVersion: 1\nChain ID: {CHAIN_ID}\n"
+        f"Nonce: {nonce}\nIssued At: {issued_at}\nExpiration Time: {expires_at}"
+    )
+    signature = account.sign_message(encode_defunct(text=message)).signature.hex()
+
+    payload = {
+        "address": account.address,
+        "message": message,
+        "signature": signature if signature.startswith("0x") else "0x" + signature,
+        "chainId": CHAIN_ID,
+    }
+    return base64.b64encode(json.dumps(payload).encode()).decode()
+```
+
+Three rules govern these headers, and all three exist to stop replay. The signature is valid for **five minutes** from `Issued At`. Each **nonce is single use** for about five and a half minutes. And the signer must match the wallet in the path, so one wallet cannot inspect another and gets a `403` for trying.
+
+The practical consequence is that you sign a fresh header per request rather than caching one. Signing is local and free, so this costs nothing.
+
+```python
+def wallet_get(path, **params):
+    response = requests.get(
+        f"{BASE_URL}{path}",
+        headers={"SIGN-IN-WITH-X": siwx_header()},
+        params=params,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()["data"]
+
+
+def balance():
+    return wallet_get(f"/x402/balance/{account.address}")
+
+
+print(balance())
+```
+
+On a fresh wallet:
+
+```json
+{
+  "walletAddress": "0xc5048ea84939bb7eb4c611b88ea17d5ee4f11a0c",
+  "balanceUsd": 0,
+  "canConsume": false,
+  "minimumTopUpUsd": 5,
+  "suggestedTopUpUsd": 10
+}
+```
+
+`canConsume` is the field to branch on. It accounts for the ten cent floor, so you do not have to.
+
+## Putting Money In
+
+Topping up is two requests. The first asks what Venice accepts and is unauthenticated, because there is nothing to authenticate yet. The second carries a signed transfer authorization.
+
+```python
+from x402.client import SpendControls, x402ClientSync
+from x402.http import PAYMENT_SIGNATURE_HEADER, encode_payment_signature_header
+from x402.mechanisms.evm import EthAccountSigner
+from x402.mechanisms.evm.exact.client import ExactEvmScheme
+from x402.schemas.payments import PaymentRequired
+
+
+def top_up():
+    discovery = requests.post(f"{BASE_URL}/x402/top-up", timeout=30)
+    required = PaymentRequired.model_validate(discovery.json())
+
+    rail = next(a for a in required.accepts if a.network.startswith("eip155"))
+    print(f"{rail.network}: {int(rail.amount) / 1e6:.2f} USDC to {rail.payTo}")
+
+    client = x402ClientSync()
+    client.register(rail.network, ExactEvmScheme(EthAccountSigner(account)))
+    # The SDK caps one payment at $1 by default, which is below the $5 minimum
+    # top-up, so every rail gets rejected until this is raised.
+    client.set_spend_controls(SpendControls(max_amount_per_payment="$5", allowed_assets=True))
+
+    payload = client.create_payment_payload(required)
+    settlement = requests.post(
+        f"{BASE_URL}/x402/top-up",
+        headers={PAYMENT_SIGNATURE_HEADER: encode_payment_signature_header(payload)},
+        timeout=90,
+    )
+    return settlement.json()
+```
+
+Discovery returns one entry per rail. Base and Solana today:
+
+```json
+{
+  "x402Version": 2,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "amount": "5000000",
+      "asset": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "payTo": "0x2670b922ef37c7df47158725c0cc407b5382293f",
+      "maxTimeoutSeconds": 300,
+      "extra": { "name": "USD Coin", "version": "2" }
+    },
+    {
+      "scheme": "exact",
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "amount": "5000000",
+      "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "payTo": "8qUL23aSj7mDWdoLMXGHFvnVCT9wd7jXcysiekroADEL",
+      "maxTimeoutSeconds": 300,
+      "extra": { "name": "USD Coin", "version": "2", "feePayer": "BFK9TLC3edb13K6v4YyH3DwPb5DSUpkWvb7XnqCL9b4F" }
+    }
+  ]
+}
+```
+
+Two details in there are easy to walk past. `amount` is in base units, and USDC has six decimals, so `5000000` is five dollars and not five million of anything. On the Solana rail, `extra.feePayer` is a Venice operated account that covers the transaction fee, which is what lets a wallet pay without holding SOL.
+
+<Warning>
+  The default spend control is the first thing that will stop you. The SDK ships with `max_amount_per_payment` set to one dollar, and the Venice minimum top-up is five, so an unmodified client rejects every rail on offer and raises `NoMatchingRequirementsError` before it ever contacts the network. Raise the cap deliberately rather than turning spend controls off.
+</Warning>
+
+Settling from a wallet with no USDC returns a `400` with `PAYMENT_VERIFICATION_FAILED`. That is the expected shape of failure: the signature was fine and the transfer was not.
+
+## Paying Per Call
+
+With a balance in place, inference is a normal request that happens to carry a signature. Turning off the Venice system prompt matters more than it looks: it is worth about seventeen hundred input tokens per call, which is two orders of magnitude more than the question itself.
+
+```python
+def ask(question):
+    response = requests.post(
+        f"{BASE_URL}/chat/completions",
+        headers={"SIGN-IN-WITH-X": siwx_header(), "Content-Type": "application/json"},
+        json={
+            "model": MODEL,
+            "messages": [{"role": "user", "content": question}],
+            "max_completion_tokens": 150,
+            "venice_parameters": {
+                "include_venice_system_prompt": False,
+                "disable_thinking": True,
+            },
+        },
+        timeout=90,
+    )
+    if response.status_code == 402:
+        body = response.json()
+        raise RuntimeError(
+            f"balance ${body.get('currentBalanceUsd', 0)} is under the "
+            f"${body.get('minimumBalanceUsd')} floor. Minimum top-up is "
+            f"${body['topUpInstructions']['minimumAmountUsd']}."
+        )
+    response.raise_for_status()
+    return response.json()["choices"][0]["message"]["content"].strip()
+```
+
+Handling `402` as a normal outcome rather than an exception is the whole design. An agent paying its own way will run out of money eventually, and running out of money is not a crash.
+
+## Reading What It Spent
+
+The ledger is authoritative. Rather than estimating from token counts, ask what was actually charged.
+
+```python
+def charges():
+    """Every debit against this wallet, newest first."""
+    ledger = wallet_get(f"/x402/transactions/{account.address}", limit=100)
+    return [t for t in ledger["transactions"] if t["type"] == "CHARGE"]
+```
+
+Each row links back to the call that caused it:
+
+```json
+{
+  "id": "ledger_01H...",
+  "amount": -0.0000066,
+  "balanceAfter": 4.9999934,
+  "type": "CHARGE",
+  "createdAt": "2026-08-21T18:22:10.000Z",
+  "requestId": "chatcmpl-...",
+  "modelId": "qwen3-5-9b"
+}
+```
+
+`TOP_UP` and `REFUND` rows appear here too, with positive amounts. Filtering to `CHARGE` gives you spend.
+
+## The Budgeted Run
+
+Now the loop. Before each call the agent checks what it has spent, and it declines to start work it cannot pay for.
+
+```python
+TASKS = [
+    "Name one concrete tradeoff of vector search versus keyword search. One sentence.",
+    "In one sentence, when is a bloom filter the wrong choice?",
+    "Give one reason CRDTs are hard to debug in production. One sentence.",
+    "What is one failure mode of exponential backoff without jitter? One sentence.",
+    "Name one thing consistent hashing does not solve. One sentence.",
+    "Why is p99 latency more useful than the mean? One sentence.",
+]
+
+
+def run(budget=BUDGET_USD):
+    opening = balance()
+    print(f"balance ${opening['balanceUsd']:.4f}, budget ${budget:.4f}")
+
+    if not opening["canConsume"]:
+        print(f"cannot transact yet, minimum top-up is ${opening['minimumTopUpUsd']}")
+        return
+
+    baseline = sum(abs(c["amount"]) for c in charges())
+    spent = 0.0
+
+    for number, task in enumerate(TASKS, 1):
+        if spent >= budget:
+            print(f"\nstopped before task {number}: ${spent:.6f} of ${budget:.4f} spent")
+            return
+
+        answer = ask(task)
+        spent = sum(abs(c["amount"]) for c in charges()) - baseline
+        print(f"\n{number}. {task}")
+        print(f"   {answer}")
+        print(f"   ${spent:.6f} spent, ${budget - spent:.6f} left")
+
+    print(f"\nfinished all {len(TASKS)} tasks for ${spent:.6f}")
+    if spent:
+        print(f"at this rate ${budget:.2f} covers about {int(budget / (spent / len(TASKS))):,} calls")
+```
+
+Run it with the full five dollars and the budget never binds, which is the honest result at these prices. To watch the ceiling actually work, set one that a single call will breach:
+
+```python
+run()              # $5.00, finishes every task
+run(budget=1e-5)   # stops partway, having spent about $0.000007 per call
+```
+
+## Where This Leaves You
+
+The agent holds its own money, proves its identity with a signature, and cannot exceed a limit you set, all without an account existing anywhere. For a scheduled job, a serverless function, or anything you would rather not hand a long-lived key to, that is a materially different security posture.
+
+Some things worth doing next:
+
+<CardGroup cols={2}>
+  <Card title="Cap it in the protocol" icon="shield">
+    Spend controls in the SDK are per payment, not per session. Pair them with the budget loop above so a bug in one cannot defeat the other.
+  </Card>
+  <Card title="Refill on empty" icon="refresh">
+    Catch the `402`, top up, and retry. This is what `venice-x402-client` does for you on the TypeScript side.
+  </Card>
+  <Card title="Pay on Solana" icon="currency-solana">
+    Same flow, different rail. Sign Ed25519 and set the returned `feePayer` so the wallet needs no SOL.
+  </Card>
+  <Card title="Give it real work" icon="tools">
+    Swap the task list for a tool-calling loop and the ledger starts showing you what each decision cost.
+  </Card>
+</CardGroup>
+
+For the full endpoint reference, see [x402 top-up](/api-reference/endpoint/x402/top-up) and [Using x402 with the Venice API](/guides/integrations/x402-venice-api).

--- a/llms.txt
+++ b/llms.txt
@@ -152,6 +152,7 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Building a Codebase Security Reviewer](https://docs.venice.ai/learn/security-code-reviewer): Python security agent that finds vulnerabilities and chains them into exploit paths using Venice, an AST repo map, and Pydantic guardrails
 - [Building a Rust LLM Gateway](https://docs.venice.ai/learn/rust-llm-gateway): OpenAI-compatible Rust gateway with Axum, Postgres-backed API keys, fixed-window rate limits, streaming responses, and OpenTelemetry
 - [Building an Audio Research Notebook](https://docs.venice.ai/learn/audio-research-notebook): NotebookLM-style notebook that ingests URLs and documents with Venice scrape and text parser, answers questions with citations over embeddings, and renders a two-host audio overview with text-to-speech
+- [Giving an Agent a Wallet and a Budget](https://docs.venice.ai/learn/wallet-budget-agent): Pay for Venice inference from a USDC wallet with no API key using x402, signing in with EIP-4361, topping up on Base or Solana, and capping agent spend against the per request charge ledger
 
 ## Key Features
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -6,6 +6,7 @@ Colab notebooks that accompany the tutorial pages.
 |---|---|
 | [`article-narration.ipynb`](article-narration.ipynb) | [Narrating Articles with Text-to-Speech](../guides/media/article-narration.mdx) |
 | [`audio-research-notebook.ipynb`](audio-research-notebook.ipynb) | [Building an Audio Research Notebook](../learn/audio-research-notebook.mdx) |
+| [`wallet-budget-agent.ipynb`](wallet-budget-agent.ipynb) | [Giving an Agent a Wallet and a Budget](../learn/wallet-budget-agent.mdx) |
 
 ## These are generated
 

--- a/notebooks/build.py
+++ b/notebooks/build.py
@@ -492,9 +492,130 @@ RESEARCH = [
     ),
 ]
 
+# --------------------------------------------------------------------------
+# notebooks/wallet-budget-agent.ipynb
+# --------------------------------------------------------------------------
+
+WALLET_PAGE = "learn/wallet-budget-agent.mdx"
+
+WALLET = [
+    md(
+        "# An Agent With Its Own Wallet and a Budget\n"
+        "\n"
+        "Pay for inference with a wallet signature instead of an API key, and cap what the "
+        "agent can spend.\n"
+        "\n"
+        "This notebook accompanies "
+        f"[Giving an Agent a Wallet and a Budget]({DOCS_URL}/learn/wallet-budget-agent), "
+        "which explains the reasoning behind each step. Run the cells in order.\n"
+        "\n"
+        "**You do not need a funded wallet to run this.** Without one the notebook generates a "
+        "disposable address, signs in with it, reads a zero balance, and stops at the payment "
+        "wall. Every step except the payment itself is real."
+    ),
+    md(
+        "## Setup\n"
+        "\n"
+        "If you do want to spend, put a funded wallet's private key in the Colab sidebar under "
+        "the key icon, as a secret named `WALLET_KEY`. Leave it unset to run unfunded.\n"
+        "\n"
+        "The wallet needs at least five dollars of USDC on Base, which is the minimum top-up "
+        "Venice will settle."
+    ),
+    extra(
+        '%pip install -q "x402[evm]" eth-account requests\n'
+        "\n"
+        "import os\n"
+        "\n"
+        "try:\n"
+        "    from google.colab import userdata\n"
+        "\n"
+        "    # Absent secret raises, which leaves the notebook on the disposable path.\n"
+        "    os.environ['WALLET_KEY'] = userdata.get('WALLET_KEY')\n"
+        "    print('Funded wallet key loaded.')\n"
+        "except Exception:\n"
+        "    print('No WALLET_KEY secret. Running with a disposable wallet.')"
+    ),
+    md("## Configuration"),
+    mdx("Setting Up"),
+    md(
+        "## The wallet\n"
+        "\n"
+        "In production this is a wallet you funded deliberately, with the key in a secret "
+        "manager. While building, a throwaway is safer, because a wallet with no money cannot "
+        "do anything expensive by accident."
+    ),
+    mdx("A Wallet the Agent Owns"),
+    md(
+        "## Signing in\n"
+        "\n"
+        "There is no key to send, so every request carries a signed "
+        "[EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) message proving the wallet owner "
+        "made it. Venice rebuilds these exact bytes and verifies your signature against them, "
+        "so the format is not negotiable.\n"
+        "\n"
+        "Signatures last five minutes and each nonce is single use, so we sign a fresh header "
+        "per request. Signing is local and costs nothing."
+    ),
+    mdx("Signing In Instead of Authenticating"),
+    md("Read the balance back. `canConsume` already accounts for the ten cent floor."),
+    mdx("Signing In Instead of Authenticating", 1),
+    md(
+        "## Putting money in\n"
+        "\n"
+        "Two requests: discover what Venice accepts, then settle a signed USDC transfer. The "
+        "cell below only defines the function."
+    ),
+    mdx("Putting Money In"),
+    md(
+        "Running `top_up()` moves real money, so it is commented out. Uncomment it once "
+        "`WALLET_KEY` points at a wallet holding at least five dollars of USDC on Base.\n"
+        "\n"
+        "From an empty wallet it returns `400 PAYMENT_VERIFICATION_FAILED`, which means the "
+        "signature was fine and the transfer was not."
+    ),
+    extra(
+        "# print(top_up())"
+    ),
+    md(
+        "## Paying per call\n"
+        "\n"
+        "Ordinary inference that happens to carry a signature. Turning off the Venice system "
+        "prompt is worth about seventeen hundred input tokens per call, which dwarfs the "
+        "question itself."
+    ),
+    mdx("Paying Per Call"),
+    md(
+        "## Reading what it spent\n"
+        "\n"
+        "The ledger is authoritative, so ask what was charged rather than estimating from "
+        "token counts."
+    ),
+    mdx("Reading What It Spent"),
+    md(
+        "## The budgeted run\n"
+        "\n"
+        "Before each call the agent checks what it has spent and declines work it cannot pay "
+        "for. Unfunded, this stops immediately and tells you the minimum top-up."
+    ),
+    mdx("The Budgeted Run"),
+    mdx("The Budgeted Run", 1),
+    md(
+        "## Next steps\n"
+        "\n"
+        f"- [Authentication]({DOCS_URL}/guides/getting-started/authentication), both auth modes "
+        "side by side\n"
+        f"- [x402 top-up]({DOCS_URL}/api-reference/endpoint/x402/top-up), the endpoint reference\n"
+        f"- [Building an Audio Research Notebook]({DOCS_URL}/learn/audio-research-notebook), "
+        "a longer project to point this agent's budget at\n"
+        "- `venice-x402-client` on npm, which wraps catch-402, top-up, and retry for TypeScript"
+    ),
+]
+
 BUILDS = [
     (NARRATION_PAGE, "notebooks/article-narration.ipynb", NARRATION),
     (RESEARCH_PAGE, "notebooks/audio-research-notebook.ipynb", RESEARCH),
+    (WALLET_PAGE, "notebooks/wallet-budget-agent.ipynb", WALLET),
 ]
 
 

--- a/notebooks/wallet-budget-agent.ipynb
+++ b/notebooks/wallet-budget-agent.ipynb
@@ -1,0 +1,384 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# An Agent With Its Own Wallet and a Budget\n",
+    "\n",
+    "Pay for inference with a wallet signature instead of an API key, and cap what the agent can spend.\n",
+    "\n",
+    "This notebook accompanies [Giving an Agent a Wallet and a Budget](https://docs.venice.ai/learn/wallet-budget-agent), which explains the reasoning behind each step. Run the cells in order.\n",
+    "\n",
+    "**You do not need a funded wallet to run this.** Without one the notebook generates a disposable address, signs in with it, reads a zero balance, and stops at the payment wall. Every step except the payment itself is real."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "If you do want to spend, put a funded wallet's private key in the Colab sidebar under the key icon, as a secret named `WALLET_KEY`. Leave it unset to run unfunded.\n",
+    "\n",
+    "The wallet needs at least five dollars of USDC on Base, which is the minimum top-up Venice will settle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%pip install -q \"x402[evm]\" eth-account requests\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "try:\n",
+    "    from google.colab import userdata\n",
+    "\n",
+    "    # Absent secret raises, which leaves the notebook on the disposable path.\n",
+    "    os.environ['WALLET_KEY'] = userdata.get('WALLET_KEY')\n",
+    "    print('Funded wallet key loaded.')\n",
+    "except Exception:\n",
+    "    print('No WALLET_KEY secret. Running with a disposable wallet.')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import base64\n",
+    "import json\n",
+    "import os\n",
+    "import secrets\n",
+    "from datetime import datetime, timedelta, timezone\n",
+    "\n",
+    "import requests\n",
+    "from eth_account import Account\n",
+    "from eth_account.messages import encode_defunct\n",
+    "\n",
+    "BASE_URL = \"https://api.venice.ai/api/v1\"\n",
+    "DOMAIN = \"api.venice.ai\"\n",
+    "CHAIN_ID = 8453          # Base mainnet\n",
+    "MODEL = \"qwen3-5-9b\"\n",
+    "BUDGET_USD = 5.00"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The wallet\n",
+    "\n",
+    "In production this is a wallet you funded deliberately, with the key in a secret manager. While building, a throwaway is safer, because a wallet with no money cannot do anything expensive by accident."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "key = os.environ.get(\"WALLET_KEY\")\n",
+    "account = Account.from_key(key) if key else Account.create()\n",
+    "\n",
+    "print(f\"wallet {account.address}\")\n",
+    "print(\"funded\" if key else \"disposable, cannot pay yet\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Signing in\n",
+    "\n",
+    "There is no key to send, so every request carries a signed [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) message proving the wallet owner made it. Venice rebuilds these exact bytes and verifies your signature against them, so the format is not negotiable.\n",
+    "\n",
+    "Signatures last five minutes and each nonce is single use, so we sign a fresh header per request. Signing is local and costs nothing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def siwx_header():\n",
+    "    now = datetime.now(timezone.utc)\n",
+    "    stamp = lambda t: t.isoformat(timespec=\"milliseconds\").replace(\"+00:00\", \"Z\")\n",
+    "    issued_at, expires_at = stamp(now), stamp(now + timedelta(minutes=4))\n",
+    "    nonce = secrets.token_hex(8)\n",
+    "\n",
+    "    message = (\n",
+    "        f\"{DOMAIN} wants you to sign in with your Ethereum account:\\n\"\n",
+    "        f\"{account.address}\\n\\nSign in to Venice AI\\n\\n\"\n",
+    "        f\"URI: https://{DOMAIN}\\nVersion: 1\\nChain ID: {CHAIN_ID}\\n\"\n",
+    "        f\"Nonce: {nonce}\\nIssued At: {issued_at}\\nExpiration Time: {expires_at}\"\n",
+    "    )\n",
+    "    signature = account.sign_message(encode_defunct(text=message)).signature.hex()\n",
+    "\n",
+    "    payload = {\n",
+    "        \"address\": account.address,\n",
+    "        \"message\": message,\n",
+    "        \"signature\": signature if signature.startswith(\"0x\") else \"0x\" + signature,\n",
+    "        \"chainId\": CHAIN_ID,\n",
+    "    }\n",
+    "    return base64.b64encode(json.dumps(payload).encode()).decode()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read the balance back. `canConsume` already accounts for the ten cent floor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def wallet_get(path, **params):\n",
+    "    response = requests.get(\n",
+    "        f\"{BASE_URL}{path}\",\n",
+    "        headers={\"SIGN-IN-WITH-X\": siwx_header()},\n",
+    "        params=params,\n",
+    "        timeout=30,\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()[\"data\"]\n",
+    "\n",
+    "\n",
+    "def balance():\n",
+    "    return wallet_get(f\"/x402/balance/{account.address}\")\n",
+    "\n",
+    "\n",
+    "print(balance())"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Putting money in\n",
+    "\n",
+    "Two requests: discover what Venice accepts, then settle a signed USDC transfer. The cell below only defines the function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from x402.client import SpendControls, x402ClientSync\n",
+    "from x402.http import PAYMENT_SIGNATURE_HEADER, encode_payment_signature_header\n",
+    "from x402.mechanisms.evm import EthAccountSigner\n",
+    "from x402.mechanisms.evm.exact.client import ExactEvmScheme\n",
+    "from x402.schemas.payments import PaymentRequired\n",
+    "\n",
+    "\n",
+    "def top_up():\n",
+    "    discovery = requests.post(f\"{BASE_URL}/x402/top-up\", timeout=30)\n",
+    "    required = PaymentRequired.model_validate(discovery.json())\n",
+    "\n",
+    "    rail = next(a for a in required.accepts if a.network.startswith(\"eip155\"))\n",
+    "    print(f\"{rail.network}: {int(rail.amount) / 1e6:.2f} USDC to {rail.payTo}\")\n",
+    "\n",
+    "    client = x402ClientSync()\n",
+    "    client.register(rail.network, ExactEvmScheme(EthAccountSigner(account)))\n",
+    "    # The SDK caps one payment at $1 by default, which is below the $5 minimum\n",
+    "    # top-up, so every rail gets rejected until this is raised.\n",
+    "    client.set_spend_controls(SpendControls(max_amount_per_payment=\"$5\", allowed_assets=True))\n",
+    "\n",
+    "    payload = client.create_payment_payload(required)\n",
+    "    settlement = requests.post(\n",
+    "        f\"{BASE_URL}/x402/top-up\",\n",
+    "        headers={PAYMENT_SIGNATURE_HEADER: encode_payment_signature_header(payload)},\n",
+    "        timeout=90,\n",
+    "    )\n",
+    "    return settlement.json()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Running `top_up()` moves real money, so it is commented out. Uncomment it once `WALLET_KEY` points at a wallet holding at least five dollars of USDC on Base.\n",
+    "\n",
+    "From an empty wallet it returns `400 PAYMENT_VERIFICATION_FAILED`, which means the signature was fine and the transfer was not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# print(top_up())"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Paying per call\n",
+    "\n",
+    "Ordinary inference that happens to carry a signature. Turning off the Venice system prompt is worth about seventeen hundred input tokens per call, which dwarfs the question itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def ask(question):\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/chat/completions\",\n",
+    "        headers={\"SIGN-IN-WITH-X\": siwx_header(), \"Content-Type\": \"application/json\"},\n",
+    "        json={\n",
+    "            \"model\": MODEL,\n",
+    "            \"messages\": [{\"role\": \"user\", \"content\": question}],\n",
+    "            \"max_completion_tokens\": 150,\n",
+    "            \"venice_parameters\": {\n",
+    "                \"include_venice_system_prompt\": False,\n",
+    "                \"disable_thinking\": True,\n",
+    "            },\n",
+    "        },\n",
+    "        timeout=90,\n",
+    "    )\n",
+    "    if response.status_code == 402:\n",
+    "        body = response.json()\n",
+    "        raise RuntimeError(\n",
+    "            f\"balance ${body.get('currentBalanceUsd', 0)} is under the \"\n",
+    "            f\"${body.get('minimumBalanceUsd')} floor. Minimum top-up is \"\n",
+    "            f\"${body['topUpInstructions']['minimumAmountUsd']}.\"\n",
+    "        )\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()[\"choices\"][0][\"message\"][\"content\"].strip()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading what it spent\n",
+    "\n",
+    "The ledger is authoritative, so ask what was charged rather than estimating from token counts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def charges():\n",
+    "    \"\"\"Every debit against this wallet, newest first.\"\"\"\n",
+    "    ledger = wallet_get(f\"/x402/transactions/{account.address}\", limit=100)\n",
+    "    return [t for t in ledger[\"transactions\"] if t[\"type\"] == \"CHARGE\"]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The budgeted run\n",
+    "\n",
+    "Before each call the agent checks what it has spent and declines work it cannot pay for. Unfunded, this stops immediately and tells you the minimum top-up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "TASKS = [\n",
+    "    \"Name one concrete tradeoff of vector search versus keyword search. One sentence.\",\n",
+    "    \"In one sentence, when is a bloom filter the wrong choice?\",\n",
+    "    \"Give one reason CRDTs are hard to debug in production. One sentence.\",\n",
+    "    \"What is one failure mode of exponential backoff without jitter? One sentence.\",\n",
+    "    \"Name one thing consistent hashing does not solve. One sentence.\",\n",
+    "    \"Why is p99 latency more useful than the mean? One sentence.\",\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def run(budget=BUDGET_USD):\n",
+    "    opening = balance()\n",
+    "    print(f\"balance ${opening['balanceUsd']:.4f}, budget ${budget:.4f}\")\n",
+    "\n",
+    "    if not opening[\"canConsume\"]:\n",
+    "        print(f\"cannot transact yet, minimum top-up is ${opening['minimumTopUpUsd']}\")\n",
+    "        return\n",
+    "\n",
+    "    baseline = sum(abs(c[\"amount\"]) for c in charges())\n",
+    "    spent = 0.0\n",
+    "\n",
+    "    for number, task in enumerate(TASKS, 1):\n",
+    "        if spent >= budget:\n",
+    "            print(f\"\\nstopped before task {number}: ${spent:.6f} of ${budget:.4f} spent\")\n",
+    "            return\n",
+    "\n",
+    "        answer = ask(task)\n",
+    "        spent = sum(abs(c[\"amount\"]) for c in charges()) - baseline\n",
+    "        print(f\"\\n{number}. {task}\")\n",
+    "        print(f\"   {answer}\")\n",
+    "        print(f\"   ${spent:.6f} spent, ${budget - spent:.6f} left\")\n",
+    "\n",
+    "    print(f\"\\nfinished all {len(TASKS)} tasks for ${spent:.6f}\")\n",
+    "    if spent:\n",
+    "        print(f\"at this rate ${budget:.2f} covers about {int(budget / (spent / len(TASKS))):,} calls\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "run()              # $5.00, finishes every task\n",
+    "run(budget=1e-5)   # stops partway, having spent about $0.000007 per call"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- [Authentication](https://docs.venice.ai/guides/getting-started/authentication), both auth modes side by side\n",
+    "- [x402 top-up](https://docs.venice.ai/api-reference/endpoint/x402/top-up), the endpoint reference\n",
+    "- [Building an Audio Research Notebook](https://docs.venice.ai/learn/audio-research-notebook), a longer project to point this agent's budget at\n",
+    "- `venice-x402-client` on npm, which wraps catch-402, top-up, and retry for TypeScript"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary

An agent that holds a wallet instead of an API key. It signs in with an EIP-4361 message, pays per request out of a USDC balance, reads back a ledger of every charge, and stops at a ceiling it enforces on itself. No account exists anywhere.

The agent is funded with a $5 top-up, which is the smallest amount Venice will settle, and the budget in the guide is that whole $5. Lowering `BUDGET_USD` is the one knob a reader is likely to turn, and the page shows the ceiling actually binding by setting one a single call will breach.

## How much of this is verified

Everything except the settlement itself, which needs USDC I do not have. Specifically, run live against `api.venice.ai`:

- **SIWX sign-in**, a hand-built EIP-4361 message, signed with `eth-account`, accepted by the server. This was the part most likely to be wrong and it is right.
- `GET /x402/balance` and `GET /x402/transactions`, both `200`
- Wrong-wallet access, `403`, as documented
- Inference with a zero balance, `402` with the full top-up instructions
- **A fully signed payment, submitted.** Discovery, EIP-3009 authorization, `PAYMENT-SIGNATURE` header, POST. Venice rejected it at on-chain verification with `400 PAYMENT_VERIFICATION_FAILED`, which is the correct failure for an empty wallet. The signature and the request shape are proven, only the funds are missing.
- **Every Python block on the page**, extracted in order and executed as one script
- **The generated notebook**, executed end to end through `nbclient`, 11 code cells, no exceptions

What is *not* verified: a successful top-up, and therefore real `CHARGE` rows and a real budget halt. Worth a funded run before merge.

## Three things the live run turned up

**The SDK's default spend control blocks the minimum top-up.** `x402` ships with `max_amount_per_payment` set to `$1`. The Venice minimum is `$5`. So an unmodified client raises `NoMatchingRequirementsError` and never contacts the network. Anyone following the SDK docs naively hits this first. The page calls it out in a warning.

**Two different minimums.** `$5` is the smallest top-up that will settle, `$0.10` is the smallest balance that can make a call. A wallet can hold money and still get a `402`.

**The default system prompt costs ~1700 input tokens.** On a short question that is roughly sixty times the question itself. With `include_venice_system_prompt: false` a call drops to 27 input and 26 output tokens, about `$0.0000066` on `qwen3-5-9b`. Which puts `$5` on the order of **three quarters of a million questions**, and is the reason the page is honest that the budget is a blast radius rather than a real constraint.

## Files

- `learn/wallet-budget-agent.mdx`, the guide
- `notebooks/wallet-budget-agent.ipynb`, generated from the page by `notebooks/build.py`, so it cannot drift
- Registered in `docs.json`, `llms.txt`, `notebooks/README.md`, and the Learn page

The notebook runs without a funded wallet on purpose: it generates a disposable address, signs in, reads zero, and stops at the wall. A reader sees the entire flow before spending anything.

## Notes

- **Top of the docs stack**, currently based on #462. Everything below it merges first and the base collapses.
- English only. Translations follow separately, per the usual pattern.
- Requires Python 3.10+, which is the x402 SDK's floor. Colab is fine.

## Test plan

- [x] Page code assembled and executed against the live API
- [x] Notebook executed end to end
- [x] Links, icons, and notebook drift check all pass
- [ ] Fund a wallet and confirm a successful top-up, real charges, and the budget halt
- [ ] Confirm the Colab link resolves once merged to `main`