### PR TITLE
Bring the agent-facing index files back in line with the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ This repo holds the documentation for the Venice API. The doc-site itself is bui
 
 Our documentation is organized into several key sections:
 
-- **Welcome** - Introduction to venice and getting started guides
-- **API Reference** - Detailed API endpoint documentation
-- **Guides** - Step-by-step tutorials and integration examples
+- **Docs** - Overview, getting started, and the capability guides for text, image, video, audio, search, and integrations
+- **Models** - The model catalog, by modality
+- **Learn** - Complete, runnable walkthroughs and projects built on the API
+- **API Reference** - Endpoint documentation generated from `swagger.yaml`
 - **Changelog** - Latest updates and API changes
+- **Status Page** - Live service status
 
 ## 🚀 Getting Started
 
@@ -64,13 +66,13 @@ Changes are automatically deployed when pushed to the main branch. Just:
 1. Push changes to your default branch
 3. Your documentation will automatically update at your deployment URL
 
-NOTE that this repo does not have preview branches at the moment. So you'll need to test your changes locally before submitting a PR. The person reviewing the PR will have to pull the branch and test it locally.
+Pull requests get a Mintlify preview deployment, linked from the checks on the PR, so a reviewer can read the rendered pages without pulling the branch. Mintlify also runs a link-rot check and a spellcheck on each PR. Testing locally with `yarn dev` is still the fastest loop while you are writing.
 
 ## 🛠 Troubleshooting
 
 If you encounter any issues:
 
-- **404 Errors**: Ensure you're running the dev server in a directory containing `mint.json`
+- **404 Errors**: Ensure you're running the dev server in a directory containing `docs.json`
 - **Development Server Issues**: Run `yarn install` to reinstall dependencies
 - **Content Not Updating**: Clear your browser cache or try a hard refresh
 

--- a/agents.md
+++ b/agents.md
@@ -11,7 +11,7 @@
 - **Default text model trait:** `GET /models/traits` maps traits like `text:default`, `text:uncensored`, `image:fast` to current model IDs
 - **OpenAPI spec:** https://docs.venice.ai/swagger.yaml
 - **Full docs index:** https://docs.venice.ai/llms.txt (one-line-per-page) and https://docs.venice.ai/llms-full.txt (entire docs in one file)
-- **Markdown pages:** append `.md` to any docs URL for the raw Markdown version, e.g. `https://docs.venice.ai/overview/getting-started.md`
+- **Markdown pages:** append `.md` to any docs URL for the raw Markdown version, e.g. `https://docs.venice.ai/getting-started/quick-start.md`
 - **Agent skill file:** https://docs.venice.ai/skill.md — install with `npx skills add docs.venice.ai`
 - **Canonical Agent Skills repo:** https://github.com/veniceai/skills
 - **MCP server:** https://github.com/veniceai/venice-mcp-server (31 tools, any MCP host)
@@ -73,7 +73,7 @@ Feature suffixes also work on model IDs, e.g. `venice-uncensored:web` enables we
 
 ## Key guides
 
-- Getting started: https://docs.venice.ai/overview/getting-started.md
+- Getting started: https://docs.venice.ai/getting-started/quick-start.md
 - VVV & DIEM (stake for daily Venice credit): https://docs.venice.ai/overview/vvv-diem.md
 - AI agents (apps, coding tools, agent tooling, SDKs, and frameworks): https://docs.venice.ai/guides/integrations/ai-agents.md
 - Crypto RPC for agents: https://docs.venice.ai/guides/integrations/crypto-rpc-agents.md

--- a/claude.md
+++ b/claude.md
@@ -32,7 +32,7 @@
 
 ## Key links
 
-- Quick start: https://docs.venice.ai/overview/getting-started.md
+- Quick start: https://docs.venice.ai/getting-started/quick-start.md
 - Privacy tiers (Anonymized / Private / TEE / E2EE): https://docs.venice.ai/overview/privacy.md
 - Pricing: https://docs.venice.ai/overview/pricing.md
 - Error codes: https://docs.venice.ai/api-reference/error-codes.md

