### PR TITLE
Bake model catalogs into the markdown export

### DIFF
--- a/.github/workflows/sync-static-models.yml
+++ b/.github/workflows/sync-static-models.yml
@@ -42,7 +42,15 @@ jobs:
             overview/pricing.mdx \
             overview/about-venice.mdx \
             overview/deprecations.mdx \
-            api-reference/endpoint/models/traits.mdx; then
+            api-reference/endpoint/models/traits.mdx \
+            models/overview.mdx \
+            models/text.mdx \
+            models/image.mdx \
+            models/video.mdx \
+            models/text-to-speech.mdx \
+            models/speech-to-text.mdx \
+            models/music.mdx \
+            models/embeddings.mdx; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -57,7 +65,15 @@ jobs:
             overview/pricing.mdx \
             overview/about-venice.mdx \
             overview/deprecations.mdx \
-            api-reference/endpoint/models/traits.mdx
+            api-reference/endpoint/models/traits.mdx \
+            models/overview.mdx \
+            models/text.mdx \
+            models/image.mdx \
+            models/video.mdx \
+            models/text-to-speech.mdx \
+            models/speech-to-text.mdx \
+            models/music.mdx \
+            models/embeddings.mdx
           git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
             commit -m "chore: sync static model snapshot"
 

--- a/api-reference/endpoint/models/traits.mdx
+++ b/api-reference/endpoint/models/traits.mdx
@@ -8,10 +8,12 @@ openapi: 'GET /models/traits'
 ## Postman Collection
 For additional examples, please see this [Postman Collection](https://www.postman.com/veniceai/workspace/venice-ai-workspace/folder/38652128-59dfa959-7038-4cd8-b8ba-80cf09f2f026?action=share&source=copy-link&creator=38652128&ctx=documentation).
 
-{/* AUTO-GENERATED:API-TRAITS:START */}
 ## Current text trait mappings
 
 These mappings are refreshed automatically from the public API.
+
+<div id="traits-list-placeholder">
+{/* AUTO-GENERATED:API-TRAITS:START */}
 
 - `default` → currently routes to `zai-org-glm-5-2`
 - `function_calling_default` → currently routes to `zai-org-glm-5-2`
@@ -20,6 +22,8 @@ These mappings are refreshed automatically from the public API.
 - `default_code` → currently routes to `deepseek-v4-pro-0813`
 - `most_uncensored` → currently routes to `venice-uncensored-1-2`
 - `most_intelligent` → currently routes to `grok-4-6`
+
 {/* AUTO-GENERATED:API-TRAITS:END */}
+</div>
 
 -------

--- a/model-search.js
+++ b/model-search.js
@@ -263,8 +263,11 @@
   // Static fallback data for fast first paint. Loaded from a cacheable JSON file
   // rather than inlined here, because Mintlify injects this script into every page.
   const STATIC_MODELS_URL = '/data/static-models.json';
+  const STATIC_TRAITS_URL = '/data/static-traits.json';
   let STATIC_MODELS = [];
+  let STATIC_TRAITS = null;
   let staticModelsPromise = null;
+  let staticTraitsPromise = null;
 
   // Resolves once STATIC_MODELS is populated. Falls back to the live API so the
   // tables still render if the snapshot is unavailable.
@@ -288,6 +291,28 @@
         .catch(() => STATIC_MODELS));
 
     return staticModelsPromise;
+  }
+
+  function ensureStaticTraits() {
+    if (staticTraitsPromise) return staticTraitsPromise;
+
+    staticTraitsPromise = fetch(STATIC_TRAITS_URL)
+      .then(r => {
+        if (!r.ok) throw new Error(`traits snapshot returned ${r.status}`);
+        return r.json();
+      })
+      .then(traits => {
+        if (traits && typeof traits === 'object' && !Array.isArray(traits)) STATIC_TRAITS = traits;
+        return STATIC_TRAITS;
+      })
+      .catch(() => fetchTraitsFromAPI()
+        .then(traits => {
+          if (traits) STATIC_TRAITS = traits;
+          return STATIC_TRAITS;
+        })
+        .catch(() => STATIC_TRAITS));
+
+    return staticTraitsPromise;
   }
   
   // Privacy types that are always private (no API privacy field needed)
@@ -2035,7 +2060,7 @@
       return `<li><code>${escapeHtml(label)}</code> → currently routes to <code>${escapeHtml(modelId)}</code></li>`;
     }).join('\n');
 
-    return `<ul>\n${items}\n</ul>`;
+    return `<ul class="vpt-traits-list">\n${items}\n</ul>`;
   }
 
   async function initTraitsList() {
@@ -2045,14 +2070,22 @@
     const cachedTraits = getCachedTraits();
     if (cachedTraits) {
       el.innerHTML = renderTraitsList(cachedTraits);
-    } else {
-      await ensureStaticModels();
-      el.innerHTML = renderTraitsList(getStaticTraits());
+    } else if (!el.querySelector('li')) {
+      const snapshot = await ensureStaticTraits();
+      if (!snapshot || Object.keys(snapshot).length === 0) {
+        await ensureStaticModels();
+      }
+      const fallback = snapshot && Object.keys(snapshot).length > 0
+        ? snapshot
+        : getStaticTraits();
+      if (fallback && Object.keys(fallback).length > 0) {
+        el.innerHTML = renderTraitsList(fallback);
+      }
     }
     ensurePlaceholderVisible(el);
 
     const freshTraits = await fetchTraitsFromAPI();
-    if (freshTraits) {
+    if (freshTraits && document.body.contains(el)) {
       el.innerHTML = renderTraitsList(freshTraits);
     }
   }
@@ -3314,9 +3347,17 @@
     }
   });
 
