### PR TITLE
ci: sync models after Outerface deployments

### DIFF
--- a/.github/workflows/sync-static-models.yml
+++ b/.github/workflows/sync-static-models.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "17 * * * *"
   workflow_dispatch:
+  repository_dispatch:
+    types: [outerface-deployed]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Trigger the existing static model snapshot workflow when Outerface reports a successful production deployment.
- Retain the hourly schedule and manual trigger as recovery paths.

## Test plan
- `git diff --check`
- YAML workflow reviewed against the existing repository dispatch contract.

Made with [Cursor](https://cursor.com)