--- a/llms.txt
+++ b/llms.txt
@@ -13,13 +13,15 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Quick Start Guide](https://docs.venice.ai/getting-started/quick-start): Get your API key and make your first request in minutes
 - [API Key Generation](https://docs.venice.ai/guides/getting-started/generating-api-key): Step-by-step guide to creating API keys
 - [About Venice](https://docs.venice.ai/overview/about-venice): Overview of Venice's capabilities and OpenAI compatibility
+- [OpenAI Migration](https://docs.venice.ai/guides/getting-started/openai-migration): Migrate from OpenAI to Venice
+- [Postman Collection](https://docs.venice.ai/guides/getting-started/postman): Import ready-to-use API examples
 
 ## API Reference
 
 ### Text & Chat
 - [API Specification](https://docs.venice.ai/api-reference/api-spec): Complete API specification with Venice-specific parameters
 - [Chat Completions](https://docs.venice.ai/api-reference/endpoint/chat/completions): Text generation endpoint with streaming, vision, audio input, video input, and tool calling
-- [Responses API (Alpha)](https://docs.venice.ai/api-reference/api-spec): OpenAI-compatible `POST /responses` endpoint with typed output blocks for reasoning, messages, function calls, and web search. Stateless, supports streaming via SSE, API key or x402 wallet auth. E2EE models not supported — use `/chat/completions` instead.
+- [Responses API (Alpha)](https://docs.venice.ai/api-reference/api-spec): OpenAI-compatible `POST /responses` endpoint with typed output blocks for reasoning, messages, function calls, and web search. Stateless, supports streaming via SSE, API key or x402 wallet auth. E2EE models not supported — use `/chat/completions` instead
 - [Model Feature Suffixes](https://docs.venice.ai/api-reference/endpoint/chat/model_feature_suffix): Enable features via model name suffixes (e.g., `model-name:web` for web search)
 
 ### Image
@@ -51,7 +53,7 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Web Scrape](https://docs.venice.ai/api-reference/endpoint/augment/scrape): Scrape a web page and return its content as markdown ($0.01/request)
 - [Web Search](https://docs.venice.ai/api-reference/endpoint/augment/search): Search the web with privacy-preserving providers — Brave (ZDR, zero data retention) or Google (proxied through Venice so your identity is not associated with the search) ($0.01/request)
 - [Crypto Networks](https://docs.venice.ai/api-reference/endpoint/crypto/networks): List all supported blockchain networks (public endpoint, no auth required)
-- [Crypto RPC](https://docs.venice.ai/api-reference/endpoint/crypto/rpc): **Venice provides blockchain RPC access** — send JSON-RPC requests to Ethereum, Base, Arbitrum, Optimism, Polygon, Linea, Avalanche, BSC, Blast, zkSync Era, Starknet, Solana, and Robinhood Chain (mainnet + testnets). One API key, unified billing in Venice credits. Supports batch requests (up to 100), idempotent retries, and x402 wallet auth. No separate RPC provider signup needed.
+- [Crypto RPC](https://docs.venice.ai/api-reference/endpoint/crypto/rpc): **Venice provides blockchain RPC access** — send JSON-RPC requests to Ethereum, Base, Arbitrum, Optimism, Polygon, Linea, Avalanche, BSC, Blast, zkSync Era, Starknet, Solana, and Robinhood Chain (mainnet + testnets). One API key, unified billing in Venice credits. Supports batch requests (up to 100), idempotent retries, and x402 wallet auth. No separate RPC provider signup needed
 - [Crypto RPC Postman Collection](https://www.postman.com/veniceai/workspace/venice-ai-workspace/folder/38652128-2cf5a817-41cd-438b-ad37-5d07c3f13005?action=share&creator=48156591&active-environment=38652128-ef110f4e-d3e1-43b5-8029-4d6877e62041): 27 ready-to-run examples for crypto RPC calls
 
 ### Embeddings
@@ -104,6 +106,38 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 
 ## Guides
 
+### Text & Chat
+- [Structured Responses](https://docs.venice.ai/guides/features/structured-responses): Get JSON responses with guaranteed schemas using `response_format`
+- [Reasoning Models](https://docs.venice.ai/guides/features/reasoning-models): Use models with step-by-step reasoning (supports `reasoning_effort` parameter)
+- [Function Calling](https://docs.venice.ai/guides/features/function-calling): Let Venice chat models call your tools with OpenAI-compatible function calling
+- [Building a Tool-Using Agent with Function Calling](https://docs.venice.ai/guides/features/tool-using-agent): Run the full tool-calling loop against a database the model has never seen, including parallel calls, errors it recovers from, and guards it cannot talk past
+- [Characters](https://docs.venice.ai/guides/features/characters): Discover public Venice characters and chat with their personas via chat completions
+- [Vision](https://docs.venice.ai/guides/features/vision): Analyze images with Venice vision models using multimodal content in chat completions
+- [File Inputs](https://docs.venice.ai/guides/features/file-inputs): Attach PDF, Office, text, data, and source-code files directly to chat completions — Venice extracts them to text before inference
+- [Prompt Caching](https://docs.venice.ai/guides/features/prompt-caching): Reduce latency and costs with prompt caching
+- [TEE & E2EE Models](https://docs.venice.ai/guides/features/tee-e2ee-models): Privacy-enhanced AI with Trusted Execution Environments (TEE) and End-to-End Encryption (E2EE)
+
+### Image
+- [Image Generation Guide](https://docs.venice.ai/guides/media/image-generation): Best practices for image generation
+- [Prompt Enhancement](https://docs.venice.ai/guides/media/prompt-enhancement): Rewrite image prompts automatically with Venice's enhance_prompt parameter
+- [Image Editing Guide](https://docs.venice.ai/guides/media/image-editing): Image editing and inpainting techniques
+- [Image Upscaling](https://docs.venice.ai/guides/media/image-upscaling): Enhance and upscale images with Venice's synchronous /image/upscale endpoint
+
+### Video
+- [Video Generation Guide](https://docs.venice.ai/guides/media/video-generation): Video generation best practices
+- [Seedance 2.0 & 2.5](https://docs.venice.ai/guides/media/seedance-2-0): Generate, edit, extend, and stitch videos with Seedance 2.0 and 2.5 on Venice
+- [Seedance Face-Media Consent](https://docs.venice.ai/guides/media/seedance-face-consent): Submit face-bearing media to Seedance 2.0 with the two-call attestation flow
+- [Reference to Video](https://docs.venice.ai/guides/media/reference-to-video): Lock in characters, objects, and scenes across AI video generations using reference images on Kling O3 and Grok Imagine R2V
+- [Video Upscaling](https://docs.venice.ai/guides/media/video-upscaling): Enhance existing videos to higher resolution (2x/4x) or quality using the Topaz Video Upscale model
+
+### Audio
+- [Text-to-Speech](https://docs.venice.ai/guides/media/text-to-speech): Generate spoken audio from text with Venice text-to-speech models and /audio/speech
+- [Narrating Articles with Text-to-Speech](https://docs.venice.ai/guides/media/article-narration): Chunk long text past the 4096-character cap, synthesize it, and join the pieces into one narrated audio file
+- [Speech-to-Text](https://docs.venice.ai/guides/media/speech-to-text): Transcribe audio to text with Venice speech-to-text models and /audio/transcriptions
+- [Meeting Notes with Speech to Text](https://docs.venice.ai/guides/media/meeting-notes): Transcribe a recording with segment timings, extract decisions and owners against a schema, and work around the absence of speaker labels
+- [Voice Cloning](https://docs.venice.ai/guides/media/voice-cloning): Clone a voice from a short reference sample with Chatterbox HD, then generate speech with Venice text-to-speech
+- [Music & Sound Effects](https://docs.venice.ai/guides/media/music-and-sound-effects): Generate music and sound effects with Venice's asynchronous audio API
+
 ### Search & RAG
 - [Embeddings](https://docs.venice.ai/guides/features/embeddings): Generate vector embeddings for semantic search, retrieval-augmented generation, clustering, and recommendations
 - [Document Processing](https://docs.venice.ai/guides/tools/document-processing): Extract text and token counts from documents for prompts, embeddings, and retrieval pipelines
@@ -111,42 +145,45 @@ Venice offers four tiers of privacy: **Anonymized** (third-party models with ide
 - [Cited Answers with Web Search](https://docs.venice.ai/guides/tools/cited-web-answers): Chain web search, source selection, scraping, and chat completions into answers where every claim resolves to a source URL
 - [Extracting Structured Data from Documents](https://docs.venice.ai/guides/tools/document-extraction): Parse a PDF with text-parser, pin the fields to a JSON schema, and fall back to a vision model when the file is a scan with no extractable text
 
-- [Structured Responses](https://docs.venice.ai/guides/features/structured-responses): Get JSON responses with guaranteed schemas using `response_format`
-- [Reasoning Models](https://docs.venice.ai/guides/features/reasoning-models): Use models with step-by-step reasoning (supports `reasoning_effort` parameter)
-- [Building a Tool-Using Agent with Function Calling](https://docs.venice.ai/guides/features/tool-using-agent): Run the full tool-calling loop against a database the model has never seen, including parallel calls, errors it recovers from, and guards it cannot talk past
-- [File Inputs](https://docs.venice.ai/guides/features/file-inputs): Attach PDF, Office, text, data, and source-code files directly to chat completions — Venice extracts them to text before inference
-- [TEE & E2EE Models](https://docs.venice.ai/guides/features/tee-e2ee-models): Privacy-enhanced AI with Trusted Execution Environments (TEE) and End-to-End Encryption (E2EE)
-- [Prompt Caching](https://docs.venice.ai/guides/features/prompt-caching): Reduce latency and costs with prompt caching
-- [Image Generation Guide](https://docs.venice.ai/guides/media/image-generation): Best practices for image generation
-- [Image Editing Guide](https://docs.venice.ai/guides/media/image-editing): Image editing and inpainting techniques
-- [Video Generation Guide](https://docs.venice.ai/guides/media/video-generation): Video generation best practices
-- [Reference to Video](https://docs.venice.ai/guides/media/reference-to-video): Lock in characters, objects, and scenes across AI video generations using reference images on Kling O3 and Grok Imagine R2V
-- [Voice Cloning](https://docs.venice.ai/guides/media/voice-cloning): Clone a voice from a short reference sample with Chatterbox HD, then generate speech with Venice text-to-speech
-- [Narrating Articles with Text-to-Speech](https://docs.venice.ai/guides/media/article-narration): Chunk long text past the 4096-character cap, synthesize it, and join the pieces into one narrated audio file
-- [Meeting Notes with Speech to Text](https://docs.venice.ai/guides/media/meeting-notes): Transcribe a recording with segment timings, extract decisions and owners against a schema, and work around the absence of speaker labels
-- [Video Upscaling](https://docs.venice.ai/guides/media/video-upscaling): Enhance existing videos to higher resolution (2x/4x) or quality using the Topaz Video Upscale model
-- [x402 Wallet API](https://docs.venice.ai/guides/integrations/x402-venice-api): Use Venice API with Ethereum wallet authentication (no API key required)
+### Agents & Integrations
 - [AI Agents](https://docs.venice.ai/guides/integrations/ai-agents): Choose an agent app, coding tool, Venice agent tool, SDK, or framework
 - [Autonomous Agent API Key Creation](https://docs.venice.ai/guides/integrations/generating-api-key-agent): Let agents programmatically mint their own Venice API key by staking VVV on Base — no human interaction required
-- [Crypto RPC for Agents](https://docs.venice.ai/guides/integrations/crypto-rpc-agents): Give AI agents inference and on-chain access through a single Venice credential. Covers JSON-RPC across 11 chains, x402 wallet auth, autonomous VVV staking, and DIEM-funded credits
-- [Venice MCP Server](https://docs.venice.ai/guides/integrations/venice-mcp): Official Model Context Protocol server exposing the full Venice API as 31 tools for Claude Desktop, Cursor, LM Studio, and any MCP host
-- [Venice Skills](https://docs.venice.ai/guides/integrations/venice-skills): Official Agent Skills that load Venice API knowledge into Claude Code, Cursor, Codex, OpenCode, Hermes, and Cline
-- [Venice Video Harness](https://docs.venice.ai/guides/integrations/venice-video-harness): Agent-first toolkit for consistency-first AI video creation across 50+ Venice video, image, audio, and music models
-- [LangChain](https://docs.venice.ai/guides/integrations/langchain): Use Venice with LangChain
-- [LlamaIndex](https://docs.venice.ai/guides/integrations/llamaindex): Build RAG pipelines, agents, and query engines with Venice models via LlamaIndex's OpenAILike client
-- [Vercel AI SDK](https://docs.venice.ai/guides/integrations/vercel-ai-sdk): Use Venice with Vercel AI SDK
-- [CrewAI](https://docs.venice.ai/guides/integrations/crewai): Use Venice with CrewAI
-- [OpenAI Migration](https://docs.venice.ai/guides/getting-started/openai-migration): Migrate from OpenAI to Venice
-- [Claude Code](https://docs.venice.ai/guides/integrations/claude-code): Use Venice with Claude Code CLI
-- [Cursor IDE](https://docs.venice.ai/guides/integrations/cursor): Use Venice with Cursor IDE
-- [Codex CLI](https://docs.venice.ai/guides/integrations/codex-cli): Use Venice with OpenAI Codex CLI
 - [OpenClaw](https://docs.venice.ai/guides/integrations/openclaw-bot): Self-hosted AI gateway connecting Venice to WhatsApp, Telegram, Discord, iMessage, and Slack
 - [Hermes Agent](https://docs.venice.ai/guides/integrations/hermes-agent): Self-improving AI agent by Nous Research with persistent memory, skills, and 15+ messaging platforms, powered by Venice as a custom provider
 - [NanoClaw](https://docs.venice.ai/guides/integrations/nanoclaw-venice): Lightweight self-hosted personal AI assistant for WhatsApp and Telegram powered by Venice
-- [Postman Collection](https://docs.venice.ai/guides/getting-started/postman): Import ready-to-use API examples
+- [Crypto RPC for Agents](https://docs.venice.ai/guides/integrations/crypto-rpc-agents): Give AI agents inference and on-chain access through a single Venice credential. Covers JSON-RPC across 11 chains, x402 wallet auth, autonomous VVV staking, and DIEM-funded credits
+- [x402 Wallet API](https://docs.venice.ai/guides/integrations/x402-venice-api): Use Venice API with Ethereum wallet authentication (no API key required)
+- [Jan AI](https://docs.venice.ai/guides/integrations/jan-ai): Configure Jan AI to use Venice models as a remote provider for private chat
+- [Brave Leo](https://docs.venice.ai/guides/integrations/brave-leo): Connect Brave Leo to Venice for private, browser-native AI chat and page summaries
 
-## Projects
+### Coding Tools
+- [Claude Code](https://docs.venice.ai/guides/integrations/claude-code): Use Venice with Claude Code CLI
+- [Cursor IDE](https://docs.venice.ai/guides/integrations/cursor): Use Venice with Cursor IDE
+- [Cline](https://docs.venice.ai/guides/integrations/cline): Configure the Cline coding assistant in VS Code to use private Venice models
+- [Kilo Code](https://docs.venice.ai/guides/integrations/kilo-code): Configure Kilo Code's native Venice provider in VS Code or the CLI for agentic coding
+- [OpenCode](https://docs.venice.ai/guides/integrations/opencode): Wire OpenCode to Venice so your coding agent runs on private models with one config file
+- [Codex CLI](https://docs.venice.ai/guides/integrations/codex-cli): Use Venice with OpenAI Codex CLI
+- [Aider](https://docs.venice.ai/guides/integrations/aider): Configure Aider for terminal pair-programming with private Venice chat models
 
+### Agent Tooling
+- [Venice CLI](https://docs.venice.ai/guides/integrations/venice-cli): Official Venice command-line tool for chat, search, images, speech, and video
+- [Venice MCP Server](https://docs.venice.ai/guides/integrations/venice-mcp): Official Model Context Protocol server exposing the full Venice API as 31 tools for Claude Desktop, Cursor, LM Studio, and any MCP host
+- [Venice Skills](https://docs.venice.ai/guides/integrations/venice-skills): Official Agent Skills that load Venice API knowledge into Claude Code, Cursor, Codex, OpenCode, Hermes, and Cline
+- [Venice Video Harness](https://docs.venice.ai/guides/integrations/venice-video-harness): Agent-first toolkit for consistency-first AI video creation across 50+ Venice video, image, audio, and music models
+
+### SDKs & Frameworks
+- [LangChain](https://docs.venice.ai/guides/integrations/langchain): Use Venice with LangChain
+- [LlamaIndex](https://docs.venice.ai/guides/integrations/llamaindex): Build RAG pipelines, agents, and query engines with Venice models via LlamaIndex's OpenAILike client
+- [Vercel AI SDK](https://docs.venice.ai/guides/integrations/vercel-ai-sdk): Use Venice with Vercel AI SDK
+- [Mastra](https://docs.venice.ai/guides/integrations/mastra): Build TypeScript agents and workflows with Mastra using Venice as the provider
+- [CrewAI](https://docs.venice.ai/guides/integrations/crewai): Use Venice with CrewAI
+- [PydanticAI](https://docs.venice.ai/guides/integrations/pydanticai): Build typed Python agents with PydanticAI using Venice chat models
+- [LiveKit Agents](https://docs.venice.ai/guides/integrations/livekit-agents): Build realtime voice agents with LiveKit using Venice STT, LLM, and TTS
+- [Rig](https://docs.venice.ai/guides/integrations/rig): Build typed Rust agents with Rig's native Venice provider for tools and streaming
+
+## Learn
+
+- [Learn](https://docs.venice.ai/learn): Complete, runnable projects built on the Venice API, from short walkthroughs to full repositories
 - [Building a Private RAG Bot](https://docs.venice.ai/learn/private-rag-bot): Modern private RAG with Venice embeddings, Qdrant vector search, FastEmbed re-ranking, and Venice chat completions
 - [Building a Private Research Agent](https://docs.venice.ai/learn/private-research-agent): Python research agent that plans searches, reads sources with Venice's scrape API, extracts evidence, and writes cited Markdown reports
 - [Building a Codebase Security Reviewer](https://docs.venice.ai/learn/security-code-reviewer): Python security agent that finds vulnerabilities and chains them into exploit paths using Venice, an AST repo map, and Pydantic guardrails

--- a/skill.md
+++ b/skill.md
@@ -191,7 +191,7 @@ ln -s ~/src/venice-skills/skills ~/.claude/skills/venice
 ## Reference
 
 - Agent guide: https://docs.venice.ai/agents.md
-- Getting started: https://docs.venice.ai/overview/getting-started.md
+- Getting started: https://docs.venice.ai/getting-started/quick-start.md
 - Privacy tiers: https://docs.venice.ai/overview/privacy.md
 - Pricing: https://docs.venice.ai/overview/pricing.md
 - Rate limiting: https://docs.venice.ai/api-reference/rate-limiting.md


### PR DESCRIPTION
`llms.txt` is how agents discover what the docs contain, and it had drifted from the navigation. This resyncs it, plus the smaller index files around it.

## What was wrong

**22 English pages were missing from `llms.txt`.** Not just the recent tutorials: function calling, vision, characters, file inputs, both speech guides, and fourteen integrations including the MCP server, the CLI, and Skills. An agent reading the index would conclude Venice has no function calling docs.

**The Guides section had one subsection for everything.** All 60-odd guides sat under a heading reading `Search & RAG`, which described maybe five of them.

**A section was still called Projects** after those pages moved to `/learn`.

**`guides/media/seedance-face-consent` is orphaned.** It is not in the nav, nothing links to it, and it was not in `llms.txt`, so the only way to reach it is to already know the URL. It is a compliance page describing the attestation flow for face-bearing media. I have indexed it here, but it still needs a home in the nav, which is a call I did not want to make unilaterally.

**`agents.md`, `claude.md`, and `skill.md` pointed at `/overview/getting-started`**, which has redirected to `/getting-started/quick-start` for a while. Every agent following it paid a redirect. In `agents.md` it was also the worked example for "append `.md` to any docs URL", so the one link teaching the trick was the one that did not resolve cleanly.

**The README** listed tabs that no longer exist (`Welcome`, `Guides`), told contributors the repo has no PR previews when Mintlify has been deploying them on every PR, and pointed at `mint.json` instead of `docs.json`.

## What changed

The Guides section is now generated from the nav groups in `docs.json`, so it lists the same nine categories in the same order: Text & Chat, Image, Video, Audio, Search & RAG, Agents & Integrations, Coding Tools, Agent Tooling, SDKs & Frameworks. Hand-written descriptions are preserved; new entries take their description from the page frontmatter. Trailing periods were normalized away, since the file was inconsistent about them.

## Verification

- All 82 English pages are indexed, each exactly once.
- Every `docs.venice.ai` link across `llms.txt`, `agents.md`, `claude.md`, `skill.md`, and both READMEs resolves to a file on disk, and every relative link in `notebooks/README.md` resolves. No broken links.
- Every nav entry in `docs.json` still has a file behind it.
- `python notebooks/build.py --check` reports the notebooks up to date.

No page content changed, so nothing here needs translating.