### PR TITLE
docs: display free models as Free instead of $0.00

### DIFF
--- a/model-search.js
+++ b/model-search.js
@@ -596,7 +596,7 @@
     const price = await fetchVideoQuote(modelId, model, { resolution, duration, audio });
     
     if (price !== null) {
-      priceEl.textContent = formatPrice(price);
+      priceEl.textContent = price === 0 ? FREE_LABEL : formatPrice(price);
     } else {
       priceEl.textContent = 'Variable';
     }
@@ -1042,6 +1042,30 @@
     return model.model_spec?.betaModel === true;
   }
 
+  // Walks a pricing object and collects every USD amount it declares, at any depth
+  // (resolutions, durations, extended context tiers, upscale factors, etc.).
+  function collectPricingUsd(node, values) {
+    if (!node || typeof node !== 'object') return values;
+    if (typeof node.usd === 'number') values.push(node.usd);
+    Object.values(node).forEach(child => collectPricingUsd(child, values));
+    return values;
+  }
+
+  function isFreeModel(model) {
+    const values = collectPricingUsd(model?.model_spec?.pricing, []);
+    return values.length > 0 && values.every(usd => usd === 0);
+  }
+
+  const FREE_LABEL = 'Free';
+
+  function formatModelPrice(model, price) {
+    return isFreeModel(model) ? FREE_LABEL : formatPrice(price);
+  }
+
+  function freePriceItem() {
+    return `<span class="vpt-price-item"><span class="vpt-price-label">Price</span><span class="vpt-price-value">${FREE_LABEL}</span></span>`;
+  }
+
   function isDeprecatedModel(model) {
     const dep = model.model_spec?.deprecation;
     return dep != null && (dep.date != null || dep.removesAt != null);
@@ -1140,6 +1164,7 @@
       const pricing = spec.pricing || {};
       const name = escapeHtml(spec.name || model.id);
       const modelId = escapeHtml(model.id);
+      const isFree = isFreeModel(model);
       const inputPrice = formatPrice(pricing.input?.usd);
       const outputPrice = formatPrice(pricing.output?.usd);
       const cacheReadStr = pricing.cache_input?.usd ? formatPrice(pricing.cache_input.usd) : null;
@@ -1152,19 +1177,22 @@
       const moderationTag = hasContentModeration(model.id) ? `<span class="vpt-badge vpt-moderation vpt-tooltip" data-tooltip="${TOOLTIPS.content_moderation}">Moderated</span>` : '';
       const privacyTag = getPrivacyTag(model, 'vpt');
 
-      let priceItems = `
-        <span class="vpt-price-item"><span class="vpt-price-label">Input Price</span><span class="vpt-price-value">${inputPrice}</span></span>
-        <span class="vpt-price-item"><span class="vpt-price-label">Output Price</span><span class="vpt-price-value">${outputPrice}</span></span>
-      `;
-      if (cacheReadStr) {
-        priceItems += `<span class="vpt-price-item vpt-tooltip" data-tooltip="Discounted rate for cached input tokens."><span class="vpt-price-label">Cache Read</span><span class="vpt-price-value">${cacheReadStr}</span></span>`;
-      }
-      if (cacheWriteStr) {
-        priceItems += `<span class="vpt-price-item vpt-tooltip" data-tooltip="Cost to write tokens to cache."><span class="vpt-price-label">Cache Write</span><span class="vpt-price-value">${cacheWriteStr}</span></span>`;
+      let priceItems = freePriceItem();
+      if (!isFree) {
+        priceItems = `
+          <span class="vpt-price-item"><span class="vpt-price-label">Input Price</span><span class="vpt-price-value">${inputPrice}</span></span>
+          <span class="vpt-price-item"><span class="vpt-price-label">Output Price</span><span class="vpt-price-value">${outputPrice}</span></span>
+        `;
+        if (cacheReadStr) {
+          priceItems += `<span class="vpt-price-item vpt-tooltip" data-tooltip="Discounted rate for cached input tokens."><span class="vpt-price-label">Cache Read</span><span class="vpt-price-value">${cacheReadStr}</span></span>`;
+        }
+        if (cacheWriteStr) {
+          priceItems += `<span class="vpt-price-item vpt-tooltip" data-tooltip="Cost to write tokens to cache."><span class="vpt-price-label">Cache Write</span><span class="vpt-price-value">${cacheWriteStr}</span></span>`;
+        }
       }
 
       let extendedLine = '';
-      if (pricing.extended) {
+      if (pricing.extended && !isFree) {
         const ext = pricing.extended;
         const thresholdStr = ext.context_token_threshold >= 1000 ? `${Math.round(ext.context_token_threshold / 1000)}K` : ext.context_token_threshold;
         extendedLine = `<div class="vpt-extended-line vpt-tooltip" data-tooltip="This model uses higher rates when your prompt exceeds ${thresholdStr} tokens.">&gt;${thresholdStr} context: ${formatPrice(ext.input?.usd)}/M input · ${formatPrice(ext.output?.usd)}/M output`;
@@ -1215,7 +1243,7 @@
           <div class="vpt-row-right">${privacyTag}</div>
         </div>
         <div class="vpt-row-bottom">
-          <span class="vpt-price-item"><span class="vpt-price-label">Per 1M tokens</span><span class="vpt-price-value">${formatPrice(pricing.input?.usd)}</span></span>
+          ${isFreeModel(model) ? freePriceItem() : `<span class="vpt-price-item"><span class="vpt-price-label">Per 1M tokens</span><span class="vpt-price-value">${formatPrice(pricing.input?.usd)}</span></span>`}
         </div>
       </div>`;
     }).join('');
@@ -1257,7 +1285,9 @@
       const defaultRes = spec.constraints?.defaultResolution;
       
       let priceItems = '';
-      if (resPricing) {
+      if (isFreeModel(model)) {
+        priceItems = freePriceItem();
+      } else if (resPricing) {
         // Show each resolution price separately
         const resKeys = Object.keys(resPricing);
         priceItems = resKeys.map(res => 
@@ -1319,6 +1349,10 @@
       const editPrice = spec.pricing?.inpaint?.usd ?? spec.pricing?.generation?.usd ?? 0.04;
       const extraInputUsd = spec.pricing?.inputImages?.additional?.usd;
       const moderationTag = hasContentModeration(model.id) ? `<span class="vpt-badge vpt-moderation vpt-tooltip" data-tooltip="${TOOLTIPS.content_moderation}">Moderated</span>` : '';
+      const priceItems = isFreeModel(model)
+        ? freePriceItem()
+        : `<span class="vpt-price-item"><span class="vpt-price-label">Per Edit</span><span class="vpt-price-value">${formatPrice(editPrice)}</span></span>
+          ${extraInputUsd ? `<span class="vpt-price-item vpt-tooltip" data-tooltip="Charged per input image beyond the first, added on top of the per-edit price."><span class="vpt-price-label">Extra Input Image</span><span class="vpt-price-value">${formatPrice(extraInputUsd)}</span></span>` : ''}`;
 
       return `<div class="vpt-row">
         <div class="vpt-row-top">
@@ -1329,8 +1363,7 @@
           <div class="vpt-row-right">${moderationTag}</div>
         </div>
         <div class="vpt-row-bottom">
-          <span class="vpt-price-item"><span class="vpt-price-label">Per Edit</span><span class="vpt-price-value">${formatPrice(editPrice)}</span></span>
-          ${extraInputUsd ? `<span class="vpt-price-item vpt-tooltip" data-tooltip="Charged per input image beyond the first, added on top of the per-edit price."><span class="vpt-price-label">Extra Input Image</span><span class="vpt-price-value">${formatPrice(extraInputUsd)}</span></span>` : ''}
+          ${priceItems}
         </div>
       </div>`;
     }).join('');
@@ -1357,7 +1390,7 @@
           <div class="vpt-row-right">${privacyTag}</div>
         </div>
         <div class="vpt-row-bottom">
-          <span class="vpt-price-item"><span class="vpt-price-label">Per 1M Characters</span><span class="vpt-price-value">${formatPrice(spec.pricing?.input?.usd)}</span></span>
+          ${isFreeModel(model) ? freePriceItem() : `<span class="vpt-price-item"><span class="vpt-price-label">Per 1M Characters</span><span class="vpt-price-value">${formatPrice(spec.pricing?.input?.usd)}</span></span>`}
         </div>
       </div>`;
     }).join('');
@@ -1376,6 +1409,9 @@
       const name = escapeHtml(spec.name || model.id);
       const price = pricing.per_audio_second?.usd ? formatPrice(pricing.per_audio_second.usd) : formatPrice(pricing.input?.usd);
       const privacyTag = getPrivacyTag(model, 'vpt');
+      const priceItem = isFreeModel(model)
+        ? freePriceItem()
+        : `<span class="vpt-price-item"><span class="vpt-price-label">Per Audio Second</span><span class="vpt-price-value">${price}</span></span>`;
 
       return `<div class="vpt-row">
         <div class="vpt-row-top">
@@ -1386,7 +1422,7 @@
           <div class="vpt-row-right">${privacyTag}</div>
         </div>
         <div class="vpt-row-bottom">
-          <span class="vpt-price-item"><span class="vpt-price-label">Per Audio Second</span><span class="vpt-price-value">${price}</span></span>
+          ${priceItem}
         </div>
       </div>`;
     }).join('');
