### PR TITLE
docs: correct rate limit values, error budgets, and uncapped media

### DIFF
--- a/api-reference/rate-limiting.mdx
+++ b/api-reference/rate-limiting.mdx
@@ -22,38 +22,31 @@ curl https://api.venice.ai/api/v1/api_keys/rate_limits \
 
 ## Default Limits
 
-### Text Models
+### Text and Embedding Models
 
-Text models are grouped into tiers based on size. Each model card on the [Models page](/models/text) displays its tier badge.
+Text and embedding models are grouped into four sizes. Each model card on the [Models page](/models/text) displays its size badge. Every embedding model is XS.
 
-| Tier | Requests/min | Tokens/min |
-|:-----|-------------:|-----------:|
-| XS | 500 | 1,000,000 |
-| S | 75 | 750,000 |
-| M | 50 | 750,000 |
-| L | 20 | 500,000 |
+| Size | Requests/min | Tokens/min | Partner requests/min | Partner tokens/min |
+|:-----|-------------:|-----------:|---------------------:|-------------------:|
+| XS | 500 | 5,000,000 | 500 | 10,000,000 |
+| S | 150 | 3,000,000 | 300 | 6,000,000 |
+| M | 100 | 2,000,000 | 200 | 4,000,000 |
+| L | 100 | 2,000,000 | 150 | 3,000,000 |
 
-<Accordion title="Which models are in each tier?">
+<Note>
+  Some models run on dedicated or third-party infrastructure and carry limits that do not map to these four sizes. Call [`GET /api_keys/rate_limits`](/api-reference/endpoint/api_keys/rate_limits) for the authoritative per-model limits on your key.
+</Note>
 
-**XS** `qwen3-4b` `llama-3.2-3b`
+### Image and Audio Models
 
-**S** `mistral-31-24b` `venice-uncensored`
+| Type | Requests/min | Partner requests/min |
+|:-----|-------------:|---------------------:|
+| Image, upscale, inpaint | 20 | 60 |
+| Speech and transcription | 60 | 120 |
 
-**M** `zai-org-glm-5` `qwen3-next-80b` `google-gemma-3-27b-it`
+### Video and Music Models
 
-**L** `qwen3-235b-a22b-instruct-2507` `qwen3-235b-a22b-thinking-2507` `deepseek-ai-DeepSeek-R1` `grok-41-fast` `kimi-k2-thinking` `gemini-3-pro-preview` `hermes-3-llama-3.1-405b` `qwen3-coder-480b-a35b-instruct` `zai-org-glm-4.7` `openai-gpt-oss-120b`
-
-</Accordion>
-
-### Other Models
-
-| Type | Requests/min |
-|:-----|-------------:|
-| Image | 20 |
-| Audio | 60 |
-| Embedding | 500 |
-| Video (queue) | 40 |
-| Video (retrieve) | 120 |
+Video and music generation are not rate limited. Both are billed per generation against your credit balance, so cost rather than a request ceiling is the practical constraint. Price a job first with [`POST /video/quote`](/api-reference/endpoint/video/quote) or [`POST /audio/quote`](/api-reference/endpoint/audio/quote).
 
 ## Handling Errors
 
@@ -61,13 +54,24 @@ Failed requests (500, 503, 429) should be retried with exponential backoff.
 
 For 429 errors specifically, check the `x-ratelimit-reset-requests` header for the exact Unix timestamp when you can retry. Most HTTP libraries have built-in retry mechanisms that handle this automatically.
 
-### Abuse Protection
+### Error Budgets
 
-If you generate more than 20 failed requests in 30 seconds, the API will block further requests for 30 seconds:
+Two further limits protect the API against clients that retry into a wall. Both are counted per model per API key over a rolling 30 seconds, and both return `429`:
+
+| Budget | Threshold | Applies to |
+|:-------|----------:|:-----------|
+| Failed requests | 50 per 30s | All endpoints |
+| Unsupported feature requests | 200 per 30s | `/chat/completions`, `/responses` |
+
+The second budget counts requests that ask a model for a feature it does not support — for example requesting vision or tool calling from a model without that capability. Exceeding either budget appears in [rate limit logs](/api-reference/endpoint/api_keys/rate_limit_logs) as `FAILED_REQUESTS` or `UNSUPPORTED_FEATURE_REQUESTS`.
+
+Both return a `customMessage` naming the threshold that tripped:
 
 ```
-Too many failed attempts (> 20) resulting in a non-success status code. Please wait 30s and try again.
+Too many failed attempts (> 50) resulting in a non-success status code. Please wait 30 seconds and try again. See https://docs.venice.ai/api-reference/rate-limiting for more information.
 ```
