### PR TITLE
Make the Learn card rows navigable with a mouse

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -69,6 +69,87 @@
   relocate();
 })();
 
+// Drag to scroll the Learn card rows.
+//
+// Each row is an overflow-x container with its scrollbar hidden, which leaves a
+// mouse user with no way to move it: there is no bar to grab, a vertical wheel
+// does nothing to a horizontal overflow, and only trackpads emit horizontal
+// deltas. That left the arrow keys, and only once a card had taken focus.
+// Pointer events close the gap without changing the markup.
+//
+// Touch is left alone because native swipe already works there. The threshold
+// is what separates a drag from a click, which matters because every card is a
+// link: once past it we capture the pointer, suppress the click that would
+// otherwise navigate on release, and drop snapping so the row tracks the cursor
+// instead of pulling against it.
+(function() {
+  const DRAG_THRESHOLD = 5;
+
+  function enableDragScroll(row) {
+    if (row.dataset.dragScroll) return;
+    row.dataset.dragScroll = 'on';
+
+    let pointerId = null;
+    let startX = 0;
+    let startScrollLeft = 0;
+    let dragged = false;
+
+    row.addEventListener('pointerdown', function(event) {
+      if (event.pointerType === 'touch' || event.button !== 0) return;
+      pointerId = event.pointerId;
+      startX = event.clientX;
+      startScrollLeft = row.scrollLeft;
+      dragged = false;
+    });
+
+    row.addEventListener('pointermove', function(event) {
+      if (pointerId === null || event.pointerId !== pointerId) return;
+      const travelled = event.clientX - startX;
+      if (!dragged) {
+        if (Math.abs(travelled) < DRAG_THRESHOLD) return;
+        dragged = true;
+        row.classList.add('is-dragging');
+        try { row.setPointerCapture(pointerId); } catch (error) {}
+      }
+      row.scrollLeft = startScrollLeft - travelled;
+      event.preventDefault();
+    });
+
+    function endDrag(event) {
+      if (pointerId === null || event.pointerId !== pointerId) return;
+      try { row.releasePointerCapture(pointerId); } catch (error) {}
+      pointerId = null;
+      row.classList.remove('is-dragging');
+      // `dragged` has to survive into the click that follows this same gesture,
+      // so it is cleared a tick later rather than here.
+      if (dragged) setTimeout(function() { dragged = false; }, 0);
+    }
+
+    row.addEventListener('pointerup', endDrag);
+    row.addEventListener('pointercancel', endDrag);
+
+    row.addEventListener('click', function(event) {
+      if (!dragged) return;
+      event.preventDefault();
+      event.stopPropagation();
+    }, true);
+
+    // Links start a native drag of their own, which kills the gesture midway.
+    row.addEventListener('dragstart', function(event) { event.preventDefault(); });
+  }
+
+  function scanForRows() {
+    document.querySelectorAll('.venice-learn-row').forEach(enableDragScroll);
+  }
+
+  new MutationObserver(scanForRows).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  scanForRows();
+})();
+
 // Venice AI Model Browser & Pricing Tables - Fetches from API
 (function() {
 

--- a/model-search.js
+++ b/model-search.js
@@ -150,6 +150,103 @@
   scanForRows();
 })();
 
