### PR TITLE
docs: correct API contracts that return 400 or misstate limits

### DIFF
--- a/api-reference/api-spec.mdx
+++ b/api-reference/api-spec.mdx
@@ -12,7 +12,7 @@ The Venice API offers HTTP-based REST and streaming interfaces for building AI a
 The Venice API uses API keys for authentication. Create and manage your API keys in your [API settings](https://venice.ai/settings/api?utm_source=venice-api-documentation).
 
 
-All API requests require HTTP Bearer authentication:
+Most API requests require HTTP Bearer authentication. A few discovery endpoints — including `GET /models`, `GET /models/traits`, `GET /models/compatibility_mapping`, and `GET /image/styles` — are readable without a key:
 
 ```
 Authorization: Bearer VENICE_API_KEY
@@ -21,6 +21,19 @@ Authorization: Bearer VENICE_API_KEY
 <Note>
 Your API key is a secret. Do not share it or expose it in any client-side code.
 </Note>
+
+### Key types
+
+Keys are either `INFERENCE` or `ADMIN`. Inference keys can call the inference endpoints — chat, image, video, audio, embeddings, and the augmentation endpoints. Account-management endpoints require an `ADMIN` key:
+
+| Endpoint | Key required |
+|---|---|
+| `GET/POST/PATCH/DELETE /api_keys`, `GET /api_keys/{id}` | `ADMIN` |
+| `GET /api_keys/rate_limits/log` | `ADMIN` |
+| `GET /api_keys/rate_limits` | Either |
+| `GET /billing/balance`, `/billing/usage-history`, `/billing/usage-analytics` | `ADMIN` |
+
+Calling an admin-only endpoint with an inference key returns `401` with `{"error":"Admin API key required"}`. Note that `GET /api_keys/rate_limits` is the one exception in that group — it works with either key type.
 
 ## OpenAI Compatibility
 
@@ -152,7 +165,7 @@ The `venice_parameters` object allows you to access Venice-specific features not
 | `enable_web_search` | string | Enable web search for this request (`off`, `on`, `auto` - auto enables based on model's discretion)<br/>Additional usage-based pricing applies, see [pricing](/overview/pricing#web-search-and-scraping). | `off` |
 | `enable_web_scraping` | boolean | Enable web scraping of up to 5 URLs detected in the user message. Scraped content augments responses and bypasses web search. Only successfully scraped URLs are billed.<br/>Additional usage-based pricing applies, see [pricing](/overview/pricing#web-search-and-scraping). | `false` |
 | `enable_x_search` | boolean | Enable xAI's native search (web + X/Twitter) for supported Grok models (e.g., `grok-4-20-beta`). Provides higher quality search results by using xAI's search infrastructure. When enabled, Venice's standard web search is bypassed.<br/>Additional usage-based pricing applies, see [pricing](/overview/pricing#web-search-and-scraping). | `false` |
-| `enable_web_citations` | boolean | When web search is enabled, request that the LLM cite its sources using `[REF]0[/REF]` format | `false` |
+| `enable_web_citations` | boolean | When web search is enabled, request that the LLM cite its sources using caret superscripts — `^1^` for a single source and `^1,2^` for several. Bracket forms such as `[1]`, `(1)`, and `<sup>1</sup>` are explicitly suppressed | `false` |
 | `include_search_results_in_stream` | boolean | Experimental: Include search results in the stream as the first emitted chunk | `false` |
 | `return_search_results_as_documents` | boolean | Surface search results in an OpenAI-compatible tool call named `venice_web_search_documents` for LangChain integration | `false` |
 | `include_venice_system_prompt` | boolean | Whether to include Venice's default system prompts alongside specified system prompts | `true` |

--- a/api-reference/endpoint/augment/text-parser.mdx
+++ b/api-reference/endpoint/augment/text-parser.mdx
@@ -7,7 +7,15 @@ openapi: 'POST /augment/text-parser'
 
 <Warning>This is an experimental API. The request and response format may change without notice.</Warning>
 
-Upload a document file via multipart/form-data using the `file` field. Supported formats include **PDF**, **DOCX**, **XLSX**, and **plain text** files (up to 25MB).
+Upload a document file via multipart/form-data using the `file` field, up to 25MB.
+
+Supported formats are broader than the structured-document set. The endpoint accepts:
+
+- **Documents** — PDF, DOCX, DOC, XLSX, XLS, PPTX, PPT, EPUB
+- **Plain text and data** — TXT, Markdown, CSV, JSON, YAML, and any `text/*` MIME type
+- **Source code** — roughly 200 recognized extensions, including `.py`, `.ts`, `.js`, `.go`, `.rs`, `.c`, `.cpp`, `.java`, `.sh`, `.sql`, plus extensionless files such as `Dockerfile` and `Makefile`
+
+If your input is already text or code, there is no need to convert it to PDF first.
 
 Set `response_format` to `json` (default) for structured output with extracted text and token count, or `text` for the raw extracted text.
 

--- a/api-reference/endpoint/augment/text-parser.mdx
+++ b/api-reference/endpoint/augment/text-parser.mdx
@@ -2,7 +2,7 @@
 title: 'Text Parser'
 openapi: 'POST /augment/text-parser'
 "og:title": "Text Parser | Venice API Docs"
-"og:description": "Documentation covering Venice's text parser API for extracting text from PDF, DOCX, XLSX, and plain text files."
+"og:description": "Documentation covering Venice's text parser API for extracting text from PDF, EPUB, DOCX, PPTX, XLSX, plain text, and source-code files."
 ---
 
 <Warning>This is an experimental API. The request and response format may change without notice.</Warning>
@@ -11,11 +11,15 @@ Upload a document file via multipart/form-data using the `file` field, up to 25M
 
 Supported formats are broader than the structured-document set. The endpoint accepts:
 
-- **Documents** — PDF, DOCX, DOC, XLSX, XLS, PPTX, PPT, EPUB
-- **Plain text and data** — TXT, Markdown, CSV, JSON, YAML, and any `text/*` MIME type
-- **Source code** — roughly 200 recognized extensions, including `.py`, `.ts`, `.js`, `.go`, `.rs`, `.c`, `.cpp`, `.java`, `.sh`, `.sql`, plus extensionless files such as `Dockerfile` and `Makefile`
+- **Documents** — PDF, EPUB, DOCX, PPTX, XLSX, XLS
+- **Plain text and data** — plain text, Markdown, CSV, JSON, YAML, TOML, XML, and any `text/*` MIME type
+- **Source code** — roughly 140 recognized extensions, including `.py`, `.ts`, `.js`, `.go`, `.rs`, `.c`, `.cpp`, `.java`, `.ps1`, `.sh`, `.sql`, plus extensionless files such as `Dockerfile` and `Makefile`
 
 If your input is already text or code, there is no need to convert it to PDF first.
+
+<Note>
+Only the modern Office formats are supported. The legacy `.doc` and `.ppt` binary formats are **not** accepted — convert them to `.docx` or `.pptx` first. Legacy `.xls` *is* accepted.
+</Note>
 
 Set `response_format` to `json` (default) for structured output with extracted text and token count, or `text` for the raw extracted text.
 

--- a/api-reference/endpoint/crypto/networks.mdx
+++ b/api-reference/endpoint/crypto/networks.mdx
@@ -20,6 +20,8 @@ This endpoint is **public** — no API key or wallet authentication required.
     "avalanche-mainnet",
     "base-mainnet",
     "base-sepolia",
+    "blast-mainnet",
+    "blast-sepolia",
     "bsc-mainnet",
     "bsc-testnet",
     "ethereum-holesky",

--- a/api-reference/endpoint/crypto/rpc.mdx
+++ b/api-reference/endpoint/crypto/rpc.mdx
@@ -79,16 +79,18 @@ Methods are classified into three credit tiers. Credits consumed per call = `bas
 
 ### Cost examples
 
-At Venice's `~$6.25 × 10⁻⁷` per credit:
+At Venice's `~$7.0 × 10⁻⁷` per credit:
 
 | Call | Credits | USD cost |
 |---|---|---|
-| `eth_call` on Ethereum (20 × 1×) | 20 | $0.0000125 |
-| `trace_transaction` on Ethereum (20 × 2×) | 40 | $0.0000250 |
-| `trace_replayTransaction` on Ethereum (20 × 4×) | 80 | $0.0000500 |
-| `eth_call` on zkSync (30 × 1×) | 30 | $0.0000188 |
-| `getBalance` on Solana (30 × 1×) | 30 | $0.0000188 |
-| `getLargestAccounts` on Solana (30 × 4×) | 120 | $0.0000750 |
+| `eth_call` on Ethereum (20 × 1×) | 20 | $0.0000140 |
+| `trace_transaction` on Ethereum (20 × 2×) | 40 | $0.0000280 |
+| `trace_replayTransaction` on Ethereum (20 × 4×) | 80 | $0.0000560 |
+| `eth_call` on zkSync (30 × 1×) | 30 | $0.0000210 |
+| `getBalance` on Solana (30 × 1×) | 30 | $0.0000210 |
+| `getLargestAccounts` on Solana (30 × 4×) | 120 | $0.0000840 |
+
+Every response carries the exact figures for that call in the `x-venice-rpc-credits` and `x-venice-rpc-cost-usd` headers. Read those rather than recomputing from the table.
 
 ### Not supported
 
@@ -163,7 +165,7 @@ curl https://api.venice.ai/api/v1/crypto/rpc/ethereum-mainnet \
 { "jsonrpc": "2.0", "id": 1, "result": "0x1" }
 ```
 
-Response headers: `X-Venice-RPC-Credits: 20`, `X-Venice-RPC-Cost-USD: 0.00001250`, `X-Request-ID: <nanoid>`.
+Response headers: `X-Venice-RPC-Credits: 20`, `X-Venice-RPC-Cost-USD: 0.00001400`, `X-Request-ID: <nanoid>`.
 
 ## Postman collection
 

--- a/api-reference/endpoint/image/generate.mdx
+++ b/api-reference/endpoint/image/generate.mdx
@@ -9,8 +9,8 @@ openapi: 'POST /image/generate'
 
 Image models use model-specific sizing parameters:
 
-- Pixel-based models accept `width` and `height`, for example `venice-sd35` and `qwen-image`.
-- Aspect-ratio models accept `aspect_ratio`, for example `qwen-image-2`.
+- Pixel-based models accept `width` and `height`, for example `venice-sd35`.
+- Aspect-ratio models accept `aspect_ratio`, for example `qwen-image-2`. The Qwen Image family — `qwen-image`, `qwen-image-3`, and `qwen-image-3-pro` — **rejects** `width` and `height` with a `400`; use `aspect_ratio` for those.
 - Resolution-tier models accept both `aspect_ratio` and `resolution`.
 
 For example, `gpt-image-2`, `nano-banana-2`, and `nano-banana-pro` support `resolution` values of `1K`, `2K`, and `4K`:

--- a/api-reference/endpoint/video/transcriptions.mdx
+++ b/api-reference/endpoint/video/transcriptions.mdx
@@ -5,7 +5,11 @@ openapi: 'POST /video/transcriptions'
 "og:description": "Documentation covering Venice's video transcription API for extracting text from video audio."
 ---
 
-Send a publicly accessible video URL in `url`. Optionally set `response_format` to `json` (default) or `text` depending on whether you want structured output or plain transcript text.
+Send a **YouTube** video URL in `url`. Optionally set `response_format` to `json` (default) or `text` depending on whether you want structured output or plain transcript text.
+
+<Warning>
+This endpoint accepts YouTube URLs only. Watch, share, embed, live, and shorts links are supported on the `youtube.com`, `youtu.be`, and `youtube-nocookie.com` hosts. Any other URL — including a self-hosted MP4, a CDN link, or an S3 object — returns `400` with *"url must be a valid YouTube video URL"*. To transcribe your own media, extract the audio track and use the [Audio Transcriptions API](/api-reference/endpoint/audio/transcriptions) instead.
+</Warning>
 
 -------
 

--- a/guides/features/embeddings.mdx
+++ b/guides/features/embeddings.mdx
@@ -67,6 +67,15 @@ curl https://api.venice.ai/api/v1/embeddings \
 
 Pass an array of strings to embed multiple texts in one request. Each item must be text, not a token ID array:
 
+Two limits apply, and both are enforced before the request reaches a model:
+
+| Limit | Value | Error when exceeded |
+|---|---|---|
+| Items per request | 2,048 | `400` — *"Array must contain at most 2048 element(s)"* |
+| Tokens per item | 8,192 | `400` — token count is checked per array entry, not across the batch |
+
+Size your ingest batches against the 2,048 cap and chunk long documents below 8,192 tokens per entry. The request body is also strict, so an unrecognized field returns a `400` rather than being ignored.
+
 ```json
 {
   "model": "text-embedding-bge-m3",

--- a/guides/integrations/generating-api-key-agent.mdx
+++ b/guides/integrations/generating-api-key-agent.mdx
@@ -74,7 +74,16 @@ This guide walks through the full flow end to end and covers the funding options
 
     Required fields: `address`, `signature`, `token`, `apiKeyType` (`INFERENCE` or `ADMIN`).
 
-    Optional fields: `description`, `expiresAt`, `consumptionLimit` (caps total spend on this key, denominated in `usd`, `vcu`, or `diem`).
+    Optional fields:
+
+    - `description`, `expiresAt`
+    - `consumptionLimit` — the spend cap for this key, denominated in `usd`, `vcu`, or `diem`
+    - `limitPeriod` — the window the cap is measured over: `EPOCH` (resets every UTC day), `MONTH` (resets on the 1st of each UTC month), or `LIFETIME` (never resets, so the cap is permanent)
+    - `modelPrivacy` — which models the key may call, by privacy tier: `ALL`, `PRIVATE_TEXT`, or `PRIVATE_ONLY`
+
+    <Warning>
+    `limitPeriod` defaults to `EPOCH` when omitted, which means the cap **resets every day** rather than being a lifetime total. A key created with `consumptionLimit: {"usd": 50}` and no `limitPeriod` can spend $50 per day. For an unattended agent key, set `limitPeriod: "LIFETIME"` explicitly so the limit is a permanent ceiling.
+    </Warning>
 
     On success the response contains the minted `apiKey` string. Store it in the agent's secret store and use it as a normal Bearer token (`Authorization: Bearer <key>`).
   </Step>

--- a/guides/integrations/generating-api-key-agent.mdx
+++ b/guides/integrations/generating-api-key-agent.mdx
@@ -113,6 +113,9 @@ const mintResponse = await fetch("https://api.venice.ai/api/v1/api_keys/generate
     token,
     apiKeyType: "INFERENCE",
     description: "Agent key",
+    // A permanent $50 ceiling. Without limitPeriod this would reset daily.
+    consumptionLimit: { usd: 50 },
+    limitPeriod: "LIFETIME",
   }),
 })
 

--- a/guides/media/image-editing.mdx
+++ b/guides/media/image-editing.mdx
@@ -16,7 +16,7 @@ The image edit endpoints are experimental and model-specific behavior may change
 | Endpoint | Purpose | Best for |
 |---|---|---|
 | `POST /image/edit` | Edit a single image with a prompt | General edits and prompt-driven inpainting |
-| `POST /image/multi-edit` | Edit using 1-3 layered images | More controlled edits with masks or overlays |
+| `POST /image/multi-edit` | Edit using multiple reference images (3, or up to 6 on higher-tier models) | Compositing and multi-reference edits |
 | `POST /image/background-remove` | Remove the background from an image | Transparent cutouts for products, portraits, and assets |
 
 ## When to use which endpoint
@@ -116,7 +116,13 @@ curl https://api.venice.ai/api/v1/image/edit \
 
 ## Step 2: Use multi-edit for masks or layered inpainting
 
-`/image/multi-edit` accepts up to three images. The first image is the base image. The remaining images are treated as edit layers or masks, which gives you more control than prompt-only editing.
+`/image/multi-edit` accepts multiple images, and the cap is model-specific: most edit models allow 3, while the higher-tier ones — including `gpt-image-2-edit`, `nano-banana-pro-edit`, `seedream-v5-pro-edit`, `flux-2-max-edit`, and `wan-2-7-pro-edit` — allow up to 6. Read `model_spec.constraints.maxInputImages` from `GET /models?type=inpaint` to get the cap for a given model; when the field is absent the cap is 3.
+
+The first image is the base image. The remaining images are additional references that condition the edit.
+
+<Note>
+The public endpoint has no mask channel. Additional images act as references across the whole image, not as region maps — there is no `mask` parameter, and sending one returns a `400`. Prompt precisely to constrain where the edit lands.
+</Note>
 
 This is the better choice when you want to:
 
@@ -223,7 +229,7 @@ Use background removal for:
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `images` | array of 1-3 files, base64 strings, or URLs | Yes | - | First image is the base image; the rest are edit layers or masks |
+| `images` | array of files, base64 strings, or URLs | Yes | - | First image is the base image; the rest are additional references. Maximum is model-specific — 3 by default, up to 6 on higher-tier models |
 | `prompt` | string | Yes | - | Text instructions for how to combine or edit the layers |
 | `modelId` | string | No | `qwen-edit` | Edit model ID |
 | `enhance_prompt` | boolean | No | `false` | Analyze the input images and rewrite the edit instruction before inference |

--- a/guides/media/image-generation.mdx
+++ b/guides/media/image-generation.mdx
@@ -19,6 +19,10 @@ Image generation on Venice is synchronous. Send a prompt to `/image/generate` an
 
 Sizing is model-specific. Some models accept explicit `width` and `height`; some expose `aspect_ratio`; and resolution-tier models expose `aspect_ratio` plus `resolution` values such as `1K`, `2K`, or `4K`.
 
+<Warning>
+`qwen-image`, `qwen-image-3`, and `qwen-image-3-pro` no longer accept `width` or `height`. Sending either returns `400` with *"`width` and `height` are no longer supported for this model. Use `aspect_ratio` instead."* Check `model_spec.constraints` from `GET /models?type=image` before choosing sizing fields.
+</Warning>
+
 **Pixel-based sizing example:**
 ```bash
 POST https://api.venice.ai/api/v1/image/generate
@@ -189,14 +193,19 @@ curl https://api.venice.ai/api/v1/image/styles \
 
 **Response (200):**
 ```json
-[
-  "3D Model",
-  "Analog Film",
-  "Anime",
-  "Cinematic",
-  "Digital Art"
-]
+{
+  "object": "list",
+  "data": [
+    "3D Model",
+    "Analog Film",
+    "Anime",
+    "Cinematic",
+    "Digital Art"
+  ]
+}
 ```
+
+The style names are inside `data`, not at the top level — read `response.data` rather than iterating the response object directly.
 
 Then pass one of those values into your generation request:
 
@@ -219,8 +228,8 @@ Use the styles endpoint when you want exact preset names instead of guessing the
 | `model` | string | Yes | - | Model ID to use for generation |
 | `prompt` | string | Yes | - | What to generate |
 | `negative_prompt` | string | No | - | What to avoid in the image |
-| `width` | integer | No | `1024` | Output width in pixels for pixel-based models such as `venice-sd35` and `qwen-image` |
-| `height` | integer | No | `1024` | Output height in pixels for pixel-based models such as `venice-sd35` and `qwen-image` |
+| `width` | integer | No | `1024` | Output width in pixels for pixel-based models such as `venice-sd35`. Rejected by the Qwen Image family — see the note below |
+| `height` | integer | No | `1024` | Output height in pixels for pixel-based models such as `venice-sd35`. Rejected by the Qwen Image family — see the note below |
 | `format` | string | No | `webp` | Output format: `jpeg`, `png`, or `webp` |
 | `variants` | integer | No | `1` | Number of images to generate (`1`-`4`), only when `return_binary` is `false` |
 | `return_binary` | boolean | No | `false` | Return raw image bytes instead of base64 JSON |

--- a/guides/media/reference-to-video.mdx
+++ b/guides/media/reference-to-video.mdx
@@ -54,7 +54,7 @@ An Element is a character or object you want to keep visually stable throughout 
 - **Frontal Image** (required per element) — a clear, front-facing photo of the subject. This is the primary identity anchor. Think of it as the "passport photo" of your character or product.
 - **Reference Images** (1–3, optional) — additional angles of the same subject (side view, 45-degree angle, back). These help the model understand the subject in 3D space. If not provided, the frontal image is automatically used as the reference.
 
-You can add up to **7 elements** per generation (limited by combined total). Reference them in your prompt using `@Element1`, `@Element2`, etc.
+You can add up to **4 elements** per generation. Reference them in your prompt using `@Element1`, `@Element2`, etc.
 
 ### Scene Reference Images
 
@@ -68,25 +68,18 @@ You can add up to **4 scene images**. Reference them as `@Image1`, `@Image2`, et
 
 ### Limitations
 
-The total number of images across all input types is limited:
+Each input type is capped independently by the API:
 
 | Limit | Value |
 |---|---|
 | **Minimum required** | At least 1 visual input (start frame, element, or scene image) |
-| **Combined total** (first frame + last frame + elements + scene images) | **7 maximum** |
-| Elements (without start/end frame) | 7 maximum |
-| Elements (with start or end frame) | 3 maximum |
-| Scene reference images | 4 maximum |
-| Reference images per element | 1–3 |
+| `elements` | **4 maximum** |
+| `scene_image_urls` | 4 maximum |
+| `reference_image_urls` per element | 1–3 |
 
-**Example scenarios:**
-
-- 7 elements + 0 scene images = 7 ✓ (no frames)
-- 5 elements + 2 scene images = 7 ✓ (no frames)
-- First frame (1) + 3 elements + 3 scene images = 7 ✓
-- First frame (1) + last frame (1) + 3 elements + 2 scene images = 7 ✓
-- First frame (1) + 4 elements = ✗ (max 3 elements with frame)
-- First frame (1) + last frame (1) + 4 elements = ✗ (max 3 elements with frames)
+<Note>
+The API applies these caps independently — there is no combined image budget across `elements`, `scene_image_urls`, and the start/end frames, and adding a start or end frame does not reduce how many elements you may send. Exceeding a single cap returns a `400` naming that field, for example *"elements must have at most 4 items"*.
+</Note>
 
 <Note>
 Each element requires a **frontal image**. If you don't provide reference images for an element, the frontal image is automatically used as the reference.
@@ -116,10 +109,10 @@ For each element:
 1. Click the **Frontal** tile to upload a clear, front-facing image of your character or object
 2. Optionally click **Add** under **Reference Images** to upload additional angles (1–3)
 
-Repeat for additional characters or objects (up to 7 elements total, or 3 if using start/end frames).
+Repeat for additional characters or objects (up to 4 elements total).
 
 <Warning>
-The combined total of first frame, last frame, elements, and scene images cannot exceed **7**. See [Limitations](#limitations) for details.
+`elements` and `scene_image_urls` are each capped at **4**, and the caps apply independently. See [Limitations](#limitations) for details.
 </Warning>
 
 <Tip>
@@ -276,7 +269,7 @@ response = requests.post(
     json={
         "model": "kling-o3-pro-reference-to-video",
         "prompt": "@Element1 walks through @Image1, camera tracking from behind",
-        "duration": "8",
+        "duration": "8s",
         "aspect_ratio": "16:9",
         "audio": True,
         "elements": [
@@ -288,13 +281,13 @@ response = requests.post(
                 ]
             }
         ],
-        "image_urls": [
+        "scene_image_urls": [
             "https://example.com/scene-background.jpg"
         ]
     }
 )
 
-queue_id = response.json()["id"]
+queue_id = response.json()["queue_id"]
 ```
 
 #### Node.js
@@ -309,7 +302,7 @@ const response = await fetch("https://api.venice.ai/api/v1/video/queue", {
   body: JSON.stringify({
     model: "kling-o3-pro-reference-to-video",
     prompt: "@Element1 walks through @Image1, camera tracking from behind",
-    duration: "8",
+    duration: "8s",
     aspect_ratio: "16:9",
     audio: true,
     elements: [
@@ -327,7 +320,7 @@ const response = await fetch("https://api.venice.ai/api/v1/video/queue", {
   })
 });
 
-const { id: queueId } = await response.json();
+const { queue_id: queueId } = await response.json();
 ```
 
 #### cURL
@@ -339,7 +332,7 @@ curl https://api.venice.ai/api/v1/video/queue \
   -d '{
     "model": "kling-o3-pro-reference-to-video",
     "prompt": "@Element1 walks through @Image1, camera tracking from behind",
-    "duration": "8",
+    "duration": "8s",
     "aspect_ratio": "16:9",
     "audio": true,
     "elements": [
@@ -351,7 +344,7 @@ curl https://api.venice.ai/api/v1/video/queue \
         ]
       }
     ],
-    "image_urls": [
+    "scene_image_urls": [
       "https://example.com/scene-background.jpg"
     ]
   }'
@@ -377,7 +370,8 @@ The API also supports `video_url` for video-based elements, but this is not curr
 | Problem | Likely cause | Fix |
 |---|---|---|
 | Generate button is disabled | No visual inputs provided | Add at least one visual input: start frame, element, or scene reference image |
-| "Number of images exceeds the limit" error | Too many combined inputs | Total of first frame + last frame + elements + scene images must be ≤ 7 |
+| `"elements must have at most 4 items"` error | More than 4 elements sent | Send at most 4 elements; the cap does not change when a start or end frame is present |
+| `"scene_image_urls must have at most 4 images"` error | More than 4 scene images sent | Send at most 4 scene images. This cap is independent of the element cap |
 | Character face changes between shots | Different or missing frontal image | Use the same frontal image consistently, keep description identical |
 | Camera movement feels random | Multiple or conflicting camera instructions | Use a single camera instruction, place it early in the prompt |
 | Style shifts between generations | Inconsistent scene references or mixed styles | Reuse the same scene images, keep style keywords consistent |
@@ -409,7 +403,7 @@ If you don't include `@Image` tags in your prompt, all uploaded images are refer
 |---|---|---|
 | Aspect Ratio | 16:9, 4:3, 3:2, 1:1, 2:3, 3:4, 9:16 | 16:9 |
 | Resolution | 480p, 720p | 480p |
-| Duration | 5s, 8s, 10s | 8s |
+| Duration | Any whole second from 1s to 10s | 8s |
 
 <Note>
 Grok Imagine R2V does not support audio generation, multi-shot mode, or Elements. For those features, use Kling O3 R2V.
@@ -474,16 +468,16 @@ response = requests.post(
     json={
         "model": "grok-imagine-reference-to-video",
         "prompt": "@Image1 and @Image2 walking through a park, cinematic tracking shot",
-        "duration": "8",
+        "duration": "8s",
         "aspect_ratio": "16:9",
-        "referenceImageUrls": [
+        "reference_image_urls": [
             "https://example.com/character-a.jpg",
             "https://example.com/character-b.jpg"
         ]
     }
 )
 
-queue_id = response.json()["id"]
+queue_id = response.json()["queue_id"]
 ```
 
 #### Node.js
@@ -498,16 +492,16 @@ const response = await fetch("https://api.venice.ai/api/v1/video/queue", {
   body: JSON.stringify({
     model: "grok-imagine-reference-to-video",
     prompt: "@Image1 and @Image2 walking through a park, cinematic tracking shot",
-    duration: "8",
+    duration: "8s",
     aspect_ratio: "16:9",
-    referenceImageUrls: [
+    reference_image_urls: [
       "https://example.com/character-a.jpg",
       "https://example.com/character-b.jpg"
     ]
   })
 });
 
-const { id: queueId } = await response.json();
+const { queue_id: queueId } = await response.json();
 ```
 
 #### cURL
@@ -519,9 +513,9 @@ curl https://api.venice.ai/api/v1/video/queue \
   -d '{
     "model": "grok-imagine-reference-to-video",
     "prompt": "@Image1 and @Image2 walking through a park, cinematic tracking shot",
-    "duration": "8",
+    "duration": "8s",
     "aspect_ratio": "16:9",
-    "referenceImageUrls": [
+    "reference_image_urls": [
       "https://example.com/character-a.jpg",
       "https://example.com/character-b.jpg"
     ]
@@ -534,13 +528,13 @@ curl https://api.venice.ai/api/v1/video/queue \
 |---|---|---|---|
 | `model` | string | **Yes** | Must be `grok-imagine-reference-to-video` |
 | `prompt` | string | **Yes** | Text prompt with optional `@Image1`, `@Image2` references |
-| `referenceImageUrls` | string[] | **Yes** | 1–7 image URLs or data URLs |
-| `duration` | string | No | `"5"`, `"8"` (default), or `"10"` |
-| `aspect_ratio` | string | No | e.g., `"16:9"` (default), `"9:16"`, `"1:1"` |
+| `reference_image_urls` | string[] | **Yes** | 1–7 image URLs or data URLs |
+| `duration` | string | **Yes** | Any whole second from `"1s"` to `"10s"`. The `s` suffix is required |
+| `aspect_ratio` | string | **Yes** | e.g., `"16:9"`, `"9:16"`, `"1:1"` |
 | `resolution` | string | No | `"480p"` (default) or `"720p"` |
 
 <Note>
-Grok Imagine R2V does not use the `elements`, `image_urls`, or `imageUrl` fields. All reference images are passed via `referenceImageUrls`.
+Grok Imagine R2V does not use the `elements`, `scene_image_urls`, or `image_url` fields. All reference images are passed via `reference_image_urls`.
 </Note>
 
 ### Grok Imagine R2V Troubleshooting
@@ -548,8 +542,9 @@ Grok Imagine R2V does not use the `elements`, `image_urls`, or `imageUrl` fields
 | Problem | Likely cause | Fix |
 |---|---|---|
 | Generate button is disabled | No reference images uploaded | Upload at least 1 reference image |
-| "At least one reference image is required" error | `referenceImageUrls` is empty or missing | Provide at least one image URL in `referenceImageUrls` |
+| "At least one reference image is required" error | `reference_image_urls` is empty or missing | Provide at least one image URL in `reference_image_urls` |
 | Wrong image associated with `@Image` tag | Image order doesn't match tags | `@Image1` corresponds to the first image in your upload order (left to right). Reorder uploads if needed. |
 | Subject not appearing in video | Too many references without explicit tags | Use `@Image` tags in your prompt to be explicit about which images to use |
 | Low quality output | Using 480p resolution | Try 720p for higher quality (costs more) |
-| Video too short | Default duration is 8s | Set duration to `"10"` for longer videos |
+| Video too short | Default duration is 8s | Set duration to `"10s"` for longer videos |
+| `"Invalid enum value ... received '8'"` error | `duration` was sent without the `s` suffix | Send `"8s"`, not `"8"`. The API matches the display form exactly |

--- a/guides/media/seedance-2-0.mdx
+++ b/guides/media/seedance-2-0.mdx
@@ -23,13 +23,13 @@ This guide covers variants, the four workflows, **public API media policy**, **f
 | `seedance-2-0-fast-text-to-video-basic` | Fast T2V | 480p / 720p | Faster, lower-fidelity tier (no 1080p / 4k) |
 | `seedance-2-0-fast-image-to-video-basic` | Fast I2V | 480p / 720p | Faster, lower-fidelity tier (no 1080p / 4k) |
 | `seedance-2-0-fast-reference-to-video-basic` | Fast R2V | 480p / 720p | Faster, lower-fidelity tier (no 1080p / 4k); same workflow set |
-| `seedance-2-5-text-to-video-basic` | T2V | 480p / 720p | Up to 30s output; native audio |
-| `seedance-2-5-image-to-video-basic` | I2V | 480p / 720p | Up to 30s output; first-frame (and optionally last-frame) grounding |
-| `seedance-2-5-reference-to-video-basic` | R2V | 480p / 720p | Up to 30 images + 10 videos + 10 audio donors; same Reference / Edit / Extend / Stitch workflows |
+| `seedance-2-5-text-to-video-basic` | T2V | 480p / 720p / 1080p | Up to 30s output; native audio |
+| `seedance-2-5-image-to-video-basic` | I2V | 480p / 720p / 1080p | Up to 30s output; first-frame (and optionally last-frame) grounding |
+| `seedance-2-5-reference-to-video-basic` | R2V | 480p / 720p / 1080p | Up to 30 images + 10 videos + 10 audio donors; same Reference / Edit / Extend / Stitch workflows |
 
 All variants are async. Submit via `POST /api/v1/video/queue`, then poll `POST /api/v1/video/retrieve` until the response body is `video/mp4`. See [Video Generation](/guides/media/video-generation) for the general queue flow.
 
-Pass `resolution` as one of: `480p`, `720p`, `1080p`, or `4k` (lowercase). Seedance **2.0** (non-Fast) accepts all four; **2.0 Fast** and **2.5** accept `480p` / `720p` only. Discover live model IDs and capabilities with `GET /models?type=video` — do not hardcode availability.
+Pass `resolution` as one of: `480p`, `720p`, `1080p`, or `4k` (lowercase). Seedance **2.0** (non-Fast) accepts all four; **2.5** accepts `480p` / `720p` / `1080p`; **2.0 Fast** accepts `480p` / `720p` only. Discover live model IDs and capabilities with `GET /models?type=video` — do not hardcode availability.
 
 ## Output bitrate
 
@@ -225,7 +225,7 @@ Values below are what the Venice API accepts. Requests outside these ranges are 
 | Constraint | Seedance 2.0 (+ Fast) | Seedance 2.5 |
 |---|---|---|
 | Output duration | 4–15 s | 4–30 s (default 10) |
-| Output resolutions | 480p / 720p / 1080p / **4k** (Fast: 480p / 720p only) | 480p / 720p only |
+| Output resolutions | 480p / 720p / 1080p / **4k** (Fast: 480p / 720p only) | 480p / 720p / 1080p |
 | Output bitrate (`bitrate_mode`) | `standard` (default) or `high` | `standard` (default) or `high` |
 | R2V reference images | 1–9 | 1–30 |
 | Max R2V reference image bytes | (shared request limits) | ≤ 30 MB per image |
@@ -510,7 +510,7 @@ curl -X POST https://api.venice.ai/api/v1/video/retrieve \
   -o output.mp4
 ```
 
-The response is JSON (`{ "status": "queued" | "running" | "failed", ... }`) until the job completes, at which point the response body switches to `video/mp4` bytes. See [Video Generation](/guides/media/video-generation) for the full polling pattern.
+The response is JSON (`{ "status": "PROCESSING", ... }`) while the job runs, and the body switches to `video/mp4` bytes once it completes. `status` is one of `PROCESSING` or `COMPLETED` — there is no `failed` status. A failed job instead returns a non-200 response carrying the recorded error. See [Video Generation](/guides/media/video-generation) for the full polling pattern.
 
 ---
 
@@ -518,7 +518,7 @@ The response is JSON (`{ "status": "queued" | "running" | "failed", ... }`) unti
 
 ### `At least one reference is required for this model`
 
-Reference-to-video submissions must include at least one of `reference_image_urls`, `reference_video_urls`, `image_references`, or `video_references`. Pure text-only generation isn't a valid R2V workflow — use a text-to-video model ID instead. `reference_audio_urls` alone is not sufficient (see the Audio section above).
+Reference-to-video submissions must include at least one of `reference_image_urls`, `reference_video_urls`, or `image_references`. Pure text-only generation isn't a valid R2V workflow — use a text-to-video model ID instead. `reference_audio_urls` alone is not sufficient (see the Audio section above). Note that `video_references` is **not** accepted on Seedance — it is specific to models that support per-reference voice audio, and passing it returns *"This model does not support per-reference video entities"*.
 
 ### Too many reference videos / images
 

--- a/guides/media/speech-to-text.mdx
+++ b/guides/media/speech-to-text.mdx
@@ -69,21 +69,62 @@ curl https://api.venice.ai/api/v1/audio/transcriptions \
 
 ## Supported Inputs
 
-Common audio formats include `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `wav`, `webm`, `flac`, and `ogg`. See the [Speech-to-Text Models](/models/speech-to-text) page for current model support and pricing.
+Supported audio formats are `wav`, `wave`, `flac`, `m4a`, `aac`, `mp4`, `mp3`, `ogg`, `oga`, and `webm`. A file is accepted when either its MIME type or its extension is on that list, and the uploaded bytes must also pass a magic-byte check — renaming a file to a supported extension will not get it through. See the [Speech-to-Text Models](/models/speech-to-text) page for current model support and pricing.
 
 ## Response Formats
 
 | Format | Use when |
 |--------|----------|
-| `json` | You want a simple `{ "text": "..." }` response. |
+| `json` | You want a structured response: `text`, plus `duration` and `timestamps` when available. |
 | `text` | You want plain text without JSON parsing. |
-| `srt` | You need SubRip subtitles. |
-| `vtt` | You need WebVTT subtitles. |
-| `verbose_json` | You need richer timestamp and segment metadata. |
 
-<Tip>
-Use subtitle formats when the transcript will be paired with media playback. Use `json` or `text` when the transcript feeds summarization, search, or downstream chat prompts.
-</Tip>
+<Note>
+These are the only two values `response_format` accepts. There is no `srt`, `vtt`, or `verbose_json` option — requesting one returns a `400`. To build subtitles, use `timestamps: true` with `response_format: json` and render the timing data yourself.
+</Note>
+
+## Timestamps
+
+Pass `timestamps=true` to get timing data back alongside the transcript. Support is model-specific, and the granularity differs:
+
+| Model | Granularity |
+|---|---|
+| `elevenlabs/scribe-v2` | `word` |
+| `stt-xai-v1` | `word` |
+| `openai/whisper-large-v3` | `segment` |
+| `fal-ai/wizper` | `segment` |
+| `nvidia/parakeet-tdt-0.6b-v3` | None |
+
+<Warning>
+The default model, `nvidia/parakeet-tdt-0.6b-v3`, accepts `timestamps=true` and then ignores it — you get a response containing only `text`, with no error and no warning. Pick a model from the table above if you need timings, and check that the `timestamps` key exists before reading it.
+</Warning>
+
+```bash
+curl https://api.venice.ai/api/v1/audio/transcriptions \
+  -H "Authorization: Bearer $VENICE_API_KEY" \
+  --form file=@meeting.mp3 \
+  --form model=elevenlabs/scribe-v2 \
+  --form timestamps=true \
+  --form response_format=json
+```
+
+```json
+{
+  "text": "The quick brown fox jumps over the lazy dog.",
+  "duration": 4.099,
+  "timestamps": {
+    "word": [
+      { "word": "The", "start": 0.0, "end": 0.14 },
+      { "word": "quick", "start": 0.14, "end": 0.42 }
+    ]
+  }
+}
+```
+
+Segment-level models return a `segment` array instead, where each entry is `{ "text": "...", "start": 0.0, "end": 3.2 }`. All times are in seconds.
+
+<Note>
+No Venice transcription model performs speaker diarization, so there is no `speaker` field on any response. A transcript is a single stream of text — speakers can only be attributed when a name is said out loud.
+</Note>
 
 ## Production Tips
 

--- a/guides/media/video-generation.mdx
+++ b/guides/media/video-generation.mdx
@@ -254,7 +254,7 @@ await fetch(`${BASE_URL}/video/complete`, {
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `model` | string | Yes | - | Model ID. Use `wan-2.5-preview-text-to-video` for text-to-video, `wan-2.5-preview-image-to-video` for image-to-video |
-| `prompt` | string | Yes | - | What to generate. Max 2500 chars |
+| `prompt` | string | Yes | - | What to generate. The maximum length is model-specific and ranges from 1,000 to 20,000 characters (2,500 is the default for models that do not declare their own). Read `model_spec.constraints.prompt_character_limit` from `GET /models?type=video` rather than assuming a single limit |
 | `negative_prompt` | string | No | `"low resolution, error, worst quality, low quality, defects"` | What to avoid |
 | `duration` | string | Yes | - | `"5s"` or `"10s"` |
 | `resolution` | string | No | `"720p"` | `"480p"`, `"720p"`, or `"1080p"` |

--- a/guides/media/video-generation.mdx
+++ b/guides/media/video-generation.mdx
@@ -254,7 +254,7 @@ await fetch(`${BASE_URL}/video/complete`, {
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `model` | string | Yes | - | Model ID. Use `wan-2.5-preview-text-to-video` for text-to-video, `wan-2.5-preview-image-to-video` for image-to-video |
-| `prompt` | string | Yes | - | What to generate. The maximum length is model-specific and ranges from 1,000 to 20,000 characters (2,500 is the default for models that do not declare their own). Read `model_spec.constraints.prompt_character_limit` from `GET /models?type=video` rather than assuming a single limit |
+| `prompt` | string | Yes | - | What to generate. The maximum length is model-specific and varies widely — from a few hundred characters up to 20,000. Models that do not declare their own limit default to 2,500. Read `model_spec.constraints.prompt_character_limit` from `GET /models?type=video` rather than assuming a single limit |
 | `negative_prompt` | string | No | `"low resolution, error, worst quality, low quality, defects"` | What to avoid |
 | `duration` | string | Yes | - | `"5s"` or `"10s"` |
 | `resolution` | string | No | `"720p"` | `"480p"`, `"720p"`, or `"1080p"` |

--- a/guides/media/video-upscaling.mdx
+++ b/guides/media/video-upscaling.mdx
@@ -221,12 +221,15 @@ curl https://api.venice.ai/api/v1/video/quote \
   -H "Content-Type: application/json" \
   -d '{
     "model": "topaz-video-upscale",
-    "duration": "10",
-    "input_height": 720
+    "video_url": "https://example.com/input.mp4"
   }'
 ```
 
-The quote endpoint accepts `input_height` so it can estimate the output resolution tier. This is optional — if omitted, the quote assumes a conservative estimate.
+`video_url` is **required** for quotes on upscale models — the quote endpoint fetches the file and detects duration, FPS, and height from the bytes, so there is no need to supply them. Omitting it returns `400` with *"video_url is required for quotes on this model"*.
+
+<Warning>
+The quote and queue endpoints currently name the upscale factor differently: `/video/queue` takes `upscale_factor` (`1`, `2`, or `4`), while `/video/quote` reads the factor from `resolution` (`"2x"` or `"4x"`). Sending `upscale_factor` to the quote endpoint has no effect — it falls back to the `"2x"` default and returns a 2x price for what may be a 4x job. When quoting a 4x upscale, pass `resolution: "4x"`.
+</Warning>
 
 ---
 

--- a/models/image.mdx
+++ b/models/image.mdx
@@ -100,7 +100,7 @@ See the [Image Generate API](/api-reference/endpoint/image/generate) for text-to
 </Note>
 
 <Tip>
-Image generation sizing is model-specific. Pixel-based models such as `venice-sd35` and `qwen-image` use `width` and `height`; aspect-ratio models such as `qwen-image-2` use `aspect_ratio`; models that list resolution options such as `1K`, `2K`, or `4K` use both `resolution` and `aspect_ratio`.
+Image generation sizing is model-specific. Pixel-based models such as `venice-sd35` use `width` and `height`; aspect-ratio models such as `qwen-image-2` use `aspect_ratio`; models that list resolution options such as `1K`, `2K`, or `4K` use both `resolution` and `aspect_ratio`. The Qwen Image family — `qwen-image`, `qwen-image-3`, and `qwen-image-3-pro` — rejects `width` and `height` with a `400` and requires `aspect_ratio`.
 </Tip>
 
 <Tip>

--- a/models/music.mdx
+++ b/models/music.mdx
@@ -41,7 +41,7 @@ Use the `id` value as the `model` parameter in API requests. 14 models currently
 - ElevenLabs Sound Effects, MMAudio V2
 
 <Tip>
-ElevenLabs Music is the only model that supports `force_instrumental` to generate music without vocals.
+`force_instrumental` generates music without vocals. It is supported by ElevenLabs Music, MiniMax Music 2.5, and MiniMax Music 2.6 — check `supports_force_instrumental` in the `/models` response rather than assuming a single model.
 </Tip>
 
 <Note>
@@ -59,7 +59,9 @@ For exact quotes before generation, use the [Audio Quote API](/api-reference/end
 
 ### Duration-Tiered Pricing
 
-Models with duration-tiered pricing accept any `duration_seconds` within the model's `min_duration`–`max_duration` range. The price is determined by which tier the requested duration falls into. Tier ranges are returned in the `/models` response under `pricing.durations`, with `min_seconds` and `max_seconds` for each tier.
+Models with duration-tiered pricing accept any `duration_seconds` within the model's `min_duration`–`max_duration` range, **unless** the model also reports `duration_options` — in that case only those exact values are accepted and anything else returns a `400`. ACE-Step 1.5, for example, accepts only `60`, `90`, `120`, `150`, `180`, and `210`, so `duration_seconds: 75` is rejected even though it sits inside the advertised range. Always check `duration_options` before falling back to `min_duration`/`max_duration`.
+
+The price is determined by which tier the requested duration falls into. Tier ranges are returned in the `/models` response under `pricing.durations`, with `min_seconds` and `max_seconds` for each tier.
 
 For example, ElevenLabs Music accepts 3–600 seconds (up to 10 minutes) at $0.75 per minute, rounded up to the nearest minute:
 

--- a/models/speech-to-text.mdx
+++ b/models/speech-to-text.mdx
@@ -28,17 +28,34 @@ Speech-to-text models transcribe spoken audio into written text. They are access
 
 ### Supported audio formats
 
-`mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `wav`, `webm`, `flac`, `ogg`
+`wav`, `wave`, `flac`, `m4a`, `aac`, `mp4`, `mp3`, `ogg`, `oga`, `webm`
+
+A file is accepted when either its MIME type or its extension is on this list, and it must also pass a magic-byte check on the uploaded bytes. Renaming a file to a supported extension is not sufficient.
 
 ### Response formats
 
 | Format | Description |
 |--------|-------------|
-| `json` | Default. Returns `{ "text": "..." }`. |
+| `json` | Default. Returns `{ "text": "..." }`, plus `duration` and `timestamps` when available. |
 | `text` | Plain transcribed text. |
-| `srt` | SubRip subtitle format with timestamps. |
-| `vtt` | WebVTT subtitle format with timestamps. |
-| `verbose_json` | Full response with segment-level timestamps and metadata. |
+
+### Timestamps
+
+Set `timestamps: true` to receive timing data alongside the transcript. The response adds a `timestamps` object whose granularity depends on the model:
+
+| Model | Granularity |
+|---|---|
+| `elevenlabs/scribe-v2` | `word` |
+| `stt-xai-v1` | `word` |
+| `openai/whisper-large-v3` | `segment` |
+| `fal-ai/wizper` | `segment` |
+| `nvidia/parakeet-tdt-0.6b-v3` | None |
+
+<Warning>
+`nvidia/parakeet-tdt-0.6b-v3` is the default model, and it accepts `timestamps: true` without returning timings. There is no error and no warning — the response simply contains `text` and nothing else. If you need timings, choose a model from the table above and check that the `timestamps` key is present before reading it.
+</Warning>
+
+Word entries are `{ "word": "...", "start": 0.0, "end": 0.5 }` and segment entries are `{ "text": "...", "start": 0.0, "end": 3.2 }`, with all times in seconds.
 
 <Note>
 Pricing is billed per second of input audio. See the [Audio Transcriptions API](/api-reference/endpoint/audio/transcriptions) for request examples and parameter details.


### PR DESCRIPTION
## Summary

Corrects documentation that contradicts the `v1` zod schemas. Every change was verified against the live API with a real inference key, not against the generated spec — the generated `swagger.yaml` is accurate and is not touched here.

Scope is deliberately limited to fixes that need **no outerface change**. Items that require a code fix are tracked separately.

## Requests that currently fail if copied from the docs

| Page | Problem |
|---|---|
| `guides/media/reference-to-video.mdx` | All six samples failed validation: camelCase `referenceImageUrls`, `image_urls` instead of `scene_image_urls`, duration literals missing the `s` suffix, and reading `id` instead of `queue_id`. Also documented `duration`/`aspect_ratio` as optional when both are required |
| `models/speech-to-text.mdx`, `guides/media/speech-to-text.mdx` | Offered `srt` / `vtt` / `verbose_json`; `response_format` accepts only `json` and `text` |
| `guides/media/reference-to-video.mdx` | `elements` cap documented as 7; the schema allows 4, and the caps are per-field with no combined image budget |
| `guides/media/video-upscaling.mdx` | Quote example omitted the required `video_url` and passed `input_height`, which the quote schema discards |
| `guides/media/image-generation.mdx`, `models/image.mdx`, `endpoint/image/generate.mdx` | Instructed callers to send `width`/`height` to `qwen-image`, which the handler rejects |
| `endpoint/video/transcriptions.mdx` | Described as accepting any public video URL; YouTube only |
| `models/music.mdx` | ACE-Step 1.5 described as accepting a continuous range; it accepts six discrete values |

## Limits and values corrected

- **Seedance 2.5 supports 1080p.** `GET /models` has advertised it since it shipped on 2026-08-17. Fixed in the variants table, the resolution sentence, and the family comparison.
- **Video prompt limit is per model** (1,000–20,000), not a flat 2,500. Points at `model_spec.constraints.prompt_character_limit`.
- **Crypto RPC costs were 12% low.** Margin is 1.4×, so a credit is `~$7.0e-7` and a 20-credit `eth_call` is `$0.0000140`. Verified against the `x-venice-rpc-cost-usd` header.
- **RPC networks list** omitted `blast-mainnet` and `blast-sepolia` (27 networks live, 25 listed).
- **Retrieve statuses** are `PROCESSING` / `COMPLETED`; there is no `failed` status.
- **Multi-edit** accepts up to 6 images on higher-tier models, not 1–3.
- **`/image/styles`** returns a `{ object, data }` envelope, not a bare array.
- **Web citations** use caret superscripts (`^1^`); `[REF]0[/REF]` exists nowhere in the codebase.
- **Text parsing** accepts EPUB, PPTX, XLS and ~200 code extensions, not just PDF/DOCX/XLSX/text.
- **`force_instrumental`** is supported by three models, not one.

## Undocumented behavior now documented

- **`limitPeriod` defaults to `EPOCH`**, so an agent key's `consumptionLimit` resets daily rather than acting as a lifetime cap. Added a warning recommending `LIFETIME` for unattended keys, plus `modelPrivacy` to the same optional-fields list.
- **Admin-only endpoints**, including that `GET /api_keys/rate_limits` is the one exception in that group.
- **Embeddings caps** of 2,048 items and 8,192 tokens per item.
- **Per-model timestamp granularity** for speech-to-text: word for Scribe V2 and xAI STT, segment for Whisper and Wizper, and none for Parakeet — which is the default model and silently ignores the flag.
- **`video_references` is not accepted on Seedance**; it was listed as a valid R2V reference input.
- **`/image/multi-edit` has no public mask channel**; additional images are references, not region maps.
- Softened the blanket "all requests require authentication" claim, since the discovery endpoints do not.

## Test plan

- [ ] `mintlify dev` renders all 18 changed pages without MDX errors
- [ ] Code fences and JSX callout tags are balanced (checked programmatically; the one table-pipe mismatch flagged in `seedance-2-0.mdx` is pre-existing on `main` and untouched)
- [ ] Spot-check the corrected `reference-to-video.mdx` samples against `/video/queue`
- [ ] Confirm no auto-generated block was modified — model tables sit inside `AUTO-GENERATED:MODELS` markers and are unchanged

## Notes for review

- **English only.** The nine locale mirrors inherit these pages through the usual translation sync.
- **Auto-generated content untouched.** The model tables on `models/*.mdx` are inside generated markers. One consequence: xAI STT still renders at `$0.0000/s` (it is `$0.00003148/s`) because that row is generated — fixing it means changing the generator, so it is out of scope here.
- Two items are documented as current API behavior rather than silently fixed, because the fix belongs in outerface: the `/video/quote` vs `/video/queue` naming split for upscale factor, and the absence of a mask parameter. Both now carry explicit warnings so callers are not surprised.