+  function hideStaleModelPlaceholders() {
+    if (!document.getElementById('venice-model-browser')) return;
+    document.querySelectorAll('#model-search-placeholder').forEach(el => {
+      el.hidden = true;
+    });
+  }
+
   function tryInitModels() {
-    if (modelsInitialized) return;
     if (!window.location.pathname.includes('/models')) return;
+    hideStaleModelPlaceholders();
+    if (modelsInitialized) return;
     const placeholder = document.getElementById('model-search-placeholder');
     if (placeholder && !document.getElementById('venice-model-browser')) {
       modelsInitialized = true;
@@ -3330,7 +3371,11 @@
     const state = pageInitializers[config.name];
 
     return function tryInit() {
-      if (!window.location.pathname.toLowerCase().includes(pathMatch)) return;
+      const path = window.location.pathname.toLowerCase();
+      const matches = Array.isArray(pathMatch)
+        ? pathMatch.some(part => path.includes(part))
+        : path.includes(pathMatch);
+      if (!matches) return;
       
       const el = document.getElementById(elementId);
       if (!el) return;
@@ -3369,10 +3414,10 @@
 
   const tryInitTraitsList = createPageInitializer({
     name: 'traitsList',
-    pathMatch: 'deprecation',
+    pathMatch: ['deprecation', 'models/traits'],
     elementId: 'traits-list-placeholder',
     initFn: initTraitsList,
-    resetCheck: el => el.innerHTML === ''
+    resetCheck: el => !el.querySelector('.vpt-traits-list')
   });
 
   const tryInitBetaModels = createPageInitializer({
@@ -3404,7 +3449,7 @@
     pathMatch: 'text-to-speech',
     elementId: 'tts-voice-picker-placeholder',
     initFn: initVoicePicker,
-    resetCheck: el => el.textContent.includes('Loading') || el.innerHTML === ''
+    resetCheck: el => !el.querySelector('.vtp-picker')
   });
 
   function resetAllInitializers() {
@@ -3467,6 +3512,7 @@
     retryInit('pricing', () => pageInitializers.pricing.initialized, tryInitPricing);
     retryInit('deprecation', () => pageInitializers.deprecations.initialized, tryInitDeprecations);
     retryInit('deprecation', () => pageInitializers.traitsList.initialized, tryInitTraitsList);
+    retryInit('models/traits', () => pageInitializers.traitsList.initialized, tryInitTraitsList);
     retryInit('beta-models', () => pageInitializers.betaModels.initialized, tryInitBetaModels);
     retryInit('prompt-caching', () => pageInitializers.cachePricing.initialized, tryInitCachePricing);
     retryInit('reasoning-models', () => pageInitializers.reasoningModels.initialized, tryInitReasoningModels);

--- a/models/embeddings.mdx
+++ b/models/embeddings.mdx
@@ -4,7 +4,25 @@ description: "Venice embedding models with pricing, dimensions, and OpenAI-compa
 "og:title": "Embedding Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="embedding">Loading models...</div>
+<div id="model-search-placeholder" data-filter="embedding">
+{/* AUTO-GENERATED:MODELS:START */}
+
+Use the `id` value as the `model` parameter in API requests. 9 models currently available.
+
+| Model | ID | Input (per 1M tokens) | Privacy |
+|---|---|---|---|
+| BGE-EN-ICL | `text-embedding-bge-en-icl` | $0.01 | Private |
+| BGE-M3 | `text-embedding-bge-m3` | $0.15 | Private |
+| Gemini Embedding 2 Preview | `gemini-embedding-2-preview` | $0.25 | Anonymized |
+| Multilingual E5 Large Instruct | `text-embedding-multilingual-e5-large-instruct` | $0.01 | Private |
+| Nemotron Embed VL 1B v2 | `text-embedding-nemotron-embed-vl-1b-v2` | $0.01 | Private |
+| Qwen3 Embedding 0.6B | `text-embedding-qwen3-0-6b` | $0.01 | Private |
+| Qwen3 Embedding 8B | `text-embedding-qwen3-8b` | $0.01 | Private |
+| Text Embedding 3 Large | `text-embedding-3-large` | $0.16 | Anonymized |
+| Text Embedding 3 Small | `text-embedding-3-small` | $0.03 | Anonymized |
+
+{/* AUTO-GENERATED:MODELS:END */}
+</div>
 
 ---
 

--- a/models/image.mdx
+++ b/models/image.mdx
@@ -4,7 +4,88 @@ description: "Venice image models for generation, editing, background removal, a
 "og:title": "Image Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="image">Loading models...</div>
+<div id="model-search-placeholder" data-filter="image">
+{/* AUTO-GENERATED:MODELS:START */}
+
+Use the `id` value as the `model` parameter in API requests. 60 models currently available.
+
+#### Generation
+
+| Model | ID | Price | Privacy |
+|---|---|---|---|
+| Anime (WAI) | `wai-Illustrious` | $0.01 | Private |
+| Background Remover | `bria-bg-remover` | $0.03 | Anonymized |
+| Chroma | `chroma` | $0.01 | Private |
+| Flux 2 Max | `flux-2-max` | $0.09 | Anonymized |
+| Flux 2 Pro | `flux-2-pro` | $0.03 | Anonymized |
+| GPT Image 1.5 | `gpt-image-1-5` | $0.26 | Anonymized |
+| GPT Image 2 | `gpt-image-2` | 1K: $0.27, 2K: $0.51, 4K: $0.84 | Anonymized |
+| Grok Imagine | `grok-imagine-image` | 1K: $0.03, 2K: $0.04 | Private |
+| Grok Imagine 2.0 | `grok-imagine-image-2-0` | 1K: $0.07, 2K: $0.10 | Private |
+| Grok Imagine High Quality (SOTA) | `grok-imagine-image-quality` | 1K: $0.06, 2K: $0.09 | Private |
+| Hunyuan Image 3.0 | `hunyuan-image-v3` | $0.09 | Private |
+| Ideogram V4 | `ideogram-v4` | $0.06 | Anonymized |
+| ImagineArt 1.5 Pro | `imagineart-1.5-pro` | $0.06 | Anonymized |
+| Krea 2 Turbo | `krea-2-turbo` | 1K: $0.04, 2K: $0.06 | Private |
+| Krea v2 Large | `krea-v2-large` | $0.07 | Anonymized |
+| Krea v2 Medium | `krea-v2-medium` | $0.04 | Anonymized |
+| Luma Uni-1 | `luma-uni-1` | $0.05 | Anonymized |
+| Luma Uni-1 Max | `luma-uni-1-max` | $0.12 | Anonymized |
+| Lustify SDXL | `lustify-sdxl` | $0.01 | Private |
+| Lustify v7 | `lustify-v7` | $0.01 | Private |
+| Lustify v8 | `lustify-v8` | $0.01 | Private |
+| Nano Banana 2 | `nano-banana-2` | 1K: $0.10, 2K: $0.14, 4K: $0.19 | Anonymized |
+| Nano Banana 2 Lite | `nano-banana-2-lite` | $0.06 | Anonymized |
+| Nano Banana Pro | `nano-banana-pro` | 1K: $0.18, 2K: $0.23, 4K: $0.35 | Anonymized |
+| Qwen Image | `qwen-image` | $0.03 | Anonymized |
+| Qwen Image 2 | `qwen-image-2` | $0.05 | Anonymized |
+| Qwen Image 2 Pro | `qwen-image-2-pro` | $0.10 | Anonymized |
+| Qwen Image 3 | `qwen-image-3` | 1K: $0.04, 2K: $0.04 | Anonymized |
+| Qwen Image 3 Pro | `qwen-image-3-pro` | 1K: $0.05, 2K: $0.09 | Anonymized |
+| Recraft V4 | `recraft-v4` | $0.05 | Anonymized |
+| Recraft V4 Pro | `recraft-v4-pro` | $0.29 | Anonymized |
+| Seedream V4.5 | `seedream-v4` | $0.05 | Anonymized |
+| Seedream V5 Lite | `seedream-v5-lite` | $0.05 | Anonymized |
+| Seedream V5 Pro | `seedream-v5-pro` | 1K: $0.06, 2K: $0.11 | Anonymized |
+| Venice SD35 | `venice-sd35` | $0.01 | Private |
+| Wan 2.7 | `wan-2-7-text-to-image` | $0.04 | Anonymized |
+| Wan 2.7 Pro | `wan-2-7-pro-text-to-image` | $0.09 | Anonymized |
+| Z-Image Turbo | `z-image-turbo` | $0.01 | Private |
+
+#### Upscaling
+
+| Model | ID | Price | Privacy |
+|---|---|---|---|
+| Upscaler | `upscaler` | 2x $0.02, 4x $0.08 | Private |
+
+#### Editing
+
+| Model | ID | Price | Privacy |
+|---|---|---|---|
+| FireRed Edit | `firered-image-edit` | $0.04 | Private |
+| Flux 2 Max | `flux-2-max-edit` | $0.12 / extra image $0.03 | Anonymized |
+| GPT Image 1.5 | `gpt-image-1-5-edit` | $0.31 / extra image $0.03 | Anonymized |
+| GPT Image 2 | `gpt-image-2-edit` | $0.34 / extra image $0.0092 | Anonymized |
+| Grok Imagine | `grok-imagine-edit` | $0.03 / extra image $0.0023 | Private |
+| Grok Imagine 2.0 | `grok-imagine-image-2-0-edit` | $0.07 / extra image $0.01 | Private |
+| Grok Imagine High Quality | `grok-imagine-quality-edit` | $0.06 / extra image $0.01 | Private |
+| Luma Uni-1 | `luma-uni-1-edit` | $0.06 | Anonymized |
+| Luma Uni-1 Max | `luma-uni-1-max-edit` | $0.13 | Anonymized |
+| Nano Banana 2 | `nano-banana-2-edit` | $0.10 | Anonymized |
+| Nano Banana 2 Lite | `nano-banana-2-lite-edit` | $0.06 | Anonymized |
+| Nano Banana Pro | `nano-banana-pro-edit` | $0.18 | Anonymized |
+| Qwen Edit Uncensored | `qwen-edit-uncensored` | $0.04 | Private |
+| Qwen Image 2 | `qwen-image-2-edit` | $0.05 | Anonymized |
+| Qwen Image 2 Pro | `qwen-image-2-pro-edit` | $0.10 | Anonymized |
+| Qwen Image 3 Edit | `qwen-image-3-edit` | $0.04 / extra image $0.0035 | Anonymized |
+| Qwen Image 3 Pro Edit | `qwen-image-3-pro-edit` | $0.05 / extra image $0.0035 | Anonymized |
+| Seedream V4.5 | `seedream-v4-edit` | $0.05 | Anonymized |
+| Seedream V5 Lite | `seedream-v5-lite-edit` | $0.05 | Anonymized |
+| Seedream V5 Pro | `seedream-v5-pro-edit` | $0.06 / extra image $0.0035 | Anonymized |
+| Wan 2.7 Pro Edit | `wan-2-7-pro-edit` | $0.09 | Anonymized |
+
+{/* AUTO-GENERATED:MODELS:END */}
+</div>
 
 ---
 

--- a/models/music.mdx
+++ b/models/music.mdx
@@ -4,7 +4,30 @@ description: "Venice music and audio models for songs, instrumental tracks, and 
 "og:title": "Music & Sound Effects Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="music">Loading models...</div>
+<div id="model-search-placeholder" data-filter="music">
+{/* AUTO-GENERATED:MODELS:START */}
+
+Use the `id` value as the `model` parameter in API requests. 14 models currently available.
+
+| Model | ID | Pricing | Privacy |
+|---|---|---|---|
+| ACE-Step 1.5 | `ace-step-15` | Duration-tiered — use Audio Quote API | Anonymized |
+| ElevenLabs Multilingual v2 | `elevenlabs-tts-multilingual-v2` | See Audio Quote API | Anonymized |
+| ElevenLabs Music | `elevenlabs-music` | Duration-tiered — use Audio Quote API | Anonymized |
+| ElevenLabs Sound Effects | `elevenlabs-sound-effects-v2` | $0.0023 / second | Anonymized |
+| ElevenLabs TTS v3 | `elevenlabs-tts-v3` | See Audio Quote API | Anonymized |
+| Lyria 3 Pro | `lyria-3-pro` | $0.10 / generation | Anonymized |
+| MiniMax Music 2.0 | `minimax-music-v2` | $0.04 / generation | Anonymized |
+| MiniMax Music 2.5 | `minimax-music-v25` | $0.18 / generation | Anonymized |
+| MiniMax Music 2.6 | `minimax-music-v26` | $0.18 / generation | Anonymized |
+| MMAudio V2 | `mmaudio-v2-text-to-audio` | $0.0009 / second | Anonymized |
+| Seed Audio 1.0 | `seed-audio-1-0` | $0.0029 / second | Anonymized |
+| Sonilo V1.1 Music | `sonilo-v1-1-music` | $0.0029 / second | Anonymized |
+| Sonilo V1.1 Sound Effects | `sonilo-v1-1-sound-effects` | $0.0021 / second | Anonymized |
+| Stable Audio 2.5 | `stable-audio-25` | $0.19 / generation | Anonymized |
+
+{/* AUTO-GENERATED:MODELS:END */}
+</div>
 
 ## Model Categories
 

--- a/models/overview.mdx
+++ b/models/overview.mdx
@@ -6,4 +6,384 @@ description: "Every model on the Venice API across text, image, video, audio, an
 mode: "wide"
 ---
 
-<div id="model-search-placeholder">Loading models...</div>
+<div id="model-search-placeholder">
+{/* AUTO-GENERATED:MODELS:START */}
+
+Use the `id` value as the `model` parameter in API requests. 327 models currently available.
+
+### Text (110)
+
+| Model | ID | Input | Output | Context | Privacy | Capabilities |
+|---|---|---|---|---|---|---|
+| Aion 3.0 | `aion-labs-aion-3-0` | $3.75 | $7.50 | 128K | Anonymized | Function calling, Reasoning, Uncensored |
+| Aion 3.0 Mini | `aion-labs-aion-3-0-mini` | $0.88 | $1.75 | 128K | Anonymized | Function calling, Reasoning, Uncensored |
+| Claude Fable 5 | `claude-fable-5` | $12.00 | $60.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.5 | `claude-opus-4-5` | $6.00 | $30.00 | 198K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.6 | `claude-opus-4-6` | $6.00 | $30.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.7 | `claude-opus-4-7` | $6.00 | $30.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.8 | `claude-opus-4-8` | $6.00 | $30.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.8 Fast | `claude-opus-4-8-fast` | $12.00 | $60.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 5 | `claude-opus-5` | $6.00 | $30.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 5 Fast | `claude-opus-5-fast` | $12.00 | $60.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5` | $3.75 | $18.75 | 198K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | $3.60 | $18.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Sonnet 5 | `claude-sonnet-5` | $3.00 | $15.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| DeepSeek V3.2 | `deepseek-v3.2` | $0.33 | $0.48 | 160K | Private | Function calling, Reasoning |
+| DeepSeek V4 Flash | `e2ee-deepseek-v4-flash` | $0.18 | $0.37 | 1000K | E2EE · Private | Function calling, Reasoning, Code |
+| DeepSeek V4 Flash 0423 | `deepseek-v4-flash` | $0.14 | $0.28 | 1000K | Anonymized | Function calling, Reasoning, Code |
+| DeepSeek V4 Flash 0731 | `deepseek-v4-flash-0731` | $0.17 | $0.35 | 1000K | Private | Function calling, Reasoning, Code |
+| DeepSeek V4 Flash 0731 Fast | `deepseek-v4-flash-0731-fast` | $0.35 | $0.70 | 1000K | Private | Function calling, Reasoning, Code |
+| DeepSeek V4 Pro | `deepseek-v4-pro` | $1.65 | $3.30 | 1000K | Anonymized | Function calling, Reasoning, Code |
+| DeepSeek V4 Pro 0813 | `deepseek-v4-pro-0813` | $1.65 | $4.95 | 1000K | Private | Function calling, Reasoning, Code |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | $0.70 | $3.75 | 256K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.1 Pro Preview | `gemini-3-1-pro-preview` | $2.50 | $15.00 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.5 Flash | `gemini-3-5-flash` | $1.55 | $9.45 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.5 Flash-Lite | `gemini-3-5-flash-lite` | $0.38 | $3.13 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.6 Flash | `gemini-3-6-flash` | $1.88 | $9.38 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.7 Flash | `gemini-3-7-flash` | $1.88 | $9.38 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemma 3 27B | `e2ee-gemma-3-27b-p` | $0.14 | $0.50 | 40K | E2EE · Private | — |
+| Gemma 4 26B A4B Uncensored | `e2ee-gemma-4-26b-a4b-uncensored-p` | $0.19 | $0.88 | 64K | E2EE · Private | Uncensored |
+| Gemma 4 Uncensored | `gemma-4-uncensored` | $0.16 | $0.50 | 256K | Private | Function calling, Vision, Uncensored |
+| GLM 4.6 | `zai-org-glm-4.6` | $0.43 | $1.75 | 198K | Private | Function calling, Reasoning |
+| GLM 4.7 | `zai-org-glm-4.7` | $0.55 | $2.65 | 198K | Private | Function calling, Reasoning |
+| GLM 4.7 Flash | `zai-org-glm-4.7-flash` | $0.06 | $0.40 | 128K | Private | Function calling, Reasoning |
+| GLM 4.7 Flash Heretic | `olafangensan-glm-4.7-flash-heretic` | $0.07 | $0.40 | 200K | Private | Function calling, Reasoning, Uncensored |
+| GLM 5 | `zai-org-glm-5` | $1.00 | $3.20 | 198K | Private | Function calling, Reasoning, Code |
+| GLM 5 Turbo | `z-ai-glm-5-turbo` | $1.20 | $4.00 | 200K | Anonymized | Function calling, Reasoning, Code |
+| GLM 5.1 | `zai-org-glm-5-1` | $1.54 | $4.84 | 200K | Private | Function calling, Reasoning |
+| GLM 5.1 | `e2ee-glm-5-1` | $1.10 | $4.15 | 200K | E2EE · Private | Reasoning |
+| GLM 5.2 | `zai-org-glm-5-2` | $1.40 | $4.40 | 1000K | Private | Function calling, Reasoning, Code |
+| GLM 5.2 | `e2ee-glm-5-2-p` | $1.75 | $5.75 | 524K | E2EE · Private | Function calling, Reasoning, Code |
+| GLM 5.3 | `z-ai-glm-5-3` | $1.75 | $5.50 | 1000K | Anonymized | Function calling, Reasoning, Code |
+| GLM 5V Turbo | `z-ai-glm-5v-turbo` | $1.50 | $5.00 | 200K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Google Gemma 3 27B Instruct | `google-gemma-3-27b-it` | $0.12 | $0.20 | 198K | Private | Function calling, Vision |
+| Google Gemma 4 26B A4B Instruct | `google-gemma-4-26b-a4b-it` | $0.13 | $0.40 | 256K | Private | Function calling, Reasoning, Vision |
+| Google Gemma 4 31B Instruct | `google-gemma-4-31b-it` | $0.12 | $0.36 | 256K | Private | Function calling, Reasoning, Vision |
+| GPT OSS 120B | `e2ee-gpt-oss-120b-p` | $0.13 | $0.65 | 128K | E2EE · Private | Reasoning |
+| GPT OSS 20B | `e2ee-gpt-oss-20b-p` | $0.05 | $0.19 | 128K | E2EE · Private | Reasoning |
+| GPT-4o | `openai-gpt-4o-2024-11-20` | $3.13 | $12.50 | 128K | Anonymized | Function calling, Vision |
+| GPT-4o Mini | `openai-gpt-4o-mini-2024-07-18` | $0.19 | $0.75 | 128K | Anonymized | Function calling, Vision |
+| GPT-5.2 | `openai-gpt-52` | $2.19 | $17.50 | 256K | Anonymized | Function calling, Reasoning |
+| GPT-5.2 Codex | `openai-gpt-52-codex` | $2.19 | $17.50 | 256K | Anonymized | Function calling, Reasoning, Vision, Code |
+| GPT-5.3 Codex | `openai-gpt-53-codex` | $2.19 | $17.50 | 400K | Anonymized | Function calling, Reasoning, Vision, Code |
+| GPT-5.4 | `openai-gpt-54` | $3.13 | $18.80 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.4 Mini | `openai-gpt-54-mini` | $0.94 | $5.63 | 400K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.4 Pro | `openai-gpt-54-pro` | $37.50 | $225.00 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.5 | `openai-gpt-55` | $6.25 | $37.50 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.5 Pro | `openai-gpt-55-pro` | $37.50 | $225.00 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Luna | `openai-gpt-56-luna` | $0.27 | $1.60 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Luna Pro | `openai-gpt-56-luna-pro` | $1.25 | $7.50 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Sol | `openai-gpt-56-sol` | $6.25 | $37.50 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Sol Pro | `openai-gpt-56-sol-pro` | $6.25 | $37.50 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Terra | `openai-gpt-56-terra` | $3.13 | $18.75 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Terra Pro | `openai-gpt-56-terra-pro` | $3.13 | $18.75 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Grok 4.20 | `grok-4-20` | $1.42 | $2.83 | 2000K | Private | Function calling, Reasoning, Vision |
+| Grok 4.20 Multi-Agent | `grok-4-20-multi-agent` | $1.42 | $2.83 | 2000K | Private | Reasoning, Vision |
+| Grok 4.3 | `grok-4-3` | $1.42 | $2.83 | 1000K | Private | Function calling, Reasoning, Vision |
+| Grok 4.5 | `grok-4-5` | $2.27 | $6.80 | 500K | Private | Function calling, Reasoning, Vision, Code |
+| Grok 4.6 | `grok-4-6` | $2.27 | $6.80 | 500K | Private | Function calling, Reasoning, Vision, Code |
+| Grok Build 0.1 | `grok-build-0-1` | $1.00 | $2.00 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Hermes 3 Llama 3.1 405b | `hermes-3-llama-3.1-405b` | $1.10 | $3.00 | 128K | Private | — |
+| Inkling | `inkling` | $1.25 | $5.06 | 524K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K2.5 | `kimi-k2-5` | $0.56 | $3.50 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K2.6 | `kimi-k2-6` | $0.75 | $3.50 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K2.7 Code | `kimi-k2-7-code` | $0.75 | $3.50 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K3 | `kimi-k3` | $3.75 | $18.75 | 1000K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K3 Fast | `kimi-k3-fast-api` | $4.50 | $22.50 | 1000K | Private | Function calling, Reasoning, Vision, Code |
+| Llama 3.2 3B | `llama-3.2-3b` | $0.15 | $0.60 | 128K | Private | Function calling |
+| Llama 3.3 70B | `llama-3.3-70b` | $0.70 | $2.80 | 128K | Private | Function calling |
+| Mercury 2 | `mercury-2` | $0.31 | $0.94 | 128K | Anonymized | Function calling, Reasoning |
+| MiMo-V2.5 | `xiaomi-mimo-v2-5` | $0.40 | $2.00 | 1000K | Private | Function calling, Reasoning, Vision, Code |
+| MiniMax M2.5 | `minimax-m25` | $0.27 | $0.95 | 198K | Private | Function calling, Reasoning, Code |
+| MiniMax M2.7 | `minimax-m27` | $0.38 | $1.50 | 198K | Private | Function calling, Reasoning, Code |
+| MiniMax M3 Preview | `minimax-m3-preview` | $0.30 | $1.20 | 524K | Private | Function calling, Reasoning, Vision, Code |
+| Mistral Small 3.2 24B Instruct | `mistral-small-3-2-24b-instruct` | $0.09 | $0.25 | 256K | Private | Function calling |
+| Mistral Small 4 | `mistral-small-2603` | $0.19 | $0.75 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| NVIDIA Nemotron 3 Nano 30B | `nvidia-nemotron-3-nano-30b-a3b` | $0.07 | $0.30 | 128K | Private | Function calling |
+| NVIDIA Nemotron 3 Ultra | `nvidia-nemotron-3-ultra-550b-a55b` | $0.63 | $3.13 | 256K | Private | Function calling, Reasoning |
+| OpenAI GPT OSS 120B | `openai-gpt-oss-120b` | $0.07 | $0.30 | 128K | Private | Function calling, Reasoning |
+| Ox Alpha (Beta) | `stealth-ox-alpha` | $0.00 | $0.00 | 1049K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen 2.5 7B | `e2ee-qwen-2-5-7b-p` | $0.05 | $0.13 | 32K | E2EE · Private | — |
+| Qwen 3 235B A22B Instruct 2507 | `qwen3-235b-a22b-instruct-2507` | $0.15 | $0.75 | 128K | Private | Function calling |
+| Qwen 3 235B A22B Thinking 2507 | `qwen3-235b-a22b-thinking-2507` | $0.45 | $3.50 | 128K | Private | Function calling, Reasoning |
+| Qwen 3 Coder 480B Turbo | `qwen3-coder-480b-a35b-instruct-turbo` | $0.35 | $1.50 | 256K | Private | Function calling, Code |
+| Qwen 3 Next 80b | `qwen3-next-80b` | $0.35 | $1.90 | 256K | Private | Function calling |
+| Qwen 3.5 35B A3B | `qwen3-5-35b-a3b` | $0.31 | $1.25 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Qwen 3.5 397B | `qwen3-5-397b-a17b` | $0.75 | $4.50 | 128K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen 3.5 9B | `qwen3-5-9b` | $0.10 | $0.15 | 256K | Private | Function calling, Reasoning, Vision |
+| Qwen 3.6 27B | `qwen3-6-27b` | $0.33 | $3.25 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Qwen 3.6 35B A3B (Beta) | `qwen3-6-35b-a3b` | $0.10 | $1.00 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Qwen 3.6 35B A3B FP8 | `e2ee-qwen3-6-35b-a3b` | $0.18 | $1.18 | 32K | E2EE · Private | Function calling, Reasoning, Code |
+| Qwen 3.6 Plus Uncensored | `qwen-3-6-plus` | $0.63 | $3.75 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code, Uncensored |
+| Qwen 3.7 Max | `qwen-3-7-max` | $2.70 | $8.05 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen 3.7 Plus | `qwen-3-7-plus` | $0.50 | $2.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen 3.8 2.4T | `qwen-3-8-2-4t-a95b` | $2.50 | $7.50 | 262K | Private | Function calling, Reasoning, Code |
+| Qwen 3.8 27B (Beta) | `qwen-3-8-27b` | $0.45 | $3.20 | 262K | Private | Function calling, Reasoning, Vision, Code, Uncensored |
+| Qwen 3.8 Max | `qwen-3-8-max` | $2.50 | $7.50 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen3 VL 235B | `qwen3-vl-235b-a22b` | $0.21 | $1.90 | 128K | Private | Function calling, Vision |
+| Qwen3 VL 30B A3B | `e2ee-qwen3-vl-30b-a3b-p` | $0.25 | $0.90 | 128K | E2EE · Private | Function calling, Vision |
+| Seed 2.1 Turbo | `seed-2-1-turbo` | $0.63 | $3.13 | 256K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Venice Role Play Uncensored | `venice-uncensored-role-play` | $0.50 | $2.00 | 128K | Private | Function calling, Vision, Uncensored |
+| Venice Uncensored 1.2 | `venice-uncensored-1-2` | $0.20 | $0.90 | 128K | Private | Function calling, Vision, Uncensored |
+
+### Image (60)
+
+#### Generation
+
+| Model | ID | Price | Privacy |
+|---|---|---|---|
+| Anime (WAI) | `wai-Illustrious` | $0.01 | Private |
+| Background Remover | `bria-bg-remover` | $0.03 | Anonymized |
+| Chroma | `chroma` | $0.01 | Private |
+| Flux 2 Max | `flux-2-max` | $0.09 | Anonymized |
+| Flux 2 Pro | `flux-2-pro` | $0.03 | Anonymized |
+| GPT Image 1.5 | `gpt-image-1-5` | $0.26 | Anonymized |
+| GPT Image 2 | `gpt-image-2` | 1K: $0.27, 2K: $0.51, 4K: $0.84 | Anonymized |
+| Grok Imagine | `grok-imagine-image` | 1K: $0.03, 2K: $0.04 | Private |
+| Grok Imagine 2.0 | `grok-imagine-image-2-0` | 1K: $0.07, 2K: $0.10 | Private |
+| Grok Imagine High Quality (SOTA) | `grok-imagine-image-quality` | 1K: $0.06, 2K: $0.09 | Private |
+| Hunyuan Image 3.0 | `hunyuan-image-v3` | $0.09 | Private |
+| Ideogram V4 | `ideogram-v4` | $0.06 | Anonymized |
+| ImagineArt 1.5 Pro | `imagineart-1.5-pro` | $0.06 | Anonymized |
+| Krea 2 Turbo | `krea-2-turbo` | 1K: $0.04, 2K: $0.06 | Private |
+| Krea v2 Large | `krea-v2-large` | $0.07 | Anonymized |
+| Krea v2 Medium | `krea-v2-medium` | $0.04 | Anonymized |
+| Luma Uni-1 | `luma-uni-1` | $0.05 | Anonymized |
+| Luma Uni-1 Max | `luma-uni-1-max` | $0.12 | Anonymized |
+| Lustify SDXL | `lustify-sdxl` | $0.01 | Private |
+| Lustify v7 | `lustify-v7` | $0.01 | Private |
+| Lustify v8 | `lustify-v8` | $0.01 | Private |
+| Nano Banana 2 | `nano-banana-2` | 1K: $0.10, 2K: $0.14, 4K: $0.19 | Anonymized |
+| Nano Banana 2 Lite | `nano-banana-2-lite` | $0.06 | Anonymized |
+| Nano Banana Pro | `nano-banana-pro` | 1K: $0.18, 2K: $0.23, 4K: $0.35 | Anonymized |
+| Qwen Image | `qwen-image` | $0.03 | Anonymized |
+| Qwen Image 2 | `qwen-image-2` | $0.05 | Anonymized |
+| Qwen Image 2 Pro | `qwen-image-2-pro` | $0.10 | Anonymized |
+| Qwen Image 3 | `qwen-image-3` | 1K: $0.04, 2K: $0.04 | Anonymized |
+| Qwen Image 3 Pro | `qwen-image-3-pro` | 1K: $0.05, 2K: $0.09 | Anonymized |
+| Recraft V4 | `recraft-v4` | $0.05 | Anonymized |
+| Recraft V4 Pro | `recraft-v4-pro` | $0.29 | Anonymized |
+| Seedream V4.5 | `seedream-v4` | $0.05 | Anonymized |
+| Seedream V5 Lite | `seedream-v5-lite` | $0.05 | Anonymized |
+| Seedream V5 Pro | `seedream-v5-pro` | 1K: $0.06, 2K: $0.11 | Anonymized |
+| Venice SD35 | `venice-sd35` | $0.01 | Private |
+| Wan 2.7 | `wan-2-7-text-to-image` | $0.04 | Anonymized |
+| Wan 2.7 Pro | `wan-2-7-pro-text-to-image` | $0.09 | Anonymized |
+| Z-Image Turbo | `z-image-turbo` | $0.01 | Private |
+
+#### Upscaling
+
+| Model | ID | Price | Privacy |
+|---|---|---|---|
+| Upscaler | `upscaler` | 2x $0.02, 4x $0.08 | Private |
+
+#### Editing
+
+| Model | ID | Price | Privacy |
+|---|---|---|---|
+| FireRed Edit | `firered-image-edit` | $0.04 | Private |
+| Flux 2 Max | `flux-2-max-edit` | $0.12 / extra image $0.03 | Anonymized |
+| GPT Image 1.5 | `gpt-image-1-5-edit` | $0.31 / extra image $0.03 | Anonymized |
+| GPT Image 2 | `gpt-image-2-edit` | $0.34 / extra image $0.0092 | Anonymized |
+| Grok Imagine | `grok-imagine-edit` | $0.03 / extra image $0.0023 | Private |
+| Grok Imagine 2.0 | `grok-imagine-image-2-0-edit` | $0.07 / extra image $0.01 | Private |
+| Grok Imagine High Quality | `grok-imagine-quality-edit` | $0.06 / extra image $0.01 | Private |
+| Luma Uni-1 | `luma-uni-1-edit` | $0.06 | Anonymized |
+| Luma Uni-1 Max | `luma-uni-1-max-edit` | $0.13 | Anonymized |
+| Nano Banana 2 | `nano-banana-2-edit` | $0.10 | Anonymized |
+| Nano Banana 2 Lite | `nano-banana-2-lite-edit` | $0.06 | Anonymized |
+| Nano Banana Pro | `nano-banana-pro-edit` | $0.18 | Anonymized |
+| Qwen Edit Uncensored | `qwen-edit-uncensored` | $0.04 | Private |
+| Qwen Image 2 | `qwen-image-2-edit` | $0.05 | Anonymized |
+| Qwen Image 2 Pro | `qwen-image-2-pro-edit` | $0.10 | Anonymized |
+| Qwen Image 3 Edit | `qwen-image-3-edit` | $0.04 / extra image $0.0035 | Anonymized |
+| Qwen Image 3 Pro Edit | `qwen-image-3-pro-edit` | $0.05 / extra image $0.0035 | Anonymized |
+| Seedream V4.5 | `seedream-v4-edit` | $0.05 | Anonymized |
+| Seedream V5 Lite | `seedream-v5-lite-edit` | $0.05 | Anonymized |
+| Seedream V5 Pro | `seedream-v5-pro-edit` | $0.06 / extra image $0.0035 | Anonymized |
+| Wan 2.7 Pro Edit | `wan-2-7-pro-edit` | $0.09 | Anonymized |
+
+### Video (118)
+
+| Model | ID | Type | Pricing | Privacy |
+|---|---|---|---|---|
+| Flux 3 | `flux-3-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Flux 3 | `flux-3-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Flux 3 First Last Frame | `flux-3-first-last-frame-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Gemini Omni Flash | `gemini-omni-flash-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Gemini Omni Flash | `gemini-omni-flash-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Gemini Omni Flash R2V | `gemini-omni-flash-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Grok Imagine | `grok-imagine-text-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| Grok Imagine | `grok-imagine-image-to-video-private` | Image to Video | Variable — use Video Quote API | Private |
+| Grok Imagine | `grok-imagine-video-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| Grok Imagine 1.5 | `grok-imagine-1-5-text-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| Grok Imagine 1.5 | `grok-imagine-1-5-image-to-video-private` | Image to Video | Variable — use Video Quote API | Private |
+| Grok Imagine 1.5 R2V | `grok-imagine-1-5-reference-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| Grok Imagine R2V | `grok-imagine-reference-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| HappyHorse 1.0 | `happyhorse-1-0-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.0 | `happyhorse-1-0-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.0 Edit | `happyhorse-1-0-video-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.0 Reference | `happyhorse-1-0-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.1 | `happyhorse-1-1-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.1 | `happyhorse-1-1-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.1 Reference | `happyhorse-1-1-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling 2.5 Turbo Pro | `kling-2.5-turbo-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling 2.5 Turbo Pro | `kling-2.5-turbo-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling 2.6 Pro | `kling-2.6-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling 2.6 Pro | `kling-2.6-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 4K | `kling-o3-4k-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 4K | `kling-o3-4k-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 4K R2V | `kling-o3-4k-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Pro | `kling-o3-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Pro | `kling-o3-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Pro R2V | `kling-o3-pro-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Standard | `kling-o3-standard-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Standard | `kling-o3-standard-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Standard R2V | `kling-o3-standard-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 4K | `kling-v3-4k-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 4K R2V | `kling-v3-4k-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Pro | `kling-v3-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Pro | `kling-v3-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Pro Motion Control | `kling-v3-pro-motion-control` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Standard | `kling-v3-standard-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Standard | `kling-v3-standard-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Standard Motion Control | `kling-v3-standard-motion-control` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Turbo Pro | `kling-v3-turbo-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Turbo Pro | `kling-v3-turbo-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Turbo Standard | `kling-v3-turbo-standard-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Turbo Standard | `kling-v3-turbo-standard-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Longcat Distilled | `longcat-distilled-image-to-video` | Image to Video | Variable — use Video Quote API | Private |
+| Longcat Distilled | `longcat-distilled-text-to-video` | Text to Video | Variable — use Video Quote API | Private |
+| Longcat Full Quality | `longcat-image-to-video` | Image to Video | Variable — use Video Quote API | Private |
+| Longcat Full Quality | `longcat-text-to-video` | Text to Video | Variable — use Video Quote API | Private |
+| LTX Video 2.3 Fast | `ltx-2-v2-3-fast-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.3 Fast | `ltx-2-v2-3-fast-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.3 Full Quality | `ltx-2-v2-3-full-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.3 Full Quality | `ltx-2-v2-3-full-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.5 Fast | `ltx-2-5-fast-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.5 Fast | `ltx-2-5-fast-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.5 Pro | `ltx-2-5-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.5 Pro | `ltx-2-5-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 | `minimax-h3-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 | `minimax-h3-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 Enhanced | `minimax-h3-enhanced-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 R2V | `minimax-h3-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 R2V Enhanced | `minimax-h3-enhanced-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Ovi | `ovi-image-to-video` | Image to Video | Variable — use Video Quote API | Private |
+| PixVerse C1 | `pixverse-c1-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse C1 | `pixverse-c1-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse C1 R2V | `pixverse-c1-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse C1 Transition | `pixverse-c1-transition` | Text to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse v5.6 | `pixverse-v5.6-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse v5.6 | `pixverse-v5.6-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse v5.6 Transition | `pixverse-v5.6-transition` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Runway Gen-4 Turbo | `runway-gen4-turbo` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Runway Gen-4.5 | `runway-gen4-5` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Runway Gen-4.5 | `runway-gen4-5-text` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 1.5 Pro | `seedance-1-5-pro-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 1.5 Pro | `seedance-1-5-pro-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 | `seedance-2-0-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 | `seedance-2-0-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Fast | `seedance-2-0-fast-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Fast | `seedance-2-0-fast-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Fast R2V | `seedance-2-0-fast-reference-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Mini | `seedance-2-0-mini-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Mini | `seedance-2-0-mini-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Mini R2V | `seedance-2-0-mini-reference-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 R2V | `seedance-2-0-reference-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.5 | `seedance-2-5-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.5 | `seedance-2-5-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.5 R2V | `seedance-2-5-reference-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Topaz Video Upscale | `topaz-video-upscale` | Video Upscale | Variable — use Video Quote API | Anonymized |
+| Veo 3 Fast | `veo3-fast-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3 Fast | `veo3-fast-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3 Full Quality | `veo3-full-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3 Full Quality | `veo3-full-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3.1 Fast | `veo3.1-fast-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3.1 Fast | `veo3.1-fast-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3.1 Full Quality | `veo3.1-full-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3.1 Full Quality | `veo3.1-full-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Vidu Q3 | `vidu-q3-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Vidu Q3 | `vidu-q3-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.1 Pro | `wan-2.1-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Private |
+| Wan 2.2 A14B | `wan-2.2-a14b-text-to-video` | Text to Video | Variable — use Video Quote API | Private |
+| Wan 2.2 Enhanced | `wan-2-2-enhanced-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.5 Preview | `wan-2.5-preview-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.5 Preview | `wan-2.5-preview-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.6 | `wan-2.6-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.6 | `wan-2.6-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.6 Flash | `wan-2.6-flash-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 | `wan-2-7-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 | `wan-2-7-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 Edit | `wan-2-7-video-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 Enhanced | `wan-2-7-enhanced-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 Enhanced | `wan-2-7-enhanced-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 Reference | `wan-2-7-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 | `wan-3-0-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 | `wan-3-0-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 Prime | `wan-3-0-prime-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 Prime | `wan-3-0-prime-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 Prime Reference | `wan-3-0-prime-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 Reference | `wan-3-0-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+
+### Text-to-Speech (11)
+
+| Model | ID | Per 1M characters | Voices | Privacy |
+|---|---|---|---|---|
+| Chatterbox HD (Resemble AI) | `tts-chatterbox-hd` | $50.00 | 9 | Private |
+| ElevenLabs Turbo v2.5 | `tts-elevenlabs-turbo-v2-5` | $62.50 | 21 | Anonymized |
+| Gemini 3.1 Flash TTS | `tts-gemini-3-1-flash` | $187.50 | 30 | Anonymized |
+| Gradium TTS | `tts-gradium-v1` | $47.50 | 12 | Anonymized |
+| Inworld TTS-1.5 Max | `tts-inworld-1-5-max` | $12.50 | 14 | Anonymized |
+| Kokoro Text to Speech | `tts-kokoro` | $3.50 | 54 | Private |
+| MiniMax Speech-02 HD | `tts-minimax-speech-02-hd` | $125.00 | 15 | Anonymized |
+| Orpheus TTS | `tts-orpheus` | $62.50 | 8 | Private |
+| Qwen 3 TTS 0.6B | `tts-qwen3-0-6b` | $87.50 | 9 | Private |
+| Qwen 3 TTS 1.7B | `tts-qwen3-1-7b` | $112.50 | 9 | Private |
+| xAI TTS v1 | `tts-xai-v1` | $18.75 | 26 | Anonymized |
+
+### Speech-to-Text (5)
+
+| Model | ID | Per audio second | Privacy |
+|---|---|---|---|
+| ElevenLabs Scribe V2 | `elevenlabs/scribe-v2` | $0.0002 | Anonymized |
+| Parakeet ASR | `nvidia/parakeet-tdt-0.6b-v3` | $0.0001 | Private |
+| Whisper Large V3 | `openai/whisper-large-v3` | $0.0001 | Private |
+| Wizper (Whisper v3) | `fal-ai/wizper` | $0.0001 | Private |
+| xAI Speech to Text v1 | `stt-xai-v1` | $0.0000 | Anonymized |
+
+### Music (14)
+
+| Model | ID | Pricing | Privacy |
+|---|---|---|---|
+| ACE-Step 1.5 | `ace-step-15` | Duration-tiered — use Audio Quote API | Anonymized |
+| ElevenLabs Multilingual v2 | `elevenlabs-tts-multilingual-v2` | See Audio Quote API | Anonymized |
+| ElevenLabs Music | `elevenlabs-music` | Duration-tiered — use Audio Quote API | Anonymized |
+| ElevenLabs Sound Effects | `elevenlabs-sound-effects-v2` | $0.0023 / second | Anonymized |
+| ElevenLabs TTS v3 | `elevenlabs-tts-v3` | See Audio Quote API | Anonymized |
+| Lyria 3 Pro | `lyria-3-pro` | $0.10 / generation | Anonymized |
+| MiniMax Music 2.0 | `minimax-music-v2` | $0.04 / generation | Anonymized |
+| MiniMax Music 2.5 | `minimax-music-v25` | $0.18 / generation | Anonymized |
+| MiniMax Music 2.6 | `minimax-music-v26` | $0.18 / generation | Anonymized |
+| MMAudio V2 | `mmaudio-v2-text-to-audio` | $0.0009 / second | Anonymized |
+| Seed Audio 1.0 | `seed-audio-1-0` | $0.0029 / second | Anonymized |
+| Sonilo V1.1 Music | `sonilo-v1-1-music` | $0.0029 / second | Anonymized |
+| Sonilo V1.1 Sound Effects | `sonilo-v1-1-sound-effects` | $0.0021 / second | Anonymized |
+| Stable Audio 2.5 | `stable-audio-25` | $0.19 / generation | Anonymized |
+
+### Embeddings (9)
+
+| Model | ID | Input (per 1M tokens) | Privacy |
+|---|---|---|---|
+| BGE-EN-ICL | `text-embedding-bge-en-icl` | $0.01 | Private |
+| BGE-M3 | `text-embedding-bge-m3` | $0.15 | Private |
+| Gemini Embedding 2 Preview | `gemini-embedding-2-preview` | $0.25 | Anonymized |
+| Multilingual E5 Large Instruct | `text-embedding-multilingual-e5-large-instruct` | $0.01 | Private |
+| Nemotron Embed VL 1B v2 | `text-embedding-nemotron-embed-vl-1b-v2` | $0.01 | Private |
+| Qwen3 Embedding 0.6B | `text-embedding-qwen3-0-6b` | $0.01 | Private |
+| Qwen3 Embedding 8B | `text-embedding-qwen3-8b` | $0.01 | Private |
+| Text Embedding 3 Large | `text-embedding-3-large` | $0.16 | Anonymized |
+| Text Embedding 3 Small | `text-embedding-3-small` | $0.03 | Anonymized |
+
+{/* AUTO-GENERATED:MODELS:END */}
+</div>

--- a/models/speech-to-text.mdx
+++ b/models/speech-to-text.mdx
@@ -4,7 +4,21 @@ description: "Venice speech-to-text models with multilingual support, timestamps
 "og:title": "Speech-to-Text Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="asr">Loading models...</div>
+<div id="model-search-placeholder" data-filter="asr">
+{/* AUTO-GENERATED:MODELS:START */}
+
+Use the `id` value as the `model` parameter in API requests. 5 models currently available.
+
+| Model | ID | Per audio second | Privacy |
+|---|---|---|---|
+| ElevenLabs Scribe V2 | `elevenlabs/scribe-v2` | $0.0002 | Anonymized |
+| Parakeet ASR | `nvidia/parakeet-tdt-0.6b-v3` | $0.0001 | Private |
+| Whisper Large V3 | `openai/whisper-large-v3` | $0.0001 | Private |
+| Wizper (Whisper v3) | `fal-ai/wizper` | $0.0001 | Private |
+| xAI Speech to Text v1 | `stt-xai-v1` | $0.0000 | Anonymized |
+
+{/* AUTO-GENERATED:MODELS:END */}
+</div>
 
 ---
 

--- a/models/text-to-speech.mdx
+++ b/models/text-to-speech.mdx
@@ -4,7 +4,27 @@ description: "Venice text-to-speech models with multilingual voices and streamin
 "og:title": "Text-to-Speech Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="tts">Loading models...</div>
+<div id="model-search-placeholder" data-filter="tts">
+{/* AUTO-GENERATED:MODELS:START */}
+
+Use the `id` value as the `model` parameter in API requests. 11 models currently available.
+
+| Model | ID | Per 1M characters | Voices | Privacy |
+|---|---|---|---|---|
+| Chatterbox HD (Resemble AI) | `tts-chatterbox-hd` | $50.00 | 9 | Private |
+| ElevenLabs Turbo v2.5 | `tts-elevenlabs-turbo-v2-5` | $62.50 | 21 | Anonymized |
+| Gemini 3.1 Flash TTS | `tts-gemini-3-1-flash` | $187.50 | 30 | Anonymized |
+| Gradium TTS | `tts-gradium-v1` | $47.50 | 12 | Anonymized |
+| Inworld TTS-1.5 Max | `tts-inworld-1-5-max` | $12.50 | 14 | Anonymized |
+| Kokoro Text to Speech | `tts-kokoro` | $3.50 | 54 | Private |
+| MiniMax Speech-02 HD | `tts-minimax-speech-02-hd` | $125.00 | 15 | Anonymized |
+| Orpheus TTS | `tts-orpheus` | $62.50 | 8 | Private |
+| Qwen 3 TTS 0.6B | `tts-qwen3-0-6b` | $87.50 | 9 | Private |
+| Qwen 3 TTS 1.7B | `tts-qwen3-1-7b` | $112.50 | 9 | Private |
+| xAI TTS v1 | `tts-xai-v1` | $18.75 | 26 | Anonymized |
+
+{/* AUTO-GENERATED:MODELS:END */}
+</div>
 
 ---
 
@@ -13,7 +33,273 @@ description: "Venice text-to-speech models with multilingual voices and streamin
 Voices are **model-specific**. The `voice` you pass must come from the catalog
 of the `model` you selected. Pick a model below to browse its voices.
 
-<div id="tts-voice-picker-placeholder">Loading voices...</div>
+<div id="tts-voice-picker-placeholder">
+{/* AUTO-GENERATED:VOICES:START */}
+
+#### Chatterbox HD (Resemble AI) (`tts-chatterbox-hd`)
+
+| Voice ID |
+|---|
+| `Aurora` |
+| `Blade` |
+| `Britney` |
+| `Carl` |
+| `Cliff` |
+| `Richard` |
+| `Rico` |
+| `Siobhan` |
+| `Vicky` |
+
+#### ElevenLabs Turbo v2.5 (`tts-elevenlabs-turbo-v2-5`)
+
+| Voice ID |
+|---|
+| `Alice` |
+| `Aria` |
+| `Bill` |
+| `Brian` |
+| `Callum` |
+| `Charlie` |
+| `Charlotte` |
+| `Chris` |
+| `Daniel` |
+| `Eric` |
+| `George` |
+| `Jessica` |
+| `Laura` |
+| `Liam` |
+| `Lily` |
+| `Matilda` |
+| `Rachel` |
+| `River` |
+| `Roger` |
+| `Sarah` |
+| `Will` |
+
+#### Gemini 3.1 Flash TTS (`tts-gemini-3-1-flash`)
+
+| Voice ID |
+|---|
+| `Achernar` |
+| `Achird` |
+| `Algenib` |
+| `Algieba` |
+| `Alnilam` |
+| `Aoede` |
+| `Autonoe` |
+| `Callirrhoe` |
+| `Charon` |
+| `Despina` |
+| `Enceladus` |
+| `Erinome` |
+| `Fenrir` |
+| `Gacrux` |
+| `Iapetus` |
+| `Kore` |
+| `Laomedeia` |
+| `Leda` |
+| `Orus` |
+| `Puck` |
+| `Pulcherrima` |
+| `Rasalgethi` |
+| `Sadachbia` |
+| `Sadaltager` |
+| `Schedar` |
+| `Sulafat` |
+| `Umbriel` |
+| `Vindemiatrix` |
+| `Zephyr` |
+| `Zubenelgenubi` |
+
+#### Gradium TTS (`tts-gradium-v1`)
+
+| Voice ID |
+|---|
+| `Alice` |
+| `Davi` |
+| `Elise` |
+| `Emma` |
+| `Eva` |
+| `Jack` |
+| `Kent` |
+| `Leo` |
+| `Maximilian` |
+| `Mia` |
+| `Sergio` |
+| `Valentina` |
+
+#### Inworld TTS-1.5 Max (`tts-inworld-1-5-max`)
+
+| Voice ID |
+|---|
+| `Alex` |
+| `Ashley` |
+| `Craig` |
+| `Edward` |
+| `Elizabeth` |
+| `Hades` |
+| `Luna` |
+| `Mark` |
+| `Olivia` |
+| `Pixie` |
+| `Priya` |
+| `Ronald` |
+| `Sarah` |
+| `Theodore` |
+
+#### Kokoro Text to Speech (`tts-kokoro`)
+
+| Voice ID |
+|---|
+| `af_alloy` |
+| `af_aoede` |
+| `af_bella` |
+| `af_heart` |
+| `af_jadzia` |
+| `af_jessica` |
+| `af_kore` |
+| `af_nicole` |
+| `af_nova` |
+| `af_river` |
+| `af_sarah` |
+| `af_sky` |
+| `am_adam` |
+| `am_echo` |
+| `am_eric` |
+| `am_fenrir` |
+| `am_liam` |
+| `am_michael` |
+| `am_onyx` |
+| `am_puck` |
+| `am_santa` |
+| `bf_alice` |
+| `bf_emma` |
+| `bf_lily` |
+| `bm_daniel` |
+| `bm_fable` |
+| `bm_george` |
+| `bm_lewis` |
+| `ef_dora` |
+| `em_alex` |
+| `em_santa` |
+| `ff_siwis` |
+| `hf_alpha` |
+| `hf_beta` |
+| `hm_omega` |
+| `hm_psi` |
+| `if_sara` |
+| `im_nicola` |
+| `jf_alpha` |
+| `jf_gongitsune` |
+| `jf_nezumi` |
+| `jf_tebukuro` |
+| `jm_kumo` |
+| `pf_dora` |
+| `pm_alex` |
+| `pm_santa` |
+| `zf_xiaobei` |
+| `zf_xiaoni` |
+| `zf_xiaoxiao` |
+| `zf_xiaoyi` |
+| `zm_yunjian` |
+| `zm_yunxi` |
+| `zm_yunxia` |
+| `zm_yunyang` |
+
+#### MiniMax Speech-02 HD (`tts-minimax-speech-02-hd`)
+
+| Voice ID |
+|---|
+| `CalmWoman` |
+| `CasualGuy` |
+| `DeepVoiceMan` |
+| `DeterminedMan` |
+| `ElegantMan` |
+| `ExuberantGirl` |
+| `FriendlyPerson` |
+| `ImposingManner` |
+| `InspirationalGirl` |
+| `LivelyGirl` |
+| `LovelyGirl` |
+| `PatientMan` |
+| `SweetGirl` |
+| `WiseWoman` |
+| `YoungKnight` |
+
+#### Orpheus TTS (`tts-orpheus`)
+
+| Voice ID |
+|---|
+| `dan` |
+| `jess` |
+| `leah` |
+| `leo` |
+| `mia` |
+| `tara` |
+| `zac` |
+| `zoe` |
+
+#### Qwen 3 TTS 0.6B (`tts-qwen3-0-6b`)
+
+| Voice ID |
+|---|
+| `Aiden` |
+| `Dylan` |
+| `Eric` |
+| `Ono_Anna` |
+| `Ryan` |
+| `Serena` |
+| `Sohee` |
+| `Uncle_Fu` |
+| `Vivian` |
+
+#### Qwen 3 TTS 1.7B (`tts-qwen3-1-7b`)
+
+| Voice ID |
+|---|
+| `Aiden` |
+| `Dylan` |
+| `Eric` |
+| `Ono_Anna` |
+| `Ryan` |
+| `Serena` |
+| `Sohee` |
+| `Uncle_Fu` |
+| `Vivian` |
+
+#### xAI TTS v1 (`tts-xai-v1`)
+
+| Voice ID |
+|---|
+| `altair` |
+| `ara` |
+| `atlas` |
+| `carina` |
+| `castor` |
+| `celeste` |
+| `cosmo` |
+| `eve` |
+| `helios` |
+| `helix` |
+| `iris` |
+| `kepler` |
+| `leo` |
+| `lumen` |
+| `luna` |
+| `lux` |
+| `naksh` |
+| `orion` |
+| `perseus` |
+| `rex` |
+| `rigel` |
+| `sal` |
+| `sirius` |
+| `ursa` |
+| `zagan` |
+| `zenith` |
+
+{/* AUTO-GENERATED:VOICES:END */}
+</div>
 
 <Note>
 Voice IDs are case-sensitive and **only valid for the matching `model`**. Pass

--- a/models/text.mdx
+++ b/models/text.mdx
@@ -4,7 +4,126 @@ description: "Venice chat, reasoning, and code models with context lengths, pric
 "og:title": "Text Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="text">Loading models...</div>
+<div id="model-search-placeholder" data-filter="text">
+{/* AUTO-GENERATED:MODELS:START */}
+
+Use the `id` value as the `model` parameter in API requests. 110 models currently available.
+
+| Model | ID | Input | Output | Context | Privacy | Capabilities |
+|---|---|---|---|---|---|---|
+| Aion 3.0 | `aion-labs-aion-3-0` | $3.75 | $7.50 | 128K | Anonymized | Function calling, Reasoning, Uncensored |
+| Aion 3.0 Mini | `aion-labs-aion-3-0-mini` | $0.88 | $1.75 | 128K | Anonymized | Function calling, Reasoning, Uncensored |
+| Claude Fable 5 | `claude-fable-5` | $12.00 | $60.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.5 | `claude-opus-4-5` | $6.00 | $30.00 | 198K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.6 | `claude-opus-4-6` | $6.00 | $30.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.7 | `claude-opus-4-7` | $6.00 | $30.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.8 | `claude-opus-4-8` | $6.00 | $30.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 4.8 Fast | `claude-opus-4-8-fast` | $12.00 | $60.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 5 | `claude-opus-5` | $6.00 | $30.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Opus 5 Fast | `claude-opus-5-fast` | $12.00 | $60.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5` | $3.75 | $18.75 | 198K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | $3.60 | $18.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Claude Sonnet 5 | `claude-sonnet-5` | $3.00 | $15.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| DeepSeek V3.2 | `deepseek-v3.2` | $0.33 | $0.48 | 160K | Private | Function calling, Reasoning |
+| DeepSeek V4 Flash | `e2ee-deepseek-v4-flash` | $0.18 | $0.37 | 1000K | E2EE · Private | Function calling, Reasoning, Code |
+| DeepSeek V4 Flash 0423 | `deepseek-v4-flash` | $0.14 | $0.28 | 1000K | Anonymized | Function calling, Reasoning, Code |
+| DeepSeek V4 Flash 0731 | `deepseek-v4-flash-0731` | $0.17 | $0.35 | 1000K | Private | Function calling, Reasoning, Code |
+| DeepSeek V4 Flash 0731 Fast | `deepseek-v4-flash-0731-fast` | $0.35 | $0.70 | 1000K | Private | Function calling, Reasoning, Code |
+| DeepSeek V4 Pro | `deepseek-v4-pro` | $1.65 | $3.30 | 1000K | Anonymized | Function calling, Reasoning, Code |
+| DeepSeek V4 Pro 0813 | `deepseek-v4-pro-0813` | $1.65 | $4.95 | 1000K | Private | Function calling, Reasoning, Code |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | $0.70 | $3.75 | 256K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.1 Pro Preview | `gemini-3-1-pro-preview` | $2.50 | $15.00 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.5 Flash | `gemini-3-5-flash` | $1.55 | $9.45 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.5 Flash-Lite | `gemini-3-5-flash-lite` | $0.38 | $3.13 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.6 Flash | `gemini-3-6-flash` | $1.88 | $9.38 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemini 3.7 Flash | `gemini-3-7-flash` | $1.88 | $9.38 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Gemma 3 27B | `e2ee-gemma-3-27b-p` | $0.14 | $0.50 | 40K | E2EE · Private | — |
+| Gemma 4 26B A4B Uncensored | `e2ee-gemma-4-26b-a4b-uncensored-p` | $0.19 | $0.88 | 64K | E2EE · Private | Uncensored |
+| Gemma 4 Uncensored | `gemma-4-uncensored` | $0.16 | $0.50 | 256K | Private | Function calling, Vision, Uncensored |
+| GLM 4.6 | `zai-org-glm-4.6` | $0.43 | $1.75 | 198K | Private | Function calling, Reasoning |
+| GLM 4.7 | `zai-org-glm-4.7` | $0.55 | $2.65 | 198K | Private | Function calling, Reasoning |
+| GLM 4.7 Flash | `zai-org-glm-4.7-flash` | $0.06 | $0.40 | 128K | Private | Function calling, Reasoning |
+| GLM 4.7 Flash Heretic | `olafangensan-glm-4.7-flash-heretic` | $0.07 | $0.40 | 200K | Private | Function calling, Reasoning, Uncensored |
+| GLM 5 | `zai-org-glm-5` | $1.00 | $3.20 | 198K | Private | Function calling, Reasoning, Code |
+| GLM 5 Turbo | `z-ai-glm-5-turbo` | $1.20 | $4.00 | 200K | Anonymized | Function calling, Reasoning, Code |
+| GLM 5.1 | `zai-org-glm-5-1` | $1.54 | $4.84 | 200K | Private | Function calling, Reasoning |
+| GLM 5.1 | `e2ee-glm-5-1` | $1.10 | $4.15 | 200K | E2EE · Private | Reasoning |
+| GLM 5.2 | `zai-org-glm-5-2` | $1.40 | $4.40 | 1000K | Private | Function calling, Reasoning, Code |
+| GLM 5.2 | `e2ee-glm-5-2-p` | $1.75 | $5.75 | 524K | E2EE · Private | Function calling, Reasoning, Code |
+| GLM 5.3 | `z-ai-glm-5-3` | $1.75 | $5.50 | 1000K | Anonymized | Function calling, Reasoning, Code |
+| GLM 5V Turbo | `z-ai-glm-5v-turbo` | $1.50 | $5.00 | 200K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Google Gemma 3 27B Instruct | `google-gemma-3-27b-it` | $0.12 | $0.20 | 198K | Private | Function calling, Vision |
+| Google Gemma 4 26B A4B Instruct | `google-gemma-4-26b-a4b-it` | $0.13 | $0.40 | 256K | Private | Function calling, Reasoning, Vision |
+| Google Gemma 4 31B Instruct | `google-gemma-4-31b-it` | $0.12 | $0.36 | 256K | Private | Function calling, Reasoning, Vision |
+| GPT OSS 120B | `e2ee-gpt-oss-120b-p` | $0.13 | $0.65 | 128K | E2EE · Private | Reasoning |
+| GPT OSS 20B | `e2ee-gpt-oss-20b-p` | $0.05 | $0.19 | 128K | E2EE · Private | Reasoning |
+| GPT-4o | `openai-gpt-4o-2024-11-20` | $3.13 | $12.50 | 128K | Anonymized | Function calling, Vision |
+| GPT-4o Mini | `openai-gpt-4o-mini-2024-07-18` | $0.19 | $0.75 | 128K | Anonymized | Function calling, Vision |
+| GPT-5.2 | `openai-gpt-52` | $2.19 | $17.50 | 256K | Anonymized | Function calling, Reasoning |
+| GPT-5.2 Codex | `openai-gpt-52-codex` | $2.19 | $17.50 | 256K | Anonymized | Function calling, Reasoning, Vision, Code |
+| GPT-5.3 Codex | `openai-gpt-53-codex` | $2.19 | $17.50 | 400K | Anonymized | Function calling, Reasoning, Vision, Code |
+| GPT-5.4 | `openai-gpt-54` | $3.13 | $18.80 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.4 Mini | `openai-gpt-54-mini` | $0.94 | $5.63 | 400K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.4 Pro | `openai-gpt-54-pro` | $37.50 | $225.00 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.5 | `openai-gpt-55` | $6.25 | $37.50 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.5 Pro | `openai-gpt-55-pro` | $37.50 | $225.00 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Luna | `openai-gpt-56-luna` | $0.27 | $1.60 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Luna Pro | `openai-gpt-56-luna-pro` | $1.25 | $7.50 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Sol | `openai-gpt-56-sol` | $6.25 | $37.50 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Sol Pro | `openai-gpt-56-sol-pro` | $6.25 | $37.50 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Terra | `openai-gpt-56-terra` | $3.13 | $18.75 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| GPT-5.6 Terra Pro | `openai-gpt-56-terra-pro` | $3.13 | $18.75 | 1000K | Anonymized | Function calling, Reasoning, Vision |
+| Grok 4.20 | `grok-4-20` | $1.42 | $2.83 | 2000K | Private | Function calling, Reasoning, Vision |
+| Grok 4.20 Multi-Agent | `grok-4-20-multi-agent` | $1.42 | $2.83 | 2000K | Private | Reasoning, Vision |
+| Grok 4.3 | `grok-4-3` | $1.42 | $2.83 | 1000K | Private | Function calling, Reasoning, Vision |
+| Grok 4.5 | `grok-4-5` | $2.27 | $6.80 | 500K | Private | Function calling, Reasoning, Vision, Code |
+| Grok 4.6 | `grok-4-6` | $2.27 | $6.80 | 500K | Private | Function calling, Reasoning, Vision, Code |
+| Grok Build 0.1 | `grok-build-0-1` | $1.00 | $2.00 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Hermes 3 Llama 3.1 405b | `hermes-3-llama-3.1-405b` | $1.10 | $3.00 | 128K | Private | — |
+| Inkling | `inkling` | $1.25 | $5.06 | 524K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K2.5 | `kimi-k2-5` | $0.56 | $3.50 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K2.6 | `kimi-k2-6` | $0.75 | $3.50 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K2.7 Code | `kimi-k2-7-code` | $0.75 | $3.50 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K3 | `kimi-k3` | $3.75 | $18.75 | 1000K | Private | Function calling, Reasoning, Vision, Code |
+| Kimi K3 Fast | `kimi-k3-fast-api` | $4.50 | $22.50 | 1000K | Private | Function calling, Reasoning, Vision, Code |
+| Llama 3.2 3B | `llama-3.2-3b` | $0.15 | $0.60 | 128K | Private | Function calling |
+| Llama 3.3 70B | `llama-3.3-70b` | $0.70 | $2.80 | 128K | Private | Function calling |
+| Mercury 2 | `mercury-2` | $0.31 | $0.94 | 128K | Anonymized | Function calling, Reasoning |
+| MiMo-V2.5 | `xiaomi-mimo-v2-5` | $0.40 | $2.00 | 1000K | Private | Function calling, Reasoning, Vision, Code |
+| MiniMax M2.5 | `minimax-m25` | $0.27 | $0.95 | 198K | Private | Function calling, Reasoning, Code |
+| MiniMax M2.7 | `minimax-m27` | $0.38 | $1.50 | 198K | Private | Function calling, Reasoning, Code |
+| MiniMax M3 Preview | `minimax-m3-preview` | $0.30 | $1.20 | 524K | Private | Function calling, Reasoning, Vision, Code |
+| Mistral Small 3.2 24B Instruct | `mistral-small-3-2-24b-instruct` | $0.09 | $0.25 | 256K | Private | Function calling |
+| Mistral Small 4 | `mistral-small-2603` | $0.19 | $0.75 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| NVIDIA Nemotron 3 Nano 30B | `nvidia-nemotron-3-nano-30b-a3b` | $0.07 | $0.30 | 128K | Private | Function calling |
+| NVIDIA Nemotron 3 Ultra | `nvidia-nemotron-3-ultra-550b-a55b` | $0.63 | $3.13 | 256K | Private | Function calling, Reasoning |
+| OpenAI GPT OSS 120B | `openai-gpt-oss-120b` | $0.07 | $0.30 | 128K | Private | Function calling, Reasoning |
+| Ox Alpha (Beta) | `stealth-ox-alpha` | $0.00 | $0.00 | 1049K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen 2.5 7B | `e2ee-qwen-2-5-7b-p` | $0.05 | $0.13 | 32K | E2EE · Private | — |
+| Qwen 3 235B A22B Instruct 2507 | `qwen3-235b-a22b-instruct-2507` | $0.15 | $0.75 | 128K | Private | Function calling |
+| Qwen 3 235B A22B Thinking 2507 | `qwen3-235b-a22b-thinking-2507` | $0.45 | $3.50 | 128K | Private | Function calling, Reasoning |
+| Qwen 3 Coder 480B Turbo | `qwen3-coder-480b-a35b-instruct-turbo` | $0.35 | $1.50 | 256K | Private | Function calling, Code |
+| Qwen 3 Next 80b | `qwen3-next-80b` | $0.35 | $1.90 | 256K | Private | Function calling |
+| Qwen 3.5 35B A3B | `qwen3-5-35b-a3b` | $0.31 | $1.25 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Qwen 3.5 397B | `qwen3-5-397b-a17b` | $0.75 | $4.50 | 128K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen 3.5 9B | `qwen3-5-9b` | $0.10 | $0.15 | 256K | Private | Function calling, Reasoning, Vision |
+| Qwen 3.6 27B | `qwen3-6-27b` | $0.33 | $3.25 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Qwen 3.6 35B A3B (Beta) | `qwen3-6-35b-a3b` | $0.10 | $1.00 | 256K | Private | Function calling, Reasoning, Vision, Code |
+| Qwen 3.6 35B A3B FP8 | `e2ee-qwen3-6-35b-a3b` | $0.18 | $1.18 | 32K | E2EE · Private | Function calling, Reasoning, Code |
+| Qwen 3.6 Plus Uncensored | `qwen-3-6-plus` | $0.63 | $3.75 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code, Uncensored |
+| Qwen 3.7 Max | `qwen-3-7-max` | $2.70 | $8.05 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen 3.7 Plus | `qwen-3-7-plus` | $0.50 | $2.00 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen 3.8 2.4T | `qwen-3-8-2-4t-a95b` | $2.50 | $7.50 | 262K | Private | Function calling, Reasoning, Code |
+| Qwen 3.8 27B (Beta) | `qwen-3-8-27b` | $0.45 | $3.20 | 262K | Private | Function calling, Reasoning, Vision, Code, Uncensored |
+| Qwen 3.8 Max | `qwen-3-8-max` | $2.50 | $7.50 | 1000K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Qwen3 VL 235B | `qwen3-vl-235b-a22b` | $0.21 | $1.90 | 128K | Private | Function calling, Vision |
+| Qwen3 VL 30B A3B | `e2ee-qwen3-vl-30b-a3b-p` | $0.25 | $0.90 | 128K | E2EE · Private | Function calling, Vision |
+| Seed 2.1 Turbo | `seed-2-1-turbo` | $0.63 | $3.13 | 256K | Anonymized | Function calling, Reasoning, Vision, Code |
+| Venice Role Play Uncensored | `venice-uncensored-role-play` | $0.50 | $2.00 | 128K | Private | Function calling, Vision, Uncensored |
+| Venice Uncensored 1.2 | `venice-uncensored-1-2` | $0.20 | $0.90 | 128K | Private | Function calling, Vision, Uncensored |
+
+{/* AUTO-GENERATED:MODELS:END */}
+</div>
 
 ---
 

--- a/models/video.mdx
+++ b/models/video.mdx
@@ -4,7 +4,134 @@ description: "Venice video models for text-to-video, image-to-video, and Topaz u
 "og:title": "Video Models | Venice API Docs"
 ---
 
-<div id="model-search-placeholder" data-filter="video">Loading models...</div>
+<div id="model-search-placeholder" data-filter="video">
+{/* AUTO-GENERATED:MODELS:START */}
+
+Use the `id` value as the `model` parameter in API requests. 118 models currently available.
+
+| Model | ID | Type | Pricing | Privacy |
+|---|---|---|---|---|
+| Flux 3 | `flux-3-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Flux 3 | `flux-3-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Flux 3 First Last Frame | `flux-3-first-last-frame-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Gemini Omni Flash | `gemini-omni-flash-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Gemini Omni Flash | `gemini-omni-flash-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Gemini Omni Flash R2V | `gemini-omni-flash-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Grok Imagine | `grok-imagine-text-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| Grok Imagine | `grok-imagine-image-to-video-private` | Image to Video | Variable — use Video Quote API | Private |
+| Grok Imagine | `grok-imagine-video-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| Grok Imagine 1.5 | `grok-imagine-1-5-text-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| Grok Imagine 1.5 | `grok-imagine-1-5-image-to-video-private` | Image to Video | Variable — use Video Quote API | Private |
+| Grok Imagine 1.5 R2V | `grok-imagine-1-5-reference-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| Grok Imagine R2V | `grok-imagine-reference-to-video-private` | Text to Video | Variable — use Video Quote API | Private |
+| HappyHorse 1.0 | `happyhorse-1-0-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.0 | `happyhorse-1-0-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.0 Edit | `happyhorse-1-0-video-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.0 Reference | `happyhorse-1-0-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.1 | `happyhorse-1-1-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.1 | `happyhorse-1-1-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| HappyHorse 1.1 Reference | `happyhorse-1-1-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling 2.5 Turbo Pro | `kling-2.5-turbo-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling 2.5 Turbo Pro | `kling-2.5-turbo-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling 2.6 Pro | `kling-2.6-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling 2.6 Pro | `kling-2.6-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 4K | `kling-o3-4k-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 4K | `kling-o3-4k-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 4K R2V | `kling-o3-4k-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Pro | `kling-o3-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Pro | `kling-o3-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Pro R2V | `kling-o3-pro-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Standard | `kling-o3-standard-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Standard | `kling-o3-standard-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling O3 Standard R2V | `kling-o3-standard-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 4K | `kling-v3-4k-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 4K R2V | `kling-v3-4k-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Pro | `kling-v3-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Pro | `kling-v3-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Pro Motion Control | `kling-v3-pro-motion-control` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Standard | `kling-v3-standard-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Standard | `kling-v3-standard-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Standard Motion Control | `kling-v3-standard-motion-control` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Turbo Pro | `kling-v3-turbo-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Turbo Pro | `kling-v3-turbo-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Turbo Standard | `kling-v3-turbo-standard-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Kling V3 Turbo Standard | `kling-v3-turbo-standard-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Longcat Distilled | `longcat-distilled-image-to-video` | Image to Video | Variable — use Video Quote API | Private |
+| Longcat Distilled | `longcat-distilled-text-to-video` | Text to Video | Variable — use Video Quote API | Private |
+| Longcat Full Quality | `longcat-image-to-video` | Image to Video | Variable — use Video Quote API | Private |
+| Longcat Full Quality | `longcat-text-to-video` | Text to Video | Variable — use Video Quote API | Private |
+| LTX Video 2.3 Fast | `ltx-2-v2-3-fast-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.3 Fast | `ltx-2-v2-3-fast-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.3 Full Quality | `ltx-2-v2-3-full-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.3 Full Quality | `ltx-2-v2-3-full-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.5 Fast | `ltx-2-5-fast-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.5 Fast | `ltx-2-5-fast-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.5 Pro | `ltx-2-5-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| LTX Video 2.5 Pro | `ltx-2-5-pro-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 | `minimax-h3-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 | `minimax-h3-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 Enhanced | `minimax-h3-enhanced-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 R2V | `minimax-h3-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| MiniMax H3 R2V Enhanced | `minimax-h3-enhanced-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Ovi | `ovi-image-to-video` | Image to Video | Variable — use Video Quote API | Private |
+| PixVerse C1 | `pixverse-c1-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse C1 | `pixverse-c1-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse C1 R2V | `pixverse-c1-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse C1 Transition | `pixverse-c1-transition` | Text to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse v5.6 | `pixverse-v5.6-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse v5.6 | `pixverse-v5.6-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| PixVerse v5.6 Transition | `pixverse-v5.6-transition` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Runway Gen-4 Turbo | `runway-gen4-turbo` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Runway Gen-4.5 | `runway-gen4-5` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Runway Gen-4.5 | `runway-gen4-5-text` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 1.5 Pro | `seedance-1-5-pro-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 1.5 Pro | `seedance-1-5-pro-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 | `seedance-2-0-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 | `seedance-2-0-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Fast | `seedance-2-0-fast-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Fast | `seedance-2-0-fast-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Fast R2V | `seedance-2-0-fast-reference-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Mini | `seedance-2-0-mini-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Mini | `seedance-2-0-mini-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 Mini R2V | `seedance-2-0-mini-reference-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.0 R2V | `seedance-2-0-reference-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.5 | `seedance-2-5-text-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.5 | `seedance-2-5-image-to-video-basic` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Seedance 2.5 R2V | `seedance-2-5-reference-to-video-basic` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Topaz Video Upscale | `topaz-video-upscale` | Video Upscale | Variable — use Video Quote API | Anonymized |
+| Veo 3 Fast | `veo3-fast-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3 Fast | `veo3-fast-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3 Full Quality | `veo3-full-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3 Full Quality | `veo3-full-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3.1 Fast | `veo3.1-fast-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3.1 Fast | `veo3.1-fast-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3.1 Full Quality | `veo3.1-full-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Veo 3.1 Full Quality | `veo3.1-full-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Vidu Q3 | `vidu-q3-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Vidu Q3 | `vidu-q3-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.1 Pro | `wan-2.1-pro-image-to-video` | Image to Video | Variable — use Video Quote API | Private |
+| Wan 2.2 A14B | `wan-2.2-a14b-text-to-video` | Text to Video | Variable — use Video Quote API | Private |
+| Wan 2.2 Enhanced | `wan-2-2-enhanced-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.5 Preview | `wan-2.5-preview-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.5 Preview | `wan-2.5-preview-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.6 | `wan-2.6-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.6 | `wan-2.6-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.6 Flash | `wan-2.6-flash-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 | `wan-2-7-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 | `wan-2-7-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 Edit | `wan-2-7-video-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 Enhanced | `wan-2-7-enhanced-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 Enhanced | `wan-2-7-enhanced-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 2.7 Reference | `wan-2-7-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 | `wan-3-0-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 | `wan-3-0-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 Prime | `wan-3-0-prime-text-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 Prime | `wan-3-0-prime-image-to-video` | Image to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 Prime Reference | `wan-3-0-prime-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+| Wan 3.0 Reference | `wan-3-0-reference-to-video` | Text to Video | Variable — use Video Quote API | Anonymized |
+
+{/* AUTO-GENERATED:MODELS:END */}
+</div>
 
 ## Model Types
 

--- a/scripts/generate-deprecations-static.js
+++ b/scripts/generate-deprecations-static.js
@@ -58,10 +58,6 @@ function tableCell(value) {
   return String(value).replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
 }
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function renderTraitsList(traits) {
   const entries = sortTraits(traits);
   if (entries.length === 0) return 'No text model traits are currently available.';
@@ -167,29 +163,13 @@ function updateDeprecationsPage(page, traits, models) {
 }
 
 function updateTraitsApiPage(page, traits) {
-  const section = [
+  return replacePlaceholder(
+    page,
+    'traits-list-placeholder',
     API_TRAITS_START,
-    '## Current text trait mappings',
-    '',
-    'These mappings are refreshed automatically from the public API.',
-    '',
-    renderTraitsList(traits),
-    API_TRAITS_END
-  ].join('\n');
-
-  const legacyStart = '<!-- AUTO-GENERATED:API-TRAITS:START -->';
-  const legacyEnd = '<!-- AUTO-GENERATED:API-TRAITS:END -->';
-  const existingPattern = new RegExp([
-    `${escapeRegExp(API_TRAITS_START)}[\\s\\S]*?${escapeRegExp(API_TRAITS_END)}`,
-    `${escapeRegExp(legacyStart)}[\\s\\S]*?${escapeRegExp(legacyEnd)}`
-  ].join('|'));
-  if (existingPattern.test(page)) return page.replace(existingPattern, section);
-
-  const separator = '-------';
-  if (!page.includes(separator)) {
-    throw new Error('Missing OpenAPI separator in traits endpoint page');
-  }
-  return page.replace(separator, `${section}\n\n${separator}`);
+    API_TRAITS_END,
+    renderTraitsList(traits)
+  );
 }
 
 function writeIfChanged(filePath, content) {

--- a/scripts/generate-models-static.js
+++ b/scripts/generate-models-static.js
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+/**
+ * Bake snapshot-backed model catalogs into /models MDX placeholders so
+ * Mintlify's assistant can index the lists. Browser JavaScript still replaces
+ * the same placeholders with the interactive UI.
+ *
+ * Usage: node scripts/generate-models-static.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const SNAPSHOT_PATH = path.join(ROOT, 'data', 'static-models.json');
+
+const MODELS_START = '{/* AUTO-GENERATED:MODELS:START */}';
+const MODELS_END = '{/* AUTO-GENERATED:MODELS:END */}';
+const VOICES_START = '{/* AUTO-GENERATED:VOICES:START */}';
+const VOICES_END = '{/* AUTO-GENERATED:VOICES:END */}';
+
+const PRIVATE_TYPES = new Set(['upscale']);
+
+function readModels() {
+  if (!fs.existsSync(SNAPSHOT_PATH)) {
+    throw new Error('Missing data/static-models.json');
+  }
+  const models = JSON.parse(fs.readFileSync(SNAPSHOT_PATH, 'utf-8'));
+  if (!Array.isArray(models)) throw new Error('Model snapshot must be an array');
+  return models;
+}
+
+function formatPrice(price) {
+  if (price === null || price === undefined) return '—';
+  if (price < 0.01 && price > 0) return '$' + price.toFixed(4);
+  return '$' + price.toFixed(2);
+}
+
+function inlineCode(value) {
+  return `\`${String(value).replace(/`/g, '\\`')}\``;
+}
+
+function tableCell(value) {
+  return String(value ?? '').replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+}
+
+function isDeprecatedModel(model) {
+  const dep = model.model_spec?.deprecation;
+  return dep != null && (dep.date != null || dep.removesAt != null);
+}
+
+function isBetaModel(model) {
+  return model.model_spec?.betaModel === true;
+}
+
+function isE2EEModel(model) {
+  const caps = model.model_spec?.capabilities || {};
+  const modelId = (model.id || '').toLowerCase();
+  return caps.supportsE2EE === true || modelId.startsWith('e2ee-');
+}
+
+function isTEEModel(model) {
+  const caps = model.model_spec?.capabilities || {};
+  const modelId = (model.id || '').toLowerCase();
+  return caps.supportsTeeAttestation === true || modelId.startsWith('tee-') || isE2EEModel(model);
+}
+
+function isAnonymizedModel(model) {
+  if (PRIVATE_TYPES.has(model.type)) return false;
+  return model.model_spec?.privacy === 'anonymized';
+}
+
+function getPrivacyLabel(model) {
+  if (isE2EEModel(model)) return 'E2EE · Private';
+  if (isTEEModel(model)) return 'TEE · Private';
+  if (isAnonymizedModel(model)) return 'Anonymized';
+  return 'Private';
+}
+
+function getModelName(model) {
+  const name = model.model_spec?.name || model.id;
+  return isBetaModel(model) ? `${name} (Beta)` : name;
+}
+
+function formatContext(model) {
+  const tokens = model.model_spec?.availableContextTokens;
+  if (!tokens) return '—';
+  return tokens >= 1000 ? `${Math.round(tokens / 1000)}K` : String(tokens);
+}
+
+function getCapabilityLabels(model) {
+  const caps = model.model_spec?.capabilities || {};
+  const labels = [];
+  if (caps.supportsFunctionCalling) labels.push('Function calling');
+  if (caps.supportsReasoning) labels.push('Reasoning');
+  if (caps.supportsVision) labels.push('Vision');
+  if (caps.optimizedForCode) labels.push('Code');
+  if (model.model_spec?.uncensored) labels.push('Uncensored');
+  return labels.join(', ') || '—';
+}
+
+function sortByName(models) {
+  return [...models].sort((a, b) => {
+    const nameA = a.model_spec?.name || a.id;
+    const nameB = b.model_spec?.name || b.id;
+    return nameA.localeCompare(nameB);
+  });
+}
+
+function liveModels(models, predicate) {
+  return sortByName(models.filter(predicate).filter(m => !isDeprecatedModel(m)));
+}
+
+function markdownTable(headers, rows) {
+  const header = `| ${headers.join(' | ')} |`;
+  const divider = `|${headers.map(() => '---').join('|')}|`;
+  if (rows.length === 0) {
+    const empty = headers.map((_, i) => (i === 0 ? 'No models available.' : '—'));
+    return [header, divider, `| ${empty.join(' | ')} |`].join('\n');
+  }
+  return [header, divider, ...rows.map(cols => `| ${cols.join(' | ')} |`)].join('\n');
+}
+
+function row(model, extraCols = []) {
+  return [
+    tableCell(getModelName(model)),
+    inlineCode(model.id),
+    ...extraCols
+  ];
+}
+
+function formatImagePrice(model) {
+  const pricing = model.model_spec?.pricing || {};
+  if (model.type === 'upscale') {
+    const upscale = pricing.upscale || {};
+    const parts = [];
+    if (upscale['2x']?.usd != null) parts.push(`2x ${formatPrice(upscale['2x'].usd)}`);
+    if (upscale['4x']?.usd != null) parts.push(`4x ${formatPrice(upscale['4x'].usd)}`);
+    return parts.join(', ') || formatPrice(pricing.generation?.usd);
+  }
+  if (model.type === 'inpaint' || pricing.inpaint) {
+    const extra = pricing.inputImages?.additional?.usd;
+    const base = formatPrice(pricing.inpaint?.usd);
+    return extra != null ? `${base} / extra image ${formatPrice(extra)}` : base;
+  }
+  if (pricing.resolutions) {
+    return Object.keys(pricing.resolutions)
+      .map(res => `${res}: ${formatPrice(pricing.resolutions[res]?.usd)}`)
+      .join(', ');
+  }
+  if (pricing.generation?.usd != null) return formatPrice(pricing.generation.usd);
+  return '—';
+}
+
+function formatMusicPrice(model) {
+  const pricing = model.model_spec?.pricing || {};
+  if (pricing.durations) return 'Duration-tiered — use Audio Quote API';
+  if (pricing.generation?.usd != null) return `${formatPrice(pricing.generation.usd)} / generation`;
+  if (pricing.per_second?.usd != null) return `${formatPrice(pricing.per_second.usd)} / second`;
+  return 'See Audio Quote API';
+}
+
+function getVideoType(modelId) {
+  if (modelId.includes('image-to-video')) return 'Image to Video';
+  if (modelId.includes('text-to-video')) return 'Text to Video';
+  if (modelId.includes('-i2v') || modelId.endsWith('-itv')) return 'Image to Video';
+  if (modelId.includes('upscale') || modelId.includes('topaz')) return 'Video Upscale';
+  return 'Text to Video';
+}
+
+function renderCatalogIntro(count) {
+  const noun = count === 1 ? 'model' : 'models';
+  return `Use the \`id\` value as the \`model\` parameter in API requests. ${count} ${noun} currently available.`;
+}
+
+function renderTextTable(models) {
+  const rows = liveModels(models, m => m.type === 'text').map(model => {
+    const pricing = model.model_spec?.pricing || {};
+    return row(model, [
+      formatPrice(pricing.input?.usd),
+      formatPrice(pricing.output?.usd),
+      formatContext(model),
+      getPrivacyLabel(model),
+      tableCell(getCapabilityLabels(model))
+    ]);
+  });
+  return markdownTable(
+    ['Model', 'ID', 'Input', 'Output', 'Context', 'Privacy', 'Capabilities'],
+    rows
+  );
+}
+
+function renderImageTables(models) {
+  const sections = [
+    ['Generation', liveModels(models, m => m.type === 'image')],
+    ['Upscaling', liveModels(models, m => m.type === 'upscale')],
+    ['Editing', liveModels(models, m => m.type === 'inpaint')]
+  ];
+
+  return sections.map(([heading, group]) => {
+    const table = markdownTable(
+      ['Model', 'ID', 'Price', 'Privacy'],
+      group.map(model => row(model, [tableCell(formatImagePrice(model)), getPrivacyLabel(model)]))
+    );
+    return `#### ${heading}\n\n${table}`;
+  }).join('\n\n');
+}
+
+function renderVideoTable(models) {
+  const rows = liveModels(models, m => m.type === 'video').map(model => row(model, [
+    getVideoType(model.id),
+    'Variable — use Video Quote API',
+    getPrivacyLabel(model)
+  ]));
+  return markdownTable(['Model', 'ID', 'Type', 'Pricing', 'Privacy'], rows);
+}
+
+function renderTtsTable(models) {
+  const rows = liveModels(models, m => m.type === 'tts').map(model => {
+    const voices = model.model_spec?.voices || [];
+    return row(model, [
+      formatPrice(model.model_spec?.pricing?.input?.usd),
+      String(voices.length),
+      getPrivacyLabel(model)
+    ]);
+  });
+  return markdownTable(['Model', 'ID', 'Per 1M characters', 'Voices', 'Privacy'], rows);
+}
+
+function renderVoiceTables(models) {
+  const ttsModels = liveModels(models, m => m.type === 'tts');
+  if (ttsModels.length === 0) return 'No voices available.';
+
+  return ttsModels.map(model => {
+    const voices = model.model_spec?.voices || [];
+    const table = markdownTable(
+      ['Voice ID'],
+      voices.map(voice => [inlineCode(voice)])
+    );
+    return `#### ${tableCell(getModelName(model))} (${inlineCode(model.id)})\n\n${table}`;
+  }).join('\n\n');
+}
+
+function renderAsrTable(models) {
+  const rows = liveModels(models, m => m.type === 'asr').map(model => {
+    const pricing = model.model_spec?.pricing || {};
+    const price = pricing.per_audio_second?.usd ?? pricing.input?.usd;
+    return row(model, [formatPrice(price), getPrivacyLabel(model)]);
+  });
+  return markdownTable(['Model', 'ID', 'Per audio second', 'Privacy'], rows);
+}
+
+function renderMusicTable(models) {
+  const rows = liveModels(models, m => m.type === 'music').map(model => row(model, [
+    tableCell(formatMusicPrice(model)),
+    getPrivacyLabel(model)
+  ]));
+  return markdownTable(['Model', 'ID', 'Pricing', 'Privacy'], rows);
+}
+
+function renderEmbeddingTable(models) {
+  const rows = liveModels(models, m => m.type === 'embedding').map(model => row(model, [
+    formatPrice(model.model_spec?.pricing?.input?.usd),
+    getPrivacyLabel(model)
+  ]));
+  return markdownTable(['Model', 'ID', 'Input (per 1M tokens)', 'Privacy'], rows);
+}
+
+function renderOverviewTables(models) {
+  const groups = [
+    ['Text', m => m.type === 'text', renderTextTable],
+    ['Image', m => m.type === 'image' || m.type === 'upscale' || m.type === 'inpaint', renderImageTables],
+    ['Video', m => m.type === 'video', renderVideoTable],
+    ['Text-to-Speech', m => m.type === 'tts', renderTtsTable],
+    ['Speech-to-Text', m => m.type === 'asr', renderAsrTable],
+    ['Music', m => m.type === 'music', renderMusicTable],
+    ['Embeddings', m => m.type === 'embedding', renderEmbeddingTable]
+  ];
+
+  const live = models.filter(m => !isDeprecatedModel(m));
+  const sections = groups.map(([heading, predicate, render]) => {
+    const count = live.filter(predicate).length;
+    return `### ${heading} (${count})\n\n${render(models)}`;
+  });
+
+  return `${renderCatalogIntro(live.length)}\n\n${sections.join('\n\n')}`;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Mintlify's .md export keeps markdown tables inside a plain placeholder
+// <div> (same pattern as overview/pricing.mdx). Visibility-for-agents
+// dropped the model catalogs on the published export.
+function upsertCatalogBlock(page, { id, startMarker, endMarker, content }) {
+  const attrMatch = page.match(new RegExp(`<div id="${escapeRegExp(id)}"([^>]*)>`));
+  const attrs = attrMatch ? attrMatch[1] : '';
+
+  const block = [
+    `<div id="${id}"${attrs}>`,
+    startMarker,
+    '',
+    content,
+    '',
+    endMarker,
+    `</div>`
+  ].join('\n');
+
+  const divPattern = new RegExp(`<div id="${escapeRegExp(id)}"[^>]*>[\\s\\S]*?<\\/div>`);
+  if (divPattern.test(page)) {
+    return page.replace(divPattern, () => block);
+  }
+
+  throw new Error(`Missing ${id} placeholder`);
+}
+
+function writeIfChanged(filePath, content) {
+  const current = fs.readFileSync(filePath, 'utf-8');
+  if (current === content) {
+    console.log(`${path.relative(ROOT, filePath)} already up to date`);
+    return;
+  }
+  fs.writeFileSync(filePath, content, 'utf-8');
+  console.log(`Updated ${path.relative(ROOT, filePath)}`);
+}
+
+function updatePage(relativePath, id, startMarker, endMarker, content) {
+  const filePath = path.join(ROOT, relativePath);
+  const page = fs.readFileSync(filePath, 'utf-8');
+  writeIfChanged(
+    filePath,
+    upsertCatalogBlock(page, { id, startMarker, endMarker, content })
+  );
+}
+
+function withIntro(count, table) {
+  return `${renderCatalogIntro(count)}\n\n${table}`;
+}
+
+function main() {
+  const models = readModels();
+  const live = models.filter(m => !isDeprecatedModel(m));
+
+  updatePage(
+    'models/overview.mdx',
+    'model-search-placeholder',
+    MODELS_START,
+    MODELS_END,
+    renderOverviewTables(models)
+  );
+  updatePage(
+    'models/text.mdx',
+    'model-search-placeholder',
+    MODELS_START,
+    MODELS_END,
+    withIntro(live.filter(m => m.type === 'text').length, renderTextTable(models))
+  );
+  updatePage(
+    'models/image.mdx',
+    'model-search-placeholder',
+    MODELS_START,
+    MODELS_END,
+    withIntro(
+      live.filter(m => m.type === 'image' || m.type === 'upscale' || m.type === 'inpaint').length,
+      renderImageTables(models)
+    )
+  );
+  updatePage(
+    'models/video.mdx',
+    'model-search-placeholder',
+    MODELS_START,
+    MODELS_END,
+    withIntro(live.filter(m => m.type === 'video').length, renderVideoTable(models))
+  );
+  updatePage(
+    'models/text-to-speech.mdx',
+    'model-search-placeholder',
+    MODELS_START,
+    MODELS_END,
+    withIntro(live.filter(m => m.type === 'tts').length, renderTtsTable(models))
+  );
+  updatePage(
+    'models/text-to-speech.mdx',
+    'tts-voice-picker-placeholder',
+    VOICES_START,
+    VOICES_END,
+    renderVoiceTables(models)
+  );
+  updatePage(
+    'models/speech-to-text.mdx',
+    'model-search-placeholder',
+    MODELS_START,
+    MODELS_END,
+    withIntro(live.filter(m => m.type === 'asr').length, renderAsrTable(models))
+  );
+  updatePage(
+    'models/music.mdx',
+    'model-search-placeholder',
+    MODELS_START,
+    MODELS_END,
+    withIntro(live.filter(m => m.type === 'music').length, renderMusicTable(models))
+  );
+  updatePage(
+    'models/embeddings.mdx',
+    'model-search-placeholder',
+    MODELS_START,
+    MODELS_END,
+    withIntro(live.filter(m => m.type === 'embedding').length, renderEmbeddingTable(models))
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error('Error generating static model catalogs:', error.message);
+  process.exit(1);
+}

--- a/scripts/update-static-models.js
+++ b/scripts/update-static-models.js
@@ -119,6 +119,9 @@ async function main() {
   console.log('Regenerating traits and deprecations...');
   require('./generate-deprecations-static.js');
 
+  console.log('Regenerating static model catalogs...');
+  require('./generate-models-static.js');
+
   console.log('Regenerating pricing.mdx...');
   require('./generate-pricing-static.js');
 }


### PR DESCRIPTION
## Summary

The eight `/models` pages contribute nothing but `<div>Loading models...</div>` to the published Markdown — `llms-full.txt` contains that placeholder 8 times and no model IDs or prices. `overview/pricing.mdx` already solves this by keeping generated tables inside the placeholder `<div>` that the browser later replaces, and that table appears in both `overview/pricing.md` and `llms-full.txt` in production today.

This reapplies the catalog effort from #449 / #450, reverted by #451, on that proven pattern. The revert reason was that Mintlify's in-docs assistant still treated the catalog as unavailable; the freshness objection is now gone because `sync-static-models.yml` regenerates the snapshot on every Outerface deploy (`repository_dispatch: outerface-deployed`, added in #464) rather than only hourly.

**Success criteria are deliberately narrower than last time.** This is judged on the published Markdown, which we control and can verify, not on the in-docs assistant, which we cannot and which is what sank the previous attempt.

### Difference from the reverted attempt

The traits endpoint page uses the placeholder `<div>` instead of `<Visibility for="agents">`. Restoring the Visibility wrapper would have regressed that page: it is exactly what #450 found Mintlify strips from the `.md` export, no page in the repo uses it today, and the current plain page *does* export its mappings. That page comes out ahead — agents keep the list in the export, and humans gain the live-refreshed list it previously lacked. The now-dead Visibility migration branches are removed from both generators.

Locale pages are intentionally untouched; the translation pass syncs them, as it already does for the pricing tables.

## Test plan

Verified locally:

- [x] `npx mint@latest validate` exits 0, "build validation passed", zero errors
- [x] `node scripts/update-static-models.js` (the CI entry point) runs green and is idempotent — 334 models fetched, every generated page reports "already up to date", so the committed tables are byte-identical to what CI produces
- [x] Baked tables reach the server-rendered HTML. `/models/text` before: 482,619 bytes, 0 `claude-fable-5`, 0 table cells. After: 617,334 bytes, `claude-fable-5` ×2, table present — matching the known-good pricing page
- [x] Built `mint export` artifact `models/text/index.html` contains the catalog
- [x] No double render for humans: `init()` calls `placeholder.replaceWith(container)`, and `hideStaleModelPlaceholders()` covers Mintlify's client-side navigation
- [x] Merge preserves the `outerface-deployed` trigger and the free-model display work from #470

Cannot be checked before merge — `.md` and `llms-full.txt` are generated by the hosted build. `mint dev` 404s on `/models/text.md`, but it also 404s on `/overview/pricing.md`, which works in production, so that is a dev-server limitation rather than a problem with these pages. `mint export` emits no `.md` files at all.

After merge:

- [ ] `curl -sL https://docs.venice.ai/models/text.md` contains real model IDs, not `Loading models...`
- [ ] `Loading models` count in `llms-full.txt` drops from 8 to 0
- [ ] `/models/text` still mounts the interactive browser for humans
- [ ] The next `sync-static-models` run commits cleanly with the model pages in its diff list

## Note

Unrelated pre-existing issue found while testing: the repo's pinned local tooling is broken. `./node_modules/.bin/mint validate` and `dev` both fail with "Unable to parse page metadata" on 857 of 1197 files, including valid English pages, on a clean `main` as well as this branch. The error set is non-deterministic (334 vs 1114 errors on consecutive runs of the same commit) and `.nvmrc`'s Node v20.17.0 fails the same way, while `npx mint@latest` works. Likely the `resolutions` block in `package.json` colliding with Mintlify's frontmatter parser. Happy to fix in a separate PR.

Made with [Cursor](https://cursor.com)