+// A transient scroll indicator for the Learn card rows.
+//
+// The native scrollbar is hidden on these rows because one sitting under every
+// row read as a rule drawn across the page. This puts a bar back, but only
+// while it is telling you something: it fades in while the row is moving and
+// while the cursor is over it, then fades out again. It is built here rather
+// than in the markup so the nine translated copies of the page do not each
+// need a wrapper element. It reports position and takes no input, since the
+// row itself is what you drag.
+(function() {
+  const HIDE_DELAY = 900;
+  const MIN_THUMB = 32;
+
+  function attachIndicator(row) {
+    if (row.dataset.scrollIndicator) return;
+    row.dataset.scrollIndicator = 'on';
+
+    const track = document.createElement('div');
+    track.className = 'venice-learn-scrollbar is-idle';
+    const thumb = document.createElement('div');
+    thumb.className = 'venice-learn-scrollbar-thumb';
+    track.appendChild(thumb);
+    row.insertAdjacentElement('afterend', track);
+
+    let hideTimer = null;
+    let hovering = false;
+
+    function scrollableBy() {
+      return row.scrollWidth - row.clientWidth;
+    }
+
+    function render() {
+      const scrollable = scrollableBy();
+      if (scrollable <= 1) {
+        track.classList.add('is-idle');
+        return;
+      }
+      // Measure only once the track is displayed, or its width reads as zero.
+      track.classList.remove('is-idle');
+      const trackWidth = track.clientWidth;
+      const width = Math.max(MIN_THUMB, Math.round(trackWidth * (row.clientWidth / row.scrollWidth)));
+      const progress = Math.min(1, Math.max(0, row.scrollLeft / scrollable));
+      thumb.style.width = width + 'px';
+      thumb.style.transform = 'translateX(' + Math.round(progress * (trackWidth - width)) + 'px)';
+    }
+
+    function armFade() {
+      clearTimeout(hideTimer);
+      hideTimer = setTimeout(function() { track.classList.remove('is-visible'); }, HIDE_DELAY);
+    }
+
+    function reveal() {
+      if (scrollableBy() <= 1) return;
+      render();
+      track.classList.add('is-visible');
+      clearTimeout(hideTimer);
+      // Scrolling under the cursor must not start the fade, or the bar drops
+      // out from under someone who is still working the row.
+      if (!hovering) armFade();
+    }
+
+    row.addEventListener('scroll', reveal, { passive: true });
+
+    // Touch has no hover state, and its pointerleave is unreliable, so a touch
+    // scroll would otherwise leave the bar up for good.
+    row.addEventListener('pointerenter', function(event) {
+      if (event.pointerType === 'touch') return;
+      hovering = true;
+      reveal();
+    });
+
+    row.addEventListener('pointerleave', function() {
+      hovering = false;
+      if (track.classList.contains('is-visible')) armFade();
+    });
+
+    if (typeof ResizeObserver === 'function') {
+      new ResizeObserver(render).observe(row);
+    } else {
+      window.addEventListener('resize', render);
+    }
+
+    render();
+  }
+
+  function scanForRows() {
+    document.querySelectorAll('.venice-learn-row').forEach(attachIndicator);
+  }
+
+  new MutationObserver(scanForRows).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  scanForRows();
+})();
+
 // Venice AI Model Browser & Pricing Tables - Fetches from API
 (function() {
 

--- a/style.css
+++ b/style.css
@@ -3250,6 +3250,10 @@ html[data-current-path="/learn"] #pagination {
   --learn-tint: rgba(18,93,163,0.08);
   --learn-edge: rgba(18,93,163,0.42);
   --learn-line: rgba(128,128,128,0.2);
+  /* Grey rather than the accent, so the scroll indicator reads as chrome
+     instead of as another thing on the page asking to be looked at. Grey with
+     alpha needs no dark override. */
+  --learn-thumb: rgba(128,128,128,0.5);
 }
 
 .dark .venice-learn,
@@ -3333,6 +3337,44 @@ html[data-current-path="/learn"] #pagination {
 
 .venice-learn-row.is-dragging .venice-learn-card {
   cursor: grabbing;
+}
+
+/* Scroll indicator, built by model-search.js and inserted after each row.
+   The native bar was taken out because one parked under every row read as a
+   rule ruled across the page, so this one only appears while it has something
+   to say: while the row is moving, and while the cursor is over it. It sits
+   in normal flow below the row, which reserves its space and keeps it off the
+   cards, and it reports position rather than accepting input, since the row
+   itself is what you drag. */
+.venice-learn-scrollbar {
+  height: 3px;
+  margin: 10px 0 0;
+  border-radius: 999px;
+  background: var(--learn-line);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.venice-learn-scrollbar.is-visible {
+  opacity: 1;
+}
+
+/* Nothing to indicate when the row fits, so it takes back its space too. */
+.venice-learn-scrollbar.is-idle {
+  display: none;
+}
+
+.venice-learn-scrollbar-thumb {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--learn-thumb);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .venice-learn-scrollbar {
+    transition: none;
+  }
 }
 
 /* The whole card is the link. Two things fight us here: prose styles colour

--- a/style.css
+++ b/style.css
@@ -3319,6 +3319,22 @@ html[data-current-path="/learn"] #pagination {
   display: none;
 }
 
+/* Drag-to-scroll states. The behaviour lives in model-search.js, which adds
+   this class for the duration of a drag. Snapping has to come off while the
+   row follows the cursor, or it keeps pulling the row back to a card edge.
+   The cursor only changes mid-drag: the cards are links, and a resting grab
+   cursor would contradict the click they are asking for. */
+.venice-learn-row.is-dragging {
+  scroll-snap-type: none;
+  cursor: grabbing;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.venice-learn-row.is-dragging .venice-learn-card {
+  cursor: grabbing;
+}
+
 /* The whole card is the link. Two things fight us here: prose styles colour
    and underline it, and the theme repaints the bottom border with the primary
    colour for every .link, which read as a stray blue rule under each card --


### PR DESCRIPTION
## Summary

Two related gaps on the Learn page: you could not grab a row of cards and slide it, and there was no scrollbar to tell you the row moved at all. Reaching the later cards meant tabbing into a row and using the arrow keys.

Both come from the same place. The rows hide their scrollbar, so there is nothing to grab, a vertical wheel does nothing to a horizontal overflow, and only trackpads emit horizontal deltas. A plain mouse had no way to move the row.

## Drag to scroll

Press and drag now scrolls a row. Every card is a link, so the work is in telling a drag apart from a click:

- Under five pixels of travel it stays a click and follows the card's link, unchanged.
- Past five pixels it becomes a drag. The pointer is captured, the row follows the cursor, and the click that would fire on release is suppressed so the page does not navigate out from under you.
- Snapping is dropped for the duration, otherwise it tugs the row back to a card edge mid-gesture, then restored so the row still settles on release.
- The cursor becomes `grabbing` only while dragging. At rest the cards keep their pointer cursor, since a resting grab cursor would argue with the click they are inviting.
- Touch is left to native swipe, and keyboard behaviour is untouched.

## A scroll indicator

A thin bar under each row, visible only while it has something to say: it fades in while the row is moving and while the cursor is over it, then fades out. Scrolling under the cursor does not start the fade, so it will not drop out from under someone still working the row.

The native bar was removed originally because one parked under every row read as a rule across the page, and that stays true. This one sits below the row in normal flow, so it reserves its own space and cannot overlap a card, and it collapses entirely on a row that fits. It is grey rather than the accent colour so it reads as chrome. It reports position and takes no input, since the row itself is now what you drag, and a three pixel target would be a poor control anyway.

## Verified

Driven through Puppeteer against a local preview, on the real page rather than a fixture. Drag: handler attaches to both rows, each scrolls independently, `is-dragging` applied and cleared, a drag does not navigate, a click does navigate both fresh and after a drag, synthetic touch pointers are ignored, and it re-attaches and still works after SPA navigation away and back. Indicator: hidden at rest, appears on drag and on scroll alone, thumb width tracks the visible fraction and reaches the end at full scroll, holds while hovered, fades after the cursor leaves, re-measures on resize, and collapses when the row fits. No page errors from this code in either suite.

## Files

- `model-search.js`, two self-contained blocks alongside the existing Learn and header tweaks already in that file
- `style.css`, the drag states, the indicator, and one grey token

No markup changed, so nothing needs re-translating.