+
+These responses set `x-ratelimit-remaining` and `x-ratelimit-resets` instead of the per-window headers below.
 
 ## Response Headers
 
@@ -82,22 +86,11 @@ Every response includes these headers:
 | `x-ratelimit-remaining-tokens` | Tokens remaining in current minute |
 | `x-ratelimit-reset-tokens` | Seconds until token limit resets |
 
+The `/crypto/rpc/{network}` endpoint uses its own limits and its own `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers, which are set only on 429 responses. See [Crypto RPC](/api-reference/endpoint/crypto/rpc) for details.
+
 ## Partner Tier
 
-Partners get significantly higher rate limits:
-
-| Tier | Requests/min | Tokens/min |
-|:-----|-------------:|-----------:|
-| XS | 500 | 2,000,000 |
-| S | 150 | 1,500,000 |
-| M | 100 | 1,500,000 |
-| L | 60 | 1,000,000 |
-
-| Type | Requests/min |
-|:-----|-------------:|
-| Image | 60 |
-| Audio | 120 |
-| Embedding | 500 |
+Partner limits are listed alongside the defaults in the tables above.
 
 If you're consistently hitting your rate limits and your usage patterns show **sustained demand over time**, reach out to discuss partner access: [api@venice.ai](mailto:api@venice.ai).
 


### PR DESCRIPTION
The rate limits page has drifted from what the API enforces. Every tokens/min figure and three of the four requests/min figures were understated, most severely at the L tier, which we publish as 20 rpm / 500K tpm against an actual 100 rpm / 2M tpm. Callers sizing their clients off this page have been leaving throughput they've paid for on the table.

Anyone with a key can confirm the corrected figures against `GET /api_keys/rate_limits` and the `x-ratelimit-*` response headers.

## Text and embedding sizes

| Size | Was | Now | Partner was | Partner now |
|:--|:--|:--|:--|:--|
| XS | 500 / 1M | 500 / 5M | 500 / 2M | 500 / 10M |
| S | 75 / 750K | 150 / 3M | 150 / 1.5M | 300 / 6M |
| M | 50 / 750K | 100 / 2M | 100 / 1.5M | 200 / 4M |
| L | 20 / 500K | 100 / 2M | 60 / 1M | 150 / 3M |

Partner figures now sit in the same tables as the defaults, so the two can't drift apart the way they did here.

## Other corrections

- **The per-tier model accordion is gone.** A third of the model IDs it listed no longer exist, and it named 17 models out of a text catalog well past a hundred. `GET /api_keys/rate_limits` is the only answer that stays correct, so the page points there.
- **Embeddings** resolve on the text size table rather than the flat 500 rpm we published, and are all XS today.
- **Video and music are not rate limited at all.** They bill per generation against your credit balance. The page previously advertised a 40 rpm queue limit and a 120 rpm retrieve limit that don't exist.
- **Abuse protection is 50 failed requests per 30s, not 20**, and the quoted error string was stale. A second budget — 200 unsupported-feature requests per 30s on `/chat/completions` and `/responses` — was undocumented entirely, despite surfacing in rate limit logs as `UNSUPPORTED_FEATURE_REQUESTS`.
- **Crypto RPC** uses its own limits and its own capitalised `X-RateLimit-*` headers, set only on 429s. The page now says so rather than leaving readers to assume the documented lowercase headers apply.

## Notes for review

English only. Per `agents.md`, Mintlify regenerates the eight locale copies and their nav after merge, so no locale files or `docs.json` entries are touched here.

The size badges on model cards are still driven by a hardcoded map in `model-search.js` that has the same stale figures and defaults unrecognised models to L. That's a separate fix and needs a decision on where the data should come from; it isn't in this PR.

Made with [Cursor](https://cursor.com)