### PR TITLE
docs: correct rate limit values, error budgets, and uncapped media

### DIFF
--- a/api-reference/rate-limiting.mdx
+++ b/api-reference/rate-limiting.mdx
@@ -22,38 +22,31 @@ curl https://api.venice.ai/api/v1/api_keys/rate_limits \
 
 ## Default Limits
 
-### Text Models
+### Text and Embedding Models
 
-Text models are grouped into tiers based on size. Each model card on the [Models page](/models/text) displays its tier badge.
+Text and embedding models are grouped into four sizes. Each model card on the [Models page](/models/text) displays its size badge. Every embedding model is XS.
 
-| Tier | Requests/min | Tokens/min |
-|:-----|-------------:|-----------:|
-| XS | 500 | 1,000,000 |
-| S | 75 | 750,000 |
-| M | 50 | 750,000 |
-| L | 20 | 500,000 |
+| Size | Requests/min | Tokens/min | Partner requests/min | Partner tokens/min |
+|:-----|-------------:|-----------:|---------------------:|-------------------:|
+| XS | 500 | 5,000,000 | 500 | 10,000,000 |
+| S | 150 | 3,000,000 | 300 | 6,000,000 |
+| M | 100 | 2,000,000 | 200 | 4,000,000 |
+| L | 100 | 2,000,000 | 150 | 3,000,000 |
 
-<Accordion title="Which models are in each tier?">
+<Note>
+  Some models run on dedicated or third-party infrastructure and carry limits that do not map to these four sizes. Call [`GET /api_keys/rate_limits`](/api-reference/endpoint/api_keys/rate_limits) for the authoritative per-model limits on your key.
+</Note>
 
-**XS** `qwen3-4b` `llama-3.2-3b`
+### Image and Audio Models
 
-**S** `mistral-31-24b` `venice-uncensored`
+| Type | Requests/min | Partner requests/min |
+|:-----|-------------:|---------------------:|
+| Image, upscale, inpaint | 20 | 60 |
+| Speech and transcription | 60 | 120 |
 
-**M** `zai-org-glm-5` `qwen3-next-80b` `google-gemma-3-27b-it`
+### Video and Music Models
 
-**L** `qwen3-235b-a22b-instruct-2507` `qwen3-235b-a22b-thinking-2507` `deepseek-ai-DeepSeek-R1` `grok-41-fast` `kimi-k2-thinking` `gemini-3-pro-preview` `hermes-3-llama-3.1-405b` `qwen3-coder-480b-a35b-instruct` `zai-org-glm-4.7` `openai-gpt-oss-120b`
-
-</Accordion>
-
-### Other Models
-
-| Type | Requests/min |
-|:-----|-------------:|
-| Image | 20 |
-| Audio | 60 |
-| Embedding | 500 |
-| Video (queue) | 40 |
-| Video (retrieve) | 120 |
+Video and music generation are not rate limited. Both are billed per generation against your credit balance, so cost rather than a request ceiling is the practical constraint. Price a job first with [`POST /video/quote`](/api-reference/endpoint/video/quote) or [`POST /audio/quote`](/api-reference/endpoint/audio/quote).
 
 ## Handling Errors
 
@@ -61,13 +54,24 @@ Failed requests (500, 503, 429) should be retried with exponential backoff.
 
 For 429 errors specifically, check the `x-ratelimit-reset-requests` header for the exact Unix timestamp when you can retry. Most HTTP libraries have built-in retry mechanisms that handle this automatically.
 
-### Abuse Protection
+### Error Budgets
 
-If you generate more than 20 failed requests in 30 seconds, the API will block further requests for 30 seconds:
+Two further limits protect the API against clients that retry into a wall. Both are counted per model per API key over a rolling 30 seconds, and both return `429`:
+
+| Budget | Threshold | Applies to |
+|:-------|----------:|:-----------|
+| Failed requests | 50 per 30s | All endpoints |
+| Unsupported feature requests | 200 per 30s | `/chat/completions`, `/responses` |
+
+The second budget counts requests that ask a model for a feature it does not support — for example requesting vision or tool calling from a model without that capability. Exceeding either budget appears in [rate limit logs](/api-reference/endpoint/api_keys/rate_limit_logs) as `FAILED_REQUESTS` or `UNSUPPORTED_FEATURE_REQUESTS`.
+
+Both return a `customMessage` naming the threshold that tripped:
 
 ```
-Too many failed attempts (> 20) resulting in a non-success status code. Please wait 30s and try again.
+Too many failed attempts (> 50) resulting in a non-success status code. Please wait 30 seconds and try again. See https://docs.venice.ai/api-reference/rate-limiting for more information.
 ```
+
+These responses set `x-ratelimit-remaining` and `x-ratelimit-resets` instead of the per-window headers below.
 
 ## Response Headers
 
@@ -82,22 +86,11 @@ Every response includes these headers:
 | `x-ratelimit-remaining-tokens` | Tokens remaining in current minute |
 | `x-ratelimit-reset-tokens` | Seconds until token limit resets |
 
+The `/crypto/rpc/{network}` endpoint uses its own limits and its own `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers, which are set only on 429 responses. See [Crypto RPC](/api-reference/endpoint/crypto/rpc) for details.
+
 ## Partner Tier
 
-Partners get significantly higher rate limits:
-
-| Tier | Requests/min | Tokens/min |
-|:-----|-------------:|-----------:|
-| XS | 500 | 2,000,000 |
-| S | 150 | 1,500,000 |
-| M | 100 | 1,500,000 |
-| L | 60 | 1,000,000 |
-
-| Type | Requests/min |
-|:-----|-------------:|
-| Image | 60 |
-| Audio | 120 |
-| Embedding | 500 |
+Partner limits are listed alongside the defaults in the tables above.
 
 If you're consistently hitting your rate limits and your usage patterns show **sustained demand over time**, reach out to discuss partner access: [api@venice.ai](mailto:api@venice.ai).
 


### PR DESCRIPTION
The published tier table understated every TPM value and three of four RPM
values; the L tier was understated fivefold. Values now match the limits in
outerface (data/inference/rate-limits.yaml and
src/lib/api/rate-limits/api-rate-limit-config.ts).

- Correct XS-L requests/min and tokens/min for both paid and partner tiers,
  and fold the partner numbers into the main tables so the two cannot drift.
- Drop the per-tier model accordion. A third of the model IDs it listed no
  longer exist, and the real size assignments are internal slugs subject to
  app/API splits, so /api_keys/rate_limits is the only durable answer.
- Embeddings resolve on the text size table rather than a flat 500 rpm.
- Video and music are not rate limited at all; they bill per generation.
- Abuse protection is 50 failed requests per 30s, not 20, and a second
  budget of 200 unsupported-feature requests per 30s was undocumented.
- Note the distinct X-RateLimit-* headers used by /crypto/rpc/{network}.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>