@@ -1411,12 +1447,14 @@
       const modelId = escapeHtml(model.id);
       const name = escapeHtml(spec.name || model.id);
       const privacyTag = getPrivacyTag(model, 'vpt');
-      const durationPricing = Object.entries(spec.pricing?.durations || {})
-        .sort(([a], [b]) => Number(a) - Number(b))
-        .map(([duration, price]) =>
-          `<span class="vpt-price-item"><span class="vpt-price-label">${duration}s</span><span class="vpt-price-value">${formatPrice(price?.usd)}</span></span>`
-        )
-        .join('');
+      const durationPricing = isFreeModel(model)
+        ? freePriceItem()
+        : Object.entries(spec.pricing?.durations || {})
+            .sort(([a], [b]) => Number(a) - Number(b))
+            .map(([duration, price]) =>
+              `<span class="vpt-price-item"><span class="vpt-price-label">${duration}s</span><span class="vpt-price-value">${formatPrice(price?.usd)}</span></span>`
+            )
+            .join('');
 
       return `<div class="vpt-row">
         <div class="vpt-row-top">
@@ -1454,7 +1492,7 @@
           <div class="vpt-row-right">${privacyTag}</div>
         </div>
         <div class="vpt-row-bottom">
-          <span class="vpt-price-item"><span class="vpt-price-label">Per Generation</span><span class="vpt-price-value">${formatPrice(spec.pricing?.generation?.usd)}</span></span>
+          ${isFreeModel(model) ? freePriceItem() : `<span class="vpt-price-item"><span class="vpt-price-label">Per Generation</span><span class="vpt-price-value">${formatPrice(spec.pricing?.generation?.usd)}</span></span>`}
         </div>
       </div>`;
     }).join('');
