### PR TITLE
docs: update Claude Code Router setup

### DIFF
--- a/guides/integrations/claude-code.mdx
+++ b/guides/integrations/claude-code.mdx
@@ -1,18 +1,18 @@
 ---
 title: Claude Code
-description: "Route Claude Code CLI requests through Venice for private, usage-based coding inference."
+description: "Configure Claude Code Router 3.x to run Claude Code with Venice models."
 "og:title": "Claude Code with Venice | Venice API Docs"
-"og:description": "Set up Claude Code to use Claude Opus 4.5/4.6/4.7/4.8, Sonnet 4.5/4.6/4.7/4.8, and Fable 5 through Venice AI"
+"og:description": "Set up Claude Code Router 3.x to use Claude models through Venice AI"
 ---
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's CLI tool for agentic coding. This guide shows you how to run it through Venice AI for pay-per-token access to Claude Opus 4.5/4.6/4.7/4.8, Sonnet 4.5/4.6/4.7/4.8, and Fable 5.
+[Claude Code](https://code.claude.com/docs) is Anthropic's CLI tool for agentic coding. This guide shows you how to run it through Venice for anonymized, pay-per-token access to Claude models.
 
 <CardGroup cols={3}>
   <Card title="Pay Per Token" icon="coins">
     No subscription. Pay only for what you use
   </Card>
   <Card title="Claude Models" icon="cpu">
-    Access Opus 4.5/4.6/4.7/4.8, Sonnet 4.5/4.6/4.7/4.8, and Fable 5 through Venice
+    Access current Opus, Sonnet, and Fable models through Venice
   </Card>
   <Card title="Prompt Caching" icon="bolt">
     Venice caching works alongside Claude Code
@@ -28,10 +28,10 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
     Catches Claude Code's outgoing requests before they reach Anthropic
   </Step>
   <Step title="Transforms" icon="refresh">
-    Converts request format and maps model IDs (e.g., `claude-opus-4-5`)
+    Converts Anthropic Messages requests into Venice's OpenAI-compatible chat format
   </Step>
   <Step title="Redirects" icon="route">
-    Forwards requests to Venice at `api.venice.ai/api/v1/chat/completions`
+    Forwards requests to `api.venice.ai/api/v1/chat/completions`
   </Step>
 </Steps>
 
@@ -44,9 +44,9 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
     With Venice credits
   </Card>
   <Card title="Node.js" icon="brand-nodejs" href="https://nodejs.org/">
-    v18 or higher
+    v22 or higher
   </Card>
-  <Card title="Claude Code" icon="terminal" href="https://docs.anthropic.com/en/docs/claude-code">
+  <Card title="Claude Code" icon="terminal" href="https://code.claude.com/docs">
     Installed via npm
   </Card>
 </CardGroup>
@@ -56,100 +56,72 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
 ## Setup
 
 <Steps>
-  <Step title="Install Claude Code">
-    If you haven't already, install Anthropic's Claude Code CLI:
+  <Step title="Install or update Claude Code">
+    Install the latest Claude Code CLI:
 
     ```bash
-    npm install -g @anthropic-ai/claude-code
+    npm install -g @anthropic-ai/claude-code@latest
+    claude --version
     ```
   </Step>
 
-  <Step title="Install the Router">
+  <Step title="Install or update Claude Code Router">
     ```bash
-    npm install -g @musistudio/claude-code-router
+    npm install -g @musistudio/claude-code-router@latest
+    npm list -g @musistudio/claude-code-router --depth=0
     ```
+
+    <Warning>
+      Use CCR 3.0.22 or newer. CCR 1.x does not advertise 1M context windows to Claude Code, and CCR 3.0.0–3.0.21 can report cached input incorrectly. If the installed package is older, update it before troubleshooting context usage or compaction.
+    </Warning>
   </Step>
 
   <Step title="Get Your API Key">
-    Generate a key from [venice.ai/settings/api](https://venice.ai/settings/api?utm_source=venice-api-documentation). You'll paste it directly in the config file in the next step.
+    Generate a key from [venice.ai/settings/api](https://venice.ai/settings/api?utm_source=venice-api-documentation). You will add it to CCR in the next step.
   </Step>
 
-  <Step title="Create Configuration">
-    Create the config directory:
+  <Step title="Add Venice as a provider">
+    Start CCR's management UI:
 
     ```bash
-    mkdir -p ~/.claude-code-router
+    ccr ui
     ```
 
-    Then create `~/.claude-code-router/config.json` with your preferred editor:
+    On the **Providers** page, choose **Add provider** and then **Other / custom API endpoint**. Enter:
 
-    ```bash
-    # Using nano
-    nano ~/.claude-code-router/config.json
+    - **Name:** `Venice`
+    - **Protocol:** `OpenAI Chat Completions`
+    - **API endpoint:** `https://api.venice.ai/api/v1`
+    - **API key:** your Venice API key
 
-    # Or using VS Code
-    code ~/.claude-code-router/config.json
-    ```
-
-    Paste the following configuration:
-
-    ```json
-    {
-      "APIKEY": "",
-      "LOG": true,
-      "LOG_LEVEL": "info",
-      "API_TIMEOUT_MS": 600000,
-      "HOST": "127.0.0.1",
-      "Providers": [
-        {
-          "name": "venice",
-          "api_base_url": "https://api.venice.ai/api/v1/chat/completions",
-          "api_key": "your-venice-api-key-here",
-          "models": [
-            "claude-opus-4-5",
-            "claude-sonnet-4-5",
-            "claude-opus-4-6",
-            "claude-opus-4-6-fast",
-            "claude-sonnet-4-6",
-            "claude-opus-4-7",
-            "claude-opus-4-7-fast",
-            "claude-opus-4-8",
-            "claude-opus-4-8-fast",
-            "claude-fable-5"
-          ],
-          "transformer": {
-            "use": ["anthropic"]
-          }
-        }
-      ],
-      "Router": {
-        "default": "venice,claude-opus-4-8",
-        "think": "venice,claude-opus-4-8",
-        "background": "venice,claude-opus-4-8",
-        "longContext": "venice,claude-opus-4-8",
-        "longContextThreshold": 100000
-      }
-    }
-    ```
-
-    <Note>
-    If you modify `config.json` while the router is running, restart it with `ccr restart` to apply changes.
-    </Note>
+    Use **Search models** or **Custom models** to add the Claude models you want, then run **Check Connection** and save the provider.
   </Step>
 
-  <Step title="Launch">
-    Start the router, then Claude Code:
+  <Step title="Create a Claude Code profile">
+    In **Agent Config**, choose **Add profile** and then **Claude Code**:
+
+    - Name the profile `Claude Code - Venice`.
+    - Keep **Effect scope** set to **Only opened from CCR** while testing.
+    - Choose **CLI only** or **CLI & APP**.
+    - Set **Model** to a Venice model such as `Venice/claude-opus-4-8`.
+    - To keep every Claude Code tier on Venice, set the optional Fable, Opus, Sonnet, and Haiku model fields to Venice models too.
+
+    Save the profile.
+  </Step>
+
+  <Step title="Launch and verify">
+    Launch the profile by name:
 
     ```bash
-    ccr start
-    ccr code
+    ccr "Claude Code - Venice"
     ```
 
-    Or use the activation method:
+    In Claude Code:
 
-    ```bash
-    eval "$(ccr activate)" && claude
-    ```
+    1. Run `/model` and select the Venice model marked **1M context**.
+    2. Start a new session after changing the model.
+    3. Run `/context` and confirm the context window is `1M`.
+    4. Send a test message, then check **Request logs** in CCR to confirm that it used Venice.
   </Step>
 </Steps>
 
@@ -157,18 +129,22 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
 
 ## Supported Models
 
-| Model | Venice ID | Best For |
-|-------|-----------|----------|
-| Claude Opus 4.5 | `claude-opus-4-5` | Complex reasoning, large refactors |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5` | Fast iteration, everyday coding |
-| Claude Opus 4.6 | `claude-opus-4-6` | Complex reasoning, large refactors |
-| Claude Opus 4.6 Fast | `claude-opus-4-6-fast` | Complex reasoning with lower latency |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | Fast iteration, everyday coding |
-| Claude Opus 4.7 | `claude-opus-4-7` | Complex reasoning, large refactors |
-| Claude Opus 4.7 Fast | `claude-opus-4-7-fast` | Complex reasoning with lower latency |
-| Claude Opus 4.8 | `claude-opus-4-8` | Complex reasoning, large refactors |
-| Claude Opus 4.8 Fast | `claude-opus-4-8-fast` | Complex reasoning with lower latency |
-| Claude Fable 5 | `claude-fable-5` | Complex tasks requiring the most intelligence |
+| Model | Venice ID | Context |
+|-------|-----------|---------|
+| Claude Fable 5.1 | `claude-fable-5-1` | 1M |
+| Claude Fable 5 | `claude-fable-5` | 1M |
+| Claude Opus 5 | `claude-opus-5` | 1M |
+| Claude Opus 5 Fast | `claude-opus-5-fast` | 1M |
+| Claude Opus 4.8 | `claude-opus-4-8` | 1M |
+| Claude Opus 4.8 Fast | `claude-opus-4-8-fast` | 1M |
+| Claude Opus 4.7 | `claude-opus-4-7` | 1M |
+| Claude Opus 4.6 | `claude-opus-4-6` | 1M |
+| Claude Opus 4.5 | `claude-opus-4-5` | 198K |
+| Claude Sonnet 5 | `claude-sonnet-5` | 1M |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | 1M |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5` | 198K |
+
+The catalog changes over time. Use **Search models** in CCR or [`GET /models?type=text`](/api-reference/endpoint/models/list) for the current list and limits.
 
 <Info>
 Claude Code is optimized for Claude models. While other models available through Venice (GPT, DeepSeek, Grok, etc.) may work, we cannot guarantee an equivalent experience since Claude Code relies on Claude-specific features like extended thinking. For other models, consider using Venice's [standard API](/api-reference/endpoint/chat/completions).
@@ -176,95 +152,67 @@ Claude Code is optimized for Claude models. While other models available through
 
 ---
 
-## Router Features
+## Upgrading from CCR 1.x
 
-The router provides several useful features beyond basic routing:
+CCR 3.x stores live configuration in `~/.claude-code-router/config.sqlite`. A legacy `config.json` is only imported when the SQLite database does not exist.
 
-<AccordionGroup>
-  <Accordion title="Switch models on the fly">
-    Use the `/model` command inside Claude Code to switch models without restarting:
-    
-    ```
-    /model venice,claude-sonnet-4-5
-    ```
-    
-    Useful when you want Opus for complex tasks and Sonnet for quick iterations.
-  </Accordion>
+```bash
+npm install -g @musistudio/claude-code-router@latest
+npm list -g @musistudio/claude-code-router --depth=0
+ccr ui
+```
 
-  <Accordion title="Visual configuration with UI mode">
-    Prefer a GUI? Launch the web-based config editor:
-    
-    ```bash
-    ccr ui
-    ```
-    
-    This opens a browser interface for editing your `config.json` without touching the file directly.
-  </Accordion>
+After migration, make changes through `ccr ui`; do not continue editing `config.json`. If a background process is still running after an upgrade, restart it:
 
-  <Accordion title="Router scenarios explained">
-    The `Router` config section controls which model handles different task types:
-    
-    | Scenario | When it's used |
-    |----------|----------------|
-    | `default` | General requests |
-    | `think` | Reasoning-heavy tasks (Plan Mode) |
-    | `background` | Background operations |
-    | `longContext` | When context exceeds `longContextThreshold` tokens |
-    
-    You can route different scenarios to different models. For example, use Sonnet for background tasks to save costs.
-  </Accordion>
-
-  <Accordion title="Debugging with logs">
-    If something isn't working, check the logs:
-    
-    ```bash
-    # Server logs (HTTP, API calls)
-    ~/.claude-code-router/logs/ccr-*.log
-    
-    # Application logs (routing decisions)
-    ~/.claude-code-router/claude-code-router.log
-    ```
-    
-    Set `"LOG_LEVEL": "debug"` in your config for more verbose output.
-  </Accordion>
-</AccordionGroup>
+```bash
+ccr stop
+ccr start
+```
 
 ---
 
-## Caching Behavior
+## Prompt Caching
 
-Venice [prompt caching](/guides/features/prompt-caching) works alongside Claude Code's native cache markers. Venice automatically detects when Claude Code sends `cache_control` fields and adjusts its caching strategy accordingly.
+Venice [prompt caching](/guides/features/prompt-caching) works with Claude Code's native cache markers. With CCR 3.0.22 or newer, no additional cache transformer is required for the normal setup.
 
-| Scenario | Cache TTL | Who Controls |
-|----------|-----------|--------------|
-| Default (recommended) | 5 minutes | Claude Code + Venice |
-| With `cleancache` transformer | 1 hour | Venice only |
+---
+
+## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="When NOT to use cleancache (most users)">
-    The default configuration lets both systems cooperate:
-    
-    - Claude Code sends its native `cache_control` markers
-    - Venice adds caching around them with a 5-minute TTL
-    - Both systems share the 4-block cache limit
-    
-    This works well for active coding sessions where you're making frequent requests.
+  <Accordion title="Context reaches 100% early or compaction fails">
+    1. Run `npm list -g @musistudio/claude-code-router --depth=0` and update if it is older than 3.0.22.
+    2. Launch a new Claude Code session from the CCR profile.
+    3. Run `/model` and select the Venice entry marked **1M context**.
+    4. Run `/context` and confirm that the window is `1M`, not `200K`.
+
+    CCR 1.x cannot advertise the 1M window, while CCR 3.0.0–3.0.21 has a cached-token accounting regression. Both can produce incorrect context and compaction behavior.
   </Accordion>
 
-  <Accordion title="When to use cleancache">
-    Add `cleancache` to the transformer if you:
-    
-    - Are hitting the 4-block cache limit errors
-    - Experience strange caching behavior
-    - Prefer Venice's 1-hour TTL for longer sessions
-    
-    ```json
-    "transformer": {
-      "use": ["anthropic", "cleancache"]
-    }
+  <Accordion title="CCR crashes during startup">
+    Confirm Node.js 22 or newer and CCR 3.0.22 or newer:
+
+    ```bash
+    node --version
+    npm list -g @musistudio/claude-code-router --depth=0
     ```
-    
-    This strips Claude Code's cache markers, giving Venice full control with a longer TTL.
+
+    Use `ccr serve` to run in the foreground and expose the original startup error. The `Cannot read properties of undefined (reading 'error')` stack from `server.logger.error` is from CCR 1.x; upgrade CCR before investigating it further.
+  </Accordion>
+
+  <Accordion title="Claude Code reports ConnectionRefused">
+    Start the gateway and verify its health:
+
+    ```bash
+    ccr start
+    curl http://127.0.0.1:3456/health
+    ```
+
+    A failed health check means the local CCR gateway is unavailable; the request has not reached Venice.
+  </Accordion>
+
+  <Accordion title="Configuration changes are ignored">
+    Open `ccr ui` and make the change there. CCR 3.x stores current configuration in `config.sqlite`; `config.json` is only a legacy migration source.
   </Accordion>
 </AccordionGroup>
 
@@ -272,11 +220,14 @@ Venice [prompt caching](/guides/features/prompt-caching) works alongside Claude 
 
 ## Resources
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Venice API Docs" icon="book" href="/api-reference/api-spec">
     Full API reference
   </Card>
   <Card title="claude-code-router" icon="brand-github" href="https://github.com/musistudio/claude-code-router">
     Source code and issues
+  </Card>
+  <Card title="CCR Releases" icon="history" href="https://github.com/musistudio/claude-code-router/releases">
+    Current versions and release notes
   </Card>
 </CardGroup>

--- a/guides/integrations/claude-code.mdx
+++ b/guides/integrations/claude-code.mdx
@@ -86,11 +86,12 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
     On the **Providers** page, choose **Add provider** and then **Other / custom API endpoint**. Enter:
 
     - **Name:** `Venice`
-    - **Protocol:** `OpenAI Chat Completions`
     - **API endpoint:** `https://api.venice.ai/api/v1`
     - **API key:** your Venice API key
 
-    Use **Search models** or **Custom models** to add the Claude models you want, then run **Check Connection** and save the provider.
+    CCR should detect **OpenAI Chat** automatically. If it does not, open **Advanced settings**, turn off automatic protocol detection, and select **OpenAI Chat**.
+
+    Use **Search models** or **Custom models** to add the Claude models you want, then run **Check Connection** and save the provider. The connection check sends a real request with a one-token output limit.
   </Step>
 
   <Step title="Create a Claude Code profile">
@@ -114,10 +115,9 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
 
     In Claude Code:
 
-    1. Run `/model` and select the Venice model marked **1M context**.
-    2. Start a new session after changing the model.
-    3. Run `/context` and confirm the context window is `1M`.
-    4. Send a test message, then check **Request logs** in CCR to confirm that it used Venice.
+    1. Run `/context` and confirm the context window matches the selected model. For `claude-opus-4-8`, it should show `1M`.
+    2. Run `/model` if you want to switch to another Venice model; 1M variants are marked **1M context**.
+    3. Send a test message, then check **Request logs** in CCR to confirm that it used Venice.
   </Step>
 </Steps>
 

--- a/guides/integrations/claude-code.mdx
+++ b/guides/integrations/claude-code.mdx
@@ -1,8 +1,8 @@
 ---
 title: Claude Code
-description: "Configure Claude Code Router 3.x to run Claude Code with Venice models."
+description: "Run Claude Code with Claude models through Venice using Claude Code Router."
 "og:title": "Claude Code with Venice | Venice API Docs"
-"og:description": "Set up Claude Code Router 3.x to use Claude models through Venice AI"
+"og:description": "Connect Claude Code to Venice for pay-per-token access to Claude models"
 ---
 
 [Claude Code](https://code.claude.com/docs) is Anthropic's CLI tool for agentic coding. This guide shows you how to run it through Venice for anonymized, pay-per-token access to Claude models.
@@ -65,15 +65,11 @@ Claude Code connects directly to Anthropic's API by default. To use it with Veni
     ```
   </Step>
 
-  <Step title="Install or update Claude Code Router">
+  <Step title="Install Claude Code Router">
     ```bash
     npm install -g @musistudio/claude-code-router@latest
     npm list -g @musistudio/claude-code-router --depth=0
     ```
-
-    <Warning>
-      Use CCR 3.0.22 or newer. CCR 1.x does not advertise 1M context windows to Claude Code, and CCR 3.0.0–3.0.21 can report cached input incorrectly. If the installed package is older, update it before troubleshooting context usage or compaction.
-    </Warning>
   </Step>
 
   <Step title="Get Your API Key">
@@ -152,9 +148,9 @@ Claude Code is optimized for Claude models. While other models available through
 
 ---
 
-## Upgrading from CCR 1.x
+## Updating an Existing Installation
 
-CCR 3.x stores live configuration in `~/.claude-code-router/config.sqlite`. A legacy `config.json` is only imported when the SQLite database does not exist.
+Update CCR before troubleshooting an existing installation:
 
 ```bash
 npm install -g @musistudio/claude-code-router@latest
@@ -162,7 +158,9 @@ npm list -g @musistudio/claude-code-router --depth=0
 ccr ui
 ```
 
-After migration, make changes through `ccr ui`; do not continue editing `config.json`. If a background process is still running after an upgrade, restart it:
+Current CCR releases store live configuration in `~/.claude-code-router/config.sqlite`. An older `config.json` is imported when the database does not exist. After migration, make changes through `ccr ui` instead of continuing to edit `config.json`.
+
+If a background process is still running after an update, restart it:
 
 ```bash
 ccr stop
@@ -173,7 +171,7 @@ ccr start
 
 ## Prompt Caching
 
-Venice [prompt caching](/guides/features/prompt-caching) works with Claude Code's native cache markers. With CCR 3.0.22 or newer, no additional cache transformer is required for the normal setup.
+Venice [prompt caching](/guides/features/prompt-caching) works with Claude Code's native cache markers. No additional cache transformer is required for the normal setup.
 
 ---
 
@@ -181,23 +179,23 @@ Venice [prompt caching](/guides/features/prompt-caching) works with Claude Code'
 
 <AccordionGroup>
   <Accordion title="Context reaches 100% early or compaction fails">
-    1. Run `npm list -g @musistudio/claude-code-router --depth=0` and update if it is older than 3.0.22.
+    1. Update CCR with `npm install -g @musistudio/claude-code-router@latest`.
     2. Launch a new Claude Code session from the CCR profile.
     3. Run `/model` and select the Venice entry marked **1M context**.
     4. Run `/context` and confirm that the window is `1M`, not `200K`.
 
-    CCR 1.x cannot advertise the 1M window, while CCR 3.0.0–3.0.21 has a cached-token accounting regression. Both can produce incorrect context and compaction behavior.
+    Older CCR releases may not expose the correct context window or token usage to Claude Code.
   </Accordion>
 
   <Accordion title="CCR crashes during startup">
-    Confirm Node.js 22 or newer and CCR 3.0.22 or newer:
+    Confirm Node.js 22 or newer and update CCR:
 
     ```bash
     node --version
     npm list -g @musistudio/claude-code-router --depth=0
     ```
 
-    Use `ccr serve` to run in the foreground and expose the original startup error. The `Cannot read properties of undefined (reading 'error')` stack from `server.logger.error` is from CCR 1.x; upgrade CCR before investigating it further.
+    Use `ccr serve` to run in the foreground and expose the original startup error. A `Cannot read properties of undefined (reading 'error')` stack from `server.logger.error` indicates an outdated CCR installation; update it before investigating further.
   </Accordion>
 
   <Accordion title="Claude Code reports ConnectionRefused">
@@ -212,7 +210,7 @@ Venice [prompt caching](/guides/features/prompt-caching) works with Claude Code'
   </Accordion>
 
   <Accordion title="Configuration changes are ignored">
-    Open `ccr ui` and make the change there. CCR 3.x stores current configuration in `config.sqlite`; `config.json` is only a legacy migration source.
+    Open `ccr ui` and make the change there. Current CCR releases store configuration in `config.sqlite`; `config.json` is only a migration source for older installations.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary
- replace the legacy `config.json` setup with the current CCR provider and Agent Config flows
- align the prerequisites and upgrade guidance with current CCR releases, including 1M context verification
- refresh the supported Claude catalog and add context, startup, and connection troubleshooting

## Test plan
- [x] authenticated CCR 3.0.22 → Venice streaming request
- [x] verified Opus 4.8 discovery reports a 1M context window
- [x] verified cache-write and cache-read usage round-trips without double-counting
- [x] `yarn mintlify broken-links`
- [x] `git diff --check`
- [x] IDE diagnostics report no errors
- [ ] `yarn mintlify validate` (blocked by the repository-wide Mintlify/React `useState` failure while parsing many existing pages)