@@ -1481,7 +1519,7 @@
           <div class="vpt-row-right">${privacyTag}</div>
         </div>
         <div class="vpt-row-bottom">
-          <span class="vpt-price-item"><span class="vpt-price-label">Per Second</span><span class="vpt-price-value">${formatPrice(spec.pricing?.per_second?.usd)}</span></span>
+          ${isFreeModel(model) ? freePriceItem() : `<span class="vpt-price-item"><span class="vpt-price-label">Per Second</span><span class="vpt-price-value">${formatPrice(spec.pricing?.per_second?.usd)}</span></span>`}
         </div>
       </div>`;
     }).join('');
@@ -1647,8 +1685,8 @@
       .filter(m => m.type === 'text' && m.model_spec?.pricing?.cache_input)
       .filter(m => !isDeprecatedModel(m))
       .sort((a, b) => {
-        const pA = a.model_spec?.pricing?.input?.usd || 999;
-        const pB = b.model_spec?.pricing?.input?.usd || 999;
+        const pA = a.model_spec?.pricing?.input?.usd ?? 999;
+        const pB = b.model_spec?.pricing?.input?.usd ?? 999;
         return pB - pA; // Sort by input price descending (premium models first)
       });
 
@@ -1665,10 +1703,10 @@
 
       return `<tr>
         <td><code>${modelId}</code>${pricingCopyBtn(modelId)}</td>
-        <td class="vpt-price">${formatPrice(input)}</td>
-        <td class="vpt-price">${formatPrice(cacheRead)}</td>
-        <td class="vpt-price">${cacheWrite ? formatPrice(cacheWrite) : '—'}</td>
-        <td class="vpt-price">${formatPrice(output)}</td>
+        <td class="vpt-price">${formatModelPrice(model, input)}</td>
+        <td class="vpt-price">${formatModelPrice(model, cacheRead)}</td>
+        <td class="vpt-price">${cacheWrite != null ? formatModelPrice(model, cacheWrite) : '—'}</td>
+        <td class="vpt-price">${formatModelPrice(model, output)}</td>
         <td>${discount ? discount + '%' : '—'}</td>
       </tr>`;
     }).join('');
@@ -1845,8 +1883,8 @@
     const betaModels = models
       .filter(isBetaModel)
       .sort((a, b) => {
-        const pA = a.model_spec?.pricing?.input?.usd || a.model_spec?.pricing?.generation?.usd || 999;
-        const pB = b.model_spec?.pricing?.input?.usd || b.model_spec?.pricing?.generation?.usd || 999;
+        const pA = a.model_spec?.pricing?.input?.usd ?? a.model_spec?.pricing?.generation?.usd ?? 999;
+        const pB = b.model_spec?.pricing?.input?.usd ?? b.model_spec?.pricing?.generation?.usd ?? 999;
         return pA - pB;
       });
 
@@ -1862,9 +1900,11 @@
       const spec = model.model_spec || {};
       const pricing = spec.pricing || {};
       const modelId = escapeHtml(model.id);
-      const priceStr = pricing.input && pricing.output
-        ? `${formatPrice(pricing.input.usd)} / ${formatPrice(pricing.output.usd)}`
-        : formatPrice(pricing.generation?.usd);
+      const priceStr = isFreeModel(model)
+        ? FREE_LABEL
+        : (pricing.input && pricing.output
+          ? `${formatPrice(pricing.input.usd)} / ${formatPrice(pricing.output.usd)}`
+          : formatPrice(pricing.generation?.usd));
       return `<tr>
         <td>${escapeHtml(spec.name || model.id)}</td>
         <td><code>${modelId}</code>${pricingCopyBtn(modelId)}</td>
@@ -2024,7 +2064,9 @@
       `<span class="vtp-pill vtp-pill-id"><code>${id}</code></span>`,
       `<span class="vtp-pill">${count} voice${count === 1 ? '' : 's'}</span>`
     ];
-    if (typeof price === 'number') {
+    if (isFreeModel(model)) {
+      pills.push(`<span class="vtp-pill">${FREE_LABEL}</span>`);
+    } else if (typeof price === 'number') {
       pills.push(`<span class="vtp-pill">${formatPrice(price)} / 1M chars</span>`);
     }
     return `
@@ -2721,7 +2763,9 @@
       // Pricing display
         let priceStr = '';
         let videoControlsHtml = '';
-        if (model.type === 'video') {
+        if (isFreeModel(model) && model.type !== 'video') {
+          priceStr = FREE_LABEL;
+        } else if (model.type === 'video') {
           // Build video controls for info row
           const resolutions = model._resolutions || [];
           const durations = model._durations || [];

--- a/overview/pricing.mdx
+++ b/overview/pricing.mdx
@@ -113,7 +113,7 @@ Prices per 1M tokens unless noted. All prices in USD. 1 Diem = $1/day of compute
 | NVIDIA Nemotron 3 Nano 30B | `nvidia-nemotron-3-nano-30b-a3b` | $0.07 | $0.30 | - | - | 128K | Private |
 | NVIDIA Nemotron 3 Ultra | `nvidia-nemotron-3-ultra-550b-a55b` | $0.63 | $3.13 | $0.19 | - | 256K | Private |
 | OpenAI GPT OSS 120B | `openai-gpt-oss-120b` | $0.07 | $0.30 | - | - | 128K | Private |
-| Ox Alpha (Beta) | `stealth-ox-alpha` | $0.00 | $0.00 | - | - | 1049K | Anonymized |
+| Ox Alpha (Beta) | `stealth-ox-alpha` | Free | Free | - | - | 1049K | Anonymized |
 | Qwen 2.5 7B | `e2ee-qwen-2-5-7b-p` | $0.05 | $0.13 | - | - | 32K | E2EE · Private |
 | Qwen 3 235B A22B Instruct 2507 | `qwen3-235b-a22b-instruct-2507` | $0.15 | $0.75 | - | - | 128K | Private |
 | Qwen 3 235B A22B Thinking 2507 | `qwen3-235b-a22b-thinking-2507` | $0.45 | $3.50 | - | - | 128K | Private |

--- a/scripts/generate-pricing-static.js
+++ b/scripts/generate-pricing-static.js
@@ -31,6 +31,26 @@ function formatPrice(price) {
   return '$' + price.toFixed(2);
 }
 
+const FREE_LABEL = 'Free';
+
+// Walks a pricing object and collects every USD amount it declares, at any depth
+// (resolutions, durations, extended context tiers, upscale factors, etc.).
+function collectPricingUsd(node, values) {
+  if (!node || typeof node !== 'object') return values;
+  if (typeof node.usd === 'number') values.push(node.usd);
+  Object.values(node).forEach(child => collectPricingUsd(child, values));
+  return values;
+}
+
+function isFreeModel(model) {
+  const values = collectPricingUsd(model?.model_spec?.pricing, []);
+  return values.length > 0 && values.every(usd => usd === 0);
+}
+
+function formatModelPrice(model, price) {
+  return isFreeModel(model) ? FREE_LABEL : formatPrice(price);
+}
+
 function escapeHtml(str) {
   if (!str) return '';
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -84,8 +104,8 @@ function renderPricingChatTable(models) {
     const pricing = spec.pricing || {};
     const name = escapeHtml(spec.name || model.id) + (isBetaModel(model) ? ' (Beta)' : '');
     const modelId = '\`' + escapeHtml(model.id) + '\`';
-    const inputPrice = formatPrice(pricing.input?.usd);
-    const outputPrice = formatPrice(pricing.output?.usd);
+    const inputPrice = formatModelPrice(model, pricing.input?.usd);
+    const outputPrice = formatModelPrice(model, pricing.output?.usd);
     const cacheReadStr = pricing.cache_input?.usd ? formatPrice(pricing.cache_input.usd) : '-';
     const cacheWriteStr = pricing.cache_write?.usd ? formatPrice(pricing.cache_write.usd) : '-';
     const contextWindow = spec.availableContextTokens || spec.constraints?.maxContextTokens;
@@ -95,7 +115,7 @@ function renderPricingChatTable(models) {
     let row = `| ${name} | ${modelId} | ${inputPrice} | ${outputPrice} | ${cacheReadStr} | ${cacheWriteStr} | ${contextStr} | ${privacyTag} |`;
 
     let extendedRow = '';
-    if (pricing.extended) {
+    if (pricing.extended && !isFreeModel(model)) {
       const ext = pricing.extended;
       const thresholdStr = ext.context_token_threshold >= 1000 ? `${Math.round(ext.context_token_threshold / 1000)}K` : ext.context_token_threshold;
       extendedRow = `\n| ↳ >${thresholdStr} Context | | ${formatPrice(ext.input?.usd)} | ${formatPrice(ext.output?.usd)} | ${ext.cache_input?.usd ? formatPrice(ext.cache_input.usd) : '-'} | ${ext.cache_write?.usd ? formatPrice(ext.cache_write.usd) : '-'} | | |`;
@@ -120,7 +140,7 @@ function renderPricingEmbeddingTable(models) {
     const name = escapeHtml(spec.name || model.id);
     const privacyTag = getPrivacyLabel(model);
 
-    return `| ${name} | ${modelId} | ${formatPrice(pricing.input?.usd)} | ${formatPrice(pricing.output?.usd)} | ${privacyTag} |`;
+    return `| ${name} | ${modelId} | ${formatModelPrice(model, pricing.input?.usd)} | ${formatModelPrice(model, pricing.output?.usd)} | ${privacyTag} |`;
   }).join('\n');
 
   return header + '\n' + rows + '\n';
@@ -148,7 +168,9 @@ function renderPricingImageTable(models) {
     const resPricing = spec.pricing?.resolutions;
     
     let priceStr = '';
-    if (resPricing) {
+    if (isFreeModel(model)) {
+      priceStr = FREE_LABEL;
+    } else if (resPricing) {
       const resKeys = Object.keys(resPricing);
       priceStr = resKeys.map(res => `${res}: ${formatPrice(resPricing[res]?.usd)}`).join(', ');
     } else {
@@ -192,7 +214,7 @@ function renderPricingEditTable(models) {
     const editPrice = spec.pricing?.inpaint?.usd ?? 0.04;
     const extraInputUsd = spec.pricing?.inputImages?.additional?.usd;
 
-    return `| ${name} | ${modelId} | ${formatPrice(editPrice)} | ${formatPrice(extraInputUsd)} |`;
+    return `| ${name} | ${modelId} | ${formatModelPrice(model, editPrice)} | ${formatModelPrice(model, extraInputUsd)} |`;
   }).join('\n');
 
   return header + '\n' + rows + '\n';
@@ -210,7 +232,7 @@ function renderPricingTTSTable(models) {
     const name = escapeHtml(spec.name || model.id);
     const privacyTag = getPrivacyLabel(model);
 
-    return `| ${name} | ${modelId} | ${formatPrice(spec.pricing?.input?.usd)} | ${privacyTag} |`;
+    return `| ${name} | ${modelId} | ${formatModelPrice(model, spec.pricing?.input?.usd)} | ${privacyTag} |`;
   }).join('\n');
 
   return header + '\n' + rows + '\n';
@@ -227,7 +249,9 @@ function renderPricingASRTable(models) {
     const pricing = spec.pricing || {};
     const modelId = '\`' + escapeHtml(model.id) + '\`';
     const name = escapeHtml(spec.name || model.id);
-    const price = pricing.per_audio_second?.usd ? formatPrice(pricing.per_audio_second.usd) : formatPrice(pricing.input?.usd);
+    const price = pricing.per_audio_second?.usd
+      ? formatModelPrice(model, pricing.per_audio_second.usd)
+      : formatModelPrice(model, pricing.input?.usd);
     const privacyTag = getPrivacyLabel(model);
 
     return `| ${name} | ${modelId} | ${price} | ${privacyTag} |`;
@@ -255,10 +279,12 @@ function renderPricingMusicDurationTable(models) {
     const modelId = '\`' + escapeHtml(model.id) + '\`';
     const name = escapeHtml(spec.name || model.id);
     const privacyTag = getPrivacyLabel(model);
-    const durationPricing = Object.entries(pricing.durations || {})
-      .sort(([a], [b]) => Number(a) - Number(b))
-      .map(([duration, price]) => `${duration}s: ${formatPrice(price?.usd)}`)
-      .join(', ');
+    const durationPricing = isFreeModel(model)
+      ? FREE_LABEL
+      : Object.entries(pricing.durations || {})
+          .sort(([a], [b]) => Number(a) - Number(b))
+          .map(([duration, price]) => `${duration}s: ${formatPrice(price?.usd)}`)
+          .join(', ');
 
     return `| ${name} | ${modelId} | ${durationPricing} | ${privacyTag} |`;
   }).join('\n');
@@ -277,7 +303,7 @@ function renderPricingMusicGenerationTable(models) {
     const name = escapeHtml(spec.name || model.id);
     const privacyTag = getPrivacyLabel(model);
 
-    return `| ${name} | ${modelId} | ${formatPrice(spec.pricing?.generation?.usd)} | ${privacyTag} |`;
+    return `| ${name} | ${modelId} | ${formatModelPrice(model, spec.pricing?.generation?.usd)} | ${privacyTag} |`;
   }).join('\n');
 
   return header + '\n' + rows + '\n';
@@ -294,7 +320,7 @@ function renderPricingMusicPerSecondTable(models) {
     const name = escapeHtml(spec.name || model.id);
     const privacyTag = getPrivacyLabel(model);
 
-    return `| ${name} | ${modelId} | ${formatPrice(spec.pricing?.per_second?.usd)} | ${privacyTag} |`;
+    return `| ${name} | ${modelId} | ${formatModelPrice(model, spec.pricing?.per_second?.usd)} | ${privacyTag} |`;
   }).join('\n');
 
   return header + '\n' + rows + '\n';


### PR DESCRIPTION
## Summary

Ox Alpha (`stealth-ox-alpha`) is priced at zero for input, output, and cache reads, so every pricing surface rendered a wall of `$0.00` that reads more like missing data than a free model. It now shows **Free**.

The rule comes from the pricing data rather than a hardcoded model ID, so it covers any future free model: a shared `isFreeModel` helper walks the whole `model_spec.pricing` object and collects every `usd` amount at any depth (input, output, cache, resolutions, durations, extended-context tiers, upscale factors). A model is free only when it declares at least one price and all of them are zero. Models that declare no USD amounts at all — the quote-based video models — are untouched, so nothing flips to "Free" by accident. Against the current snapshot, Ox Alpha is the only match.

Applied in both `model-search.js` (runtime) and `scripts/generate-pricing-static.js` (pre-rendered markdown) so the static page and the live-API re-render agree. On the pricing page the Input/Output/Cache items collapse to a single "Price: Free" and the extended-context line is suppressed, since it would only repeat zeros. Also covers the model browser cards, beta models table, prompt-caching table, embeddings, image, edit, TTS, ASR, and the three music tables.

Two related fixes: the beta and cache tables sorted with `usd || 999`, so a genuinely free model was treated as the most expensive and sank to the bottom — now `??`. And the video quote handler shows "Free" if a quote ever returns 0.

In the fixed-column markdown table there's no way to merge cells, so `overview/pricing.mdx` shows "Free" in both the input and output columns; the interactive page shows the single collapsed item.

## Test plan

Verified against a local `mint dev` preview with headless Chrome, using live API data (the dev server doesn't serve `/data/static-models.json`, so the script fell back to `api.venice.ai` — a better test than the committed snapshot). All four surfaces render "Free" with no `$0.00`, and 111 chat rows / 113 model cards rendered, so nothing else regressed.

- [x] `/overview/pricing` — `Ox Alpha BETA · PRICE Free · CONTEXT 1049K`
- [x] `/models/text` — `stealth-ox-alpha · Free`
- [x] `/overview/beta-models` — `Ox Alpha stealth-ox-alpha Free`, now sorted first
- [x] `/guides/features/prompt-caching` — `stealth-ox-alpha Free Free — Free —`
- [x] `node scripts/generate-pricing-static.js` is idempotent; the only diff is the Ox Alpha row

Note: the Mintlify version pinned in `node_modules` cannot build this repo at all (fails with "Unable to parse page metadata" across the localized API reference pages). That is pre-existing on `main` and unrelated to this change; testing used `npx mint@latest dev`.

Made with [Cursor](https://